### PR TITLE
Order of argument passing is incorrect in ModuleDef::addInstance

### DIFF
--- a/src/instantiable.cpp
+++ b/src/instantiable.cpp
@@ -125,7 +125,7 @@ Instance* ModuleDef::addInstance(Instance* i) {
   if( i->getInstRef()->isKind(MOD)) 
     return addInstance(i->getInstname(),(Module*) i->getInstRef(),i->getConfig());
   else 
-    return addInstance(i->getInstname(),(Generator*) i->getInstRef(),i->getConfig(),i->getArgs());
+    return addInstance(i->getInstname(),(Generator*) i->getInstRef(),i->getArgs(),i->getConfig());
 }
 
 


### PR DESCRIPTION
Adding an instance of a Generator has genargs and config arguments swapped in the function call.