### PR TITLE
Require that generator params/args be a superset of typegen params

### DIFF
--- a/src/args.cpp
+++ b/src/args.cpp
@@ -35,11 +35,11 @@ bool operator==(const Args& l, const Args& r) {
 }
 
 bool checkParams(Args args, Params params) {
-  if (args.size() != params.size()) return false;
+  if (args.size() < params.size()) return false;
   for (auto parammap : params) {
     auto arg = args.find(parammap.first);
     if (arg == args.end()) return false;
-    if (!arg->second->isKind(parammap.second) ) return false;
+    if (!arg->second->isKind(parammap.second)) return false;
   }
   return true;
 }

--- a/src/args.cpp
+++ b/src/args.cpp
@@ -35,7 +35,7 @@ bool operator==(const Args& l, const Args& r) {
 }
 
 bool checkArgs(Args args, Params params) {
-  if (args.size() < params.size()) return false;
+  if (args.size() != params.size()) return false;
   for (auto parammap : params) {
     auto arg = args.find(parammap.first);
     if (arg == args.end()) return false;

--- a/src/args.cpp
+++ b/src/args.cpp
@@ -34,7 +34,7 @@ bool operator==(const Args& l, const Args& r) {
   return true;
 }
 
-bool checkParams(Args args, Params params) {
+bool checkArgs(Args args, Params params) {
   if (args.size() < params.size()) return false;
   for (auto parammap : params) {
     auto arg = args.find(parammap.first);

--- a/src/args.hpp
+++ b/src/args.hpp
@@ -66,7 +66,7 @@ struct ArgType : Arg {
 //};
 
 
-bool checkParams(Args args, Params params);
+bool checkArgs(Args args, Params params);
 
 }//CoreIR namespace
 

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -9,7 +9,7 @@ using namespace std;
 namespace CoreIR {
 
 Type* TypeGen::run(Context* c, Args args) {
-  assert(checkParams(args,params));
+  assert(checkArgs(args,params));
   Type* ran = this->fun(c,args);
   return flipped ? c->Flip(ran) : ran;
 }

--- a/src/instantiable.cpp
+++ b/src/instantiable.cpp
@@ -44,9 +44,9 @@ ostream& operator<<(ostream& os, const Instantiable& i) {
 Generator::Generator(Namespace* ns,string name,Params genparams, TypeGen typegen, Params configparams) : Instantiable(GEN,ns,name,configparams), genparams(genparams), typegen(typegen), genfun(nullptr) {
   //Verify that genparams are a superset of typegen params
   for (auto const &type_param : typegen.params) {
-	  auto const &gen_param = genparams.find(type_param.first);
-	  assert(gen_param != genparams.end());
-	  assert(gen_param->second == type_param.second);
+    auto const &gen_param = genparams.find(type_param.first);
+    assert(gen_param != genparams.end());
+    assert(gen_param->second == type_param.second);
   }
 }
 

--- a/src/instantiable.cpp
+++ b/src/instantiable.cpp
@@ -42,8 +42,12 @@ ostream& operator<<(ostream& os, const Instantiable& i) {
 }
 
 Generator::Generator(Namespace* ns,string name,Params genparams, TypeGen typegen, Params configparams) : Instantiable(GEN,ns,name,configparams), genparams(genparams), typegen(typegen), genfun(nullptr) {
-  //Verify that genparams are the same
-  assert(genparams == typegen.params);
+  //Verify that genparams are a superset of typegen params
+  for (auto const &type_param : typegen.params) {
+	  auto const &gen_param = genparams.find(type_param.first);
+	  assert(gen_param != genparams.end());
+	  assert(gen_param->second == type_param.second);
+  }
 }
 
 string Generator::toString() const {

--- a/src/instantiable.cpp
+++ b/src/instantiable.cpp
@@ -42,6 +42,7 @@ ostream& operator<<(ostream& os, const Instantiable& i) {
   return os;
 }
 
+<<<<<<< Updated upstream
 Generator::Generator(Namespace* ns,string name,Params genparams, TypeGen typegen, Params configparams) : Instantiable(GEN,ns,name,configparams), genparams(genparams), typegen(typegen), def(nullptr) {
   //Verify that genparams are a superset of typegen params
   for (auto const &type_param : typegen.params) {
@@ -49,6 +50,16 @@ Generator::Generator(Namespace* ns,string name,Params genparams, TypeGen typegen
     assert(gen_param != genparams.end());
     assert(gen_param->second == type_param.second);
   }
+=======
+Generator::Generator(Namespace* ns,string name,Params genparams, TypeGen* typegen, Params configparams) : Instantiable(GEN,ns,name,configparams), genparams(genparams), typegen(typegen), def(nullptr) {
+  //Verify that typegen params are a subset of genparams
+  for (auto const &type_param : typegen->getParams()) {
+    auto const &gen_param = genparams.find(type_param.first);
+    assert(gen_param != genparams.end() && "Param not found");
+    assert(gen_param->second == type_param.second && "Param type mismatch");
+  }
+}
+>>>>>>> Stashed changes
 
 Generator::~Generator() {
   if (def) {

--- a/src/instantiable.cpp
+++ b/src/instantiable.cpp
@@ -42,15 +42,6 @@ ostream& operator<<(ostream& os, const Instantiable& i) {
   return os;
 }
 
-<<<<<<< Updated upstream
-Generator::Generator(Namespace* ns,string name,Params genparams, TypeGen typegen, Params configparams) : Instantiable(GEN,ns,name,configparams), genparams(genparams), typegen(typegen), def(nullptr) {
-  //Verify that genparams are a superset of typegen params
-  for (auto const &type_param : typegen.params) {
-    auto const &gen_param = genparams.find(type_param.first);
-    assert(gen_param != genparams.end());
-    assert(gen_param->second == type_param.second);
-  }
-=======
 Generator::Generator(Namespace* ns,string name,Params genparams, TypeGen* typegen, Params configparams) : Instantiable(GEN,ns,name,configparams), genparams(genparams), typegen(typegen), def(nullptr) {
   //Verify that typegen params are a subset of genparams
   for (auto const &type_param : typegen->getParams()) {
@@ -59,7 +50,6 @@ Generator::Generator(Namespace* ns,string name,Params genparams, TypeGen* typege
     assert(gen_param->second == type_param.second && "Param type mismatch");
   }
 }
->>>>>>> Stashed changes
 
 Generator::~Generator() {
   if (def) {

--- a/src/typegen.hpp
+++ b/src/typegen.hpp
@@ -17,7 +17,7 @@ class TypeGen {
     virtual ~TypeGen() {}
     virtual Type* createType(Context* c, Args args) = 0;
     Type* getType(Args args) {
-      assert(checkArgs(args,params) && "Argument types do not match params!");
+      assert(checkParams(args,params) && "Argument types do not match params!");
       Type* t = createType(ns->getContext(),args);
       return flipped ? t->getFlipped() : t;
     }

--- a/src/typegen.hpp
+++ b/src/typegen.hpp
@@ -17,7 +17,7 @@ class TypeGen {
     virtual ~TypeGen() {}
     virtual Type* createType(Context* c, Args args) = 0;
     Type* getType(Args args) {
-      assert(checkParams(args,params) && "Argument types do not match params!");
+      assert(checkArgs(args,params) && "Argument types do not match params!");
       Type* t = createType(ns->getContext(),args);
       return flipped ? t->getFlipped() : t;
     }

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -30,7 +30,7 @@ string RecordType::toString(void) const {
 
 NamedType::NamedType(Namespace* ns, string name, Type* raw, TypeGen typegen, Args genargs) : Type(NAMED) ,ns(ns), name(name), raw(raw), typegen(typegen), genargs(genargs) {
   //Check parameters here.
-  assert(checkParams(genargs,typegen.params));
+  assert(checkArgs(genargs,typegen.params));
 }
 
 //TODO How to deal with select? For now just do a normal select off of raw

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -30,8 +30,8 @@ string RecordType::toString(void) const {
 }
 
 NamedType::NamedType(Namespace* ns, string name, TypeGen* typegen, Args genargs) : Type(NAMED) ,ns(ns), name(name), typegen(typegen), genargs(genargs) {
-  //Check parameters here.
-  assert(checkParams(genargs,typegen->getParams()));
+  //Check args here.
+  assert(checkArgs(genargs,typegen->getParams()));
 
   //Run the typegen
   raw = typegen->getType(genargs);

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -30,8 +30,8 @@ string RecordType::toString(void) const {
 }
 
 NamedType::NamedType(Namespace* ns, string name, TypeGen* typegen, Args genargs) : Type(NAMED) ,ns(ns), name(name), typegen(typegen), genargs(genargs) {
-  //Check arguments here.
-  assert(checkArgs(genargs,typegen->getParams()));
+  //Check parameters here.
+  assert(checkParams(genargs,typegen->getParams()));
 
   //Run the typegen
   raw = typegen->getType(genargs);

--- a/tests/unit/gentest.cpp
+++ b/tests/unit/gentest.cpp
@@ -12,10 +12,10 @@ int main() {
   Args g3 = {{"c",c->int2Arg(5)},{"b",c->str2Arg("ross")}};
   Args g4 = {{"a",c->int2Arg(5)},{"b",c->str2Arg("ross")},{"c",c->type2Arg(c->BitIn())}};
   assert(g1 == g2);
-  assert(checkArgs(g1,{{"a",AINT},{"b",ASTRING}}));
+  assert(checkParams(g1,{{"a",AINT},{"b",ASTRING}}));
   assert(g1 != g3);
   assert(g1 != g4);
-  assert(checkArgs(g4,{{"a",AINT},{"b",ASTRING},{"c",ATYPE}}));
+  assert(checkParams(g4,{{"a",AINT},{"b",ASTRING},{"c",ATYPE}}));
   deleteContext(c);
   return 0;
 }

--- a/tests/unit/gentest.cpp
+++ b/tests/unit/gentest.cpp
@@ -12,10 +12,10 @@ int main() {
   Args g3 = {{"c",c->int2Arg(5)},{"b",c->str2Arg("ross")}};
   Args g4 = {{"a",c->int2Arg(5)},{"b",c->str2Arg("ross")},{"c",c->type2Arg(c->BitIn())}};
   assert(g1 == g2);
-  assert(checkParams(g1,{{"a",AINT},{"b",ASTRING}}));
+  assert(checkArgs(g1,{{"a",AINT},{"b",ASTRING}}));
   assert(g1 != g3);
   assert(g1 != g4);
-  assert(checkParams(g4,{{"a",AINT},{"b",ASTRING},{"c",ATYPE}}));
+  assert(checkArgs(g4,{{"a",AINT},{"b",ASTRING},{"c",ATYPE}}));
   deleteContext(c);
   return 0;
 }


### PR DESCRIPTION
This is a fix for issue #27.