### PR TITLE
Update shared library path for Python bindings

### DIFF
--- a/bindings/python/coreir/__init__.py
+++ b/bindings/python/coreir/__init__.py
@@ -15,7 +15,7 @@ def load_shared_lib():
 
     dir_path = os.path.dirname(os.path.realpath(__file__))
 
-    return cdll.LoadLibrary('{}/../../../build/coreir.{}'.format(dir_path, shared_lib_ext))
+    return cdll.LoadLibrary('{}/../../../bin/libcoreir-c.{}'.format(dir_path, shared_lib_ext))
 
 class COREContext(ct.Structure):
     pass
@@ -80,7 +80,6 @@ COREMapKind_STR2ARG_MAP = COREMapKind(2)
 coreir_lib = load_shared_lib()
 
 coreir_lib.CORENewMap.argtypes = [COREContext_p, ct.c_void_p, ct.c_void_p, ct.c_uint32, COREMapKind]
-
 coreir_lib.CORENewMap.restype = ct.c_void_p
 
 coreir_lib.CORENewContext.restype = COREContext_p

--- a/lib/coreir-c/Makefile
+++ b/lib/coreir-c/Makefile
@@ -37,7 +37,7 @@ clean:
 	rm -rf build/*
 
 build/%.so: build/%.o
-	$(CXX) -shared $(LPATH) -lcoreir -o $@ $^
+	$(CXX) -shared $(LPATH) -o $@ $^ -lcoreir
 	cp $@ $(BIN)/lib$*.so
 
 build/%.dylib: build/%.o


### PR DESCRIPTION
It looks like libreorg is not buildling on the CGRAFlow branch, so I will defer the integration test of this branch to the eventual libreorg pull request.