### PR TITLE
Migrate to opaque type for COREConnection

### DIFF
--- a/bindings/python/coreir/__init__.py
+++ b/bindings/python/coreir/__init__.py
@@ -68,10 +68,7 @@ class CORESelect(COREWireable):
 CORESelect_p = ct.POINTER(CORESelect)
 
 class COREConnection(ct.Structure):
-    _fields_ = [
-        ("first", COREWireable_p),
-        ("second", COREWireable_p)
-    ]
+    pass
 
 COREConnection_p = ct.POINTER(COREConnection)
 
@@ -156,7 +153,13 @@ coreir_lib.COREStr2Arg.argtypes = [COREContext_p,ct.c_char_p]
 coreir_lib.COREStr2Arg.restype = COREArg_p
 
 coreir_lib.COREModuleDefGetConnections.argtypes = [COREModuleDef_p, ct.POINTER(ct.c_int)]
-coreir_lib.COREModuleDefGetConnections.restype = COREConnection_p
+coreir_lib.COREModuleDefGetConnections.restype = ct.POINTER(COREConnection_p)
+
+coreir_lib.COREConnectionGetFirst.argtypes = [COREConnection_p]
+coreir_lib.COREConnectionGetFirst.restype = COREWireable_p
+
+coreir_lib.COREConnectionGetSecond.argtypes = [COREConnection_p]
+coreir_lib.COREConnectionGetSecond.restype = COREWireable_p
 
 coreir_lib.COREModuleDefWire.argtypes = [COREModuleDef_p, COREWireable_p, COREWireable_p]
 
@@ -243,11 +246,11 @@ class Interface(Wireable):
 class Connection(CoreIRType):
     @property
     def first(self):
-        return Wireable(self.ptr.first, self.context)
+        return Wireable(coreir_lib.COREConnectionGetFirst(self.ptr), self.context)
 
     @property
     def second(self):
-        return Wireable(self.ptr.second, self.context)
+        return Wireable(coreir_lib.COREConnectionGetSecond(self.ptr), self.context)
 
 
 class Instance(Wireable):

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -21,7 +21,8 @@ Context::~Context() {
   for (auto it : paramsList) delete it;
   for (auto it : libs) delete it.second;
   for (auto it : instanceArrays) free(it);
-  for (auto it : COREconnectionArrays) free(it);
+  for (auto it : connectionArrays) free(it);
+  for (auto it : connectionPtrArrays) free(it);
   for (auto it : wireableArrays) free(it);
   for (auto it : constStringArrays) free(it);
  
@@ -140,9 +141,15 @@ Instance** Context::newInstanceArray(int size) {
   return arr;
 }
 
-COREConnection* Context::newCOREConnectionArray(int size) {
-  COREConnection* arr = (COREConnection*) malloc(sizeof(COREConnection) * size);
-  COREconnectionArrays.push_back(arr);
+Connection* Context::newConnectionArray(int size) {
+  Connection* arr = (Connection*) malloc(sizeof(Connection) * size);
+  connectionArrays.push_back(arr);
+  return arr;
+}
+
+Connection** Context::newConnectionPtrArray(int size) {
+  Connection** arr = (Connection**) malloc(sizeof(Connection*) * size);
+  connectionPtrArrays.push_back(arr);
   return arr;
 }
 

--- a/src/context.hpp
+++ b/src/context.hpp
@@ -30,7 +30,8 @@ class Context {
   vector<RecordParams*> recordParamsList;
   vector<Params*> paramsList;
   vector<Instance**> instanceArrays;
-  vector<COREConnection*> COREconnectionArrays;
+  vector<Connection*> connectionArrays;
+  vector<Connection**> connectionPtrArrays;
   vector<Wireable**> wireableArrays;
   vector<const char**> constStringArrays;
 
@@ -76,7 +77,8 @@ class Context {
     Arg* type2Arg(Type* t);
 
     Instance** newInstanceArray(int size);
-    COREConnection* newCOREConnectionArray(int size);
+    Connection* newConnectionArray(int size);
+    Connection** newConnectionPtrArray(int size);
     Wireable** newWireableArray(int size);
     const char** newConstStringArray(int size);
     Type* Flip(Type* t);

--- a/src/context.hpp
+++ b/src/context.hpp
@@ -1,7 +1,6 @@
 #ifndef CONTEXT_HPP_
 #define CONTEXT_HPP_
 
-#include "coreir.h"
 #include "namespace.hpp"
 #include "typecache.hpp"
 #include "types.hpp"

--- a/src/coreir.cpp
+++ b/src/coreir.cpp
@@ -207,22 +207,29 @@ extern "C" {
     return rcast<COREInstance**>(arr);
   }
 
-  COREConnection* COREModuleDefGetConnections(COREModuleDef* m, int* numConnections) {
+  COREConnection** COREModuleDefGetConnections(COREModuleDef* m, int* numConnections) {
     ModuleDef* module_def = rcast<ModuleDef*>(m);
     unordered_set<Connection> connection_set = module_def->getConnections();
     Context* context = module_def->getContext();
     int size = connection_set.size();
     *numConnections = size;
-    COREConnection* arr = context->newCOREConnectionArray(size);
+    Connection* conns = context->newConnectionArray(size);
+    Connection** arr = context->newConnectionPtrArray(size);
     int count = 0;
     for (auto it : connection_set) {
-      arr[count] = (COREConnection) {
-          .first  = rcast<COREWireable*>(it.first), 
-          .second = rcast<COREWireable*>(it.second)
-      };
+      conns[count] = it;
+      arr[count] = &conns[count];
       count++;
     }
-    return rcast<COREConnection*>(arr);
+    return rcast<COREConnection**>(arr);
+  }
+
+  COREWireable* COREConnectionGetFirst(COREConnection* c) {
+    return rcast<COREWireable*>(rcast<Connection*>(c)->first);
+  }
+
+  COREWireable* COREConnectionGetSecond(COREConnection* c) {
+    return rcast<COREWireable*>(rcast<Connection*>(c)->second);
   }
 
   COREWireable** COREWireableGetConnectedWireables(COREWireable* w, int* numWireables) {

--- a/src/coreir.h
+++ b/src/coreir.h
@@ -26,10 +26,7 @@ typedef enum {
 //keys and values will not be freed
 void* CORENewMap(COREContext* c, void* keys, void* values, u32 len, COREMapKind kind);
 
-typedef struct COREConnection  {
-    COREWireable* first;
-    COREWireable* second;
-} COREConnection;
+typedef struct COREConnection COREConnection;
 
 typedef struct COREWirePath COREWirePath;
 
@@ -88,7 +85,9 @@ extern void COREModuleDefWire(COREModuleDef* module_def, COREWireable* a, COREWi
 extern CORESelect* COREInstanceSelect(COREInstance* instance, char* field);
 extern CORESelect* COREInterfaceSelect(COREInterface* interface, char* field);
 extern COREInstance** COREModuleDefGetInstances(COREModuleDef* m, u32* numInstances);
-extern COREConnection* COREModuleDefGetConnections(COREModuleDef* m, int* numWires);
+extern COREConnection** COREModuleDefGetConnections(COREModuleDef* m, int* numWires);
+extern COREWireable* COREConnectionGetFirst(COREConnection* c);
+extern COREWireable* COREConnectionGetSecond(COREConnection* c);
 extern COREWireable** COREWireableGetConnectedWireables(COREWireable* wireable, int* numWireables);
 extern CORESelect* COREWireableSelect(COREWireable* w, char* name);
 extern COREWireable* COREModuleDefSelect(COREModuleDef* m, char* name);


### PR DESCRIPTION
Removes `coreir.context` dependency on `coreir.h`

CGRAFlow Travis build: https://travis-ci.org/StanfordAHA/CGRAFlow/builds/224089808