### PR TITLE
Genupdate

### DIFF
--- a/lib/coreir-c/coreir-c.cpp
+++ b/lib/coreir-c/coreir-c.cpp
@@ -145,8 +145,9 @@ extern "C" {
     return rcast<COREInstance*>(rcast<ModuleDef*>(module_def)->addInstance(string(name),rcast<Module*>(module),*rcast<Args*>(config)));
   }
 
+  //TODO change name to 'setDef'
   void COREModuleAddDef(COREModule* module, COREModuleDef* module_def) {
-    rcast<Module*>(module)->addDef(rcast<ModuleDef*>(module_def));
+    rcast<Module*>(module)->setDef(rcast<ModuleDef*>(module_def));
   }
 
   void COREModuleDefWire(COREModuleDef* module_def, COREWireable* a, COREWireable* b) {

--- a/lib/passes/rungen.cpp
+++ b/lib/passes/rungen.cpp
@@ -85,7 +85,7 @@ bool rungeneratorsRec(Context* c, Module* m, unordered_set<Module*>* ran) {
   }
   
   //Replace the module definition with this new one
-  m->replaceDef(newDef);
+  m->setDef(newDef);
   ran->insert(m);
 
   //recurively run through the runQueue

--- a/lib/passes/typecheck.cpp
+++ b/lib/passes/typecheck.cpp
@@ -7,6 +7,11 @@ namespace CoreIR {
 bool typecheckRec(Context* c, Module* m, unordered_set<Module*>* checked);
 
 
+// This 'typechecks' everything
+  //   Verifies all selects are valid
+  //   Verifies all connections are valid. type <==> FLIP(type)
+  //   Verifies inputs are only connected once
+
 void typecheck(Context* c, Module* m, bool* err) {
   cout << "Typechecking" << endl;
   unordered_set<Module*> checked;

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -8,11 +8,6 @@
 using namespace std;
 namespace CoreIR {
 
-Type* TypeGen::run(Context* c, Args args) {
-  assert(checkParams(args,params));
-  Type* ran = this->fun(c,args);
-  return flipped ? c->Flip(ran) : ran;
-}
 bool isNumber(string s) {
   return s.find_first_not_of("0123456789")==string::npos;
 }

--- a/src/common.hpp
+++ b/src/common.hpp
@@ -43,18 +43,9 @@ struct myPair {
 };
 
 class Type;
+class TypeGen;
 class NamedType;
 typedef Type* (*TypeGenFun)(Context* c, Args args);
-struct TypeGen {
-  Namespace* ns;
-  string name;
-  Params params;
-  TypeGenFun fun;
-  bool flipped;
-  TypeGen(Namespace* ns, string name, Params params, TypeGenFun fun, bool flipped=false) : ns(ns), name(name), params(params), fun(fun), flipped(flipped) {}
-  TypeGen() : ns(nullptr), name(""), params(Params()), fun(nullptr), flipped(false) {} // TODO this is hacky. should find different solution
-  Type* run(Context* c, Args args);
-};
 typedef vector<myPair<string,Type*>> RecordParams ;
 typedef myPair<uint,Type*> ArrayParams ;
 class TypeCache;
@@ -78,8 +69,6 @@ typedef std::pair<string,vector<string>> WirePath;
 typedef myPair<Wireable*,Wireable*> Connection;
 
 
-
-
 //TODO This stuff is super fragile. 
 // Magic hash function I found online
 template <class T> 
@@ -95,7 +84,6 @@ string Param2Str(Param);
 string Params2Str(Params);
 string wireableKind2Str(WireableKind wb);
 Param Str2Param(string s);
-
 
 
 } //CoreIR namespace

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -53,9 +53,10 @@ Namespace* Context::getNamespace(string name) {
   return it->second;
 }
 
+/* TODO This is not even used in the repo yet. Should write a test for it
 // This tries to link all the definitions of def namespace to declarations of decl namespace
 // This will clobber declns
-bool Context::linkLib(Namespace* defns, Namespace* declns) {
+bool Context::linkLib(Namespace* nsFrom, Namespace* nsTo) {
   if (haserror()) {
     return true;
   }
@@ -63,7 +64,7 @@ bool Context::linkLib(Namespace* defns, Namespace* declns) {
     Generator* gdef = (it.second);
     string gdefname = gdef->getName();
     assert(it.first == gdefname);
-    ModuleDefGenFun gdeffun = gdef->getDef();
+    GeneratorDef* gdef = gdef->getDef();
     Generator* gdecl = declns->getGenerator(gdefname);
     
     //If def is not found in decl,
@@ -96,6 +97,7 @@ bool Context::linkLib(Namespace* defns, Namespace* declns) {
   //TODO do modules as well
   return false;
 }
+*/
 
 Type* Context::Any() { return cache->newAny(); }
 Type* Context::BitIn() { return cache->newBitIn(); }

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -113,7 +113,7 @@ Type* Context::Named(string ns, string name, Args args) {
   return this->getNamespace(ns)->getNamedType(name,args);
 }
 
-TypeGen Context::getTypeGen(string ns, string name) {
+TypeGen* Context::getTypeGen(string ns, string name) {
   return this->getNamespace(ns)->getTypeGen(name);
 }
 RecordParams* Context::newRecordParams() {

--- a/src/context.hpp
+++ b/src/context.hpp
@@ -66,7 +66,7 @@ class Context {
     Type* Record(RecordParams rp);
     Type* Named(string ns, string name);
     Type* Named(string ns, string name, Args args);
-    TypeGen getTypeGen(string ns, string name);
+    TypeGen* getTypeGen(string ns, string name);
 
     RecordParams* newRecordParams();
     Params* newParams();

--- a/src/fileIO.cpp
+++ b/src/fileIO.cpp
@@ -189,7 +189,7 @@ Module* loadModule(Context* c, string filename, bool* err) {
       }
       
       //Add Def back in
-      m->addDef(mdef);
+      m->setDef(mdef);
     } //End Module loop
     
     //Reference Top

--- a/src/generatordef.hpp
+++ b/src/generatordef.hpp
@@ -1,0 +1,25 @@
+#ifndef GENERATORDEF_HPP_
+#define GENERATORDEF_HPP_
+
+namespace CoreIR {
+class GeneratorDef {
+  protected:
+    Generator* g;
+  public: 
+    GeneratorDef(Generator* g) : g(g) {}
+    virtual ~GeneratorDef() {}
+    virtual void createModuleDef(ModuleDef*,Context*, Type*, Args) = 0;
+};
+
+class GeneratorDefFromFun : public GeneratorDef {
+  protected:
+    ModuleDefGenFun moduledefgenfun;
+  public:
+    GeneratorDefFromFun(Generator* g, ModuleDefGenFun moduledefgenfun) : GeneratorDef(g), moduledefgenfun(moduledefgenfun) {}
+    void createModuleDef(ModuleDef* mdef, Context* c, Type* t, Args args) {
+      moduledefgenfun(mdef,c,t,args);
+    }
+};
+
+} //CoreIR namespace
+#endif //GENERATORDEF_HPP_

--- a/src/instantiable.cpp
+++ b/src/instantiable.cpp
@@ -3,6 +3,7 @@
 #include <set>
 
 #include "instantiable.hpp"
+#include "typegen.hpp"
 
 using namespace std;
 
@@ -41,9 +42,9 @@ ostream& operator<<(ostream& os, const Instantiable& i) {
   return os;
 }
 
-Generator::Generator(Namespace* ns,string name,Params genparams, TypeGen typegen, Params configparams) : Instantiable(GEN,ns,name,configparams), genparams(genparams), typegen(typegen), def(nullptr) {
+Generator::Generator(Namespace* ns,string name,Params genparams, TypeGen* typegen, Params configparams) : Instantiable(GEN,ns,name,configparams), genparams(genparams), typegen(typegen), def(nullptr) {
   //Verify that genparams are the same
-  assert(genparams == typegen.params);
+  assert(genparams == typegen->getParams());
 }
 
 Generator::~Generator() {

--- a/src/instantiable.cpp
+++ b/src/instantiable.cpp
@@ -41,9 +41,18 @@ ostream& operator<<(ostream& os, const Instantiable& i) {
   return os;
 }
 
-Generator::Generator(Namespace* ns,string name,Params genparams, TypeGen typegen, Params configparams) : Instantiable(GEN,ns,name,configparams), genparams(genparams), typegen(typegen), genfun(nullptr) {
+Generator::Generator(Namespace* ns,string name,Params genparams, TypeGen typegen, Params configparams) : Instantiable(GEN,ns,name,configparams), genparams(genparams), typegen(typegen), def(nullptr) {
   //Verify that genparams are the same
   assert(genparams == typegen.params);
+}
+
+Generator::~Generator() {
+  if (def) {
+    delete def;
+  }
+}
+void Generator::setGeneratorDefFromFun(ModuleDefGenFun fun) {
+  this->def = new GeneratorDefFromFun(this,fun);
 }
 
 string Generator::toString() const {

--- a/src/instantiable.hpp
+++ b/src/instantiable.hpp
@@ -52,19 +52,21 @@ std::ostream& operator<<(ostream& os, const Instantiable&);
 
 class Generator : public Instantiable {
   Params genparams;
-  TypeGen typegen;
+  TypeGen* typegen;
   
   //This is memory managed
   GeneratorDef* def;
   
   public :
-    Generator(Namespace* ns,string name,Params genparams, TypeGen typegen, Params configparams=Params());
+    Generator(Namespace* ns,string name,Params genparams, TypeGen* typegen, Params configparams=Params());
     ~Generator();
     string toString() const;
     json toJson();
-    TypeGen getTypeGen() const { return typegen;}
+    TypeGen* getTypeGen() const { return typegen;}
     bool hasDef() const { return !!def; }
     GeneratorDef* getDef() const {return def;}
+    
+    //This will transfer memory management of def to this Generator
     void setDef(GeneratorDef* def) { assert(!this->def); this->def = def;}
     void setGeneratorDefFromFun(ModuleDefGenFun fun);
     Params getGenparams() {return genparams;}

--- a/src/instantiable.hpp
+++ b/src/instantiable.hpp
@@ -13,6 +13,7 @@
 #include "json.hpp"
 
 #include "moduledef.hpp"
+#include "generatordef.hpp"
 
 #include "metadata.hpp"
 
@@ -52,50 +53,26 @@ std::ostream& operator<<(ostream& os, const Instantiable&);
 class Generator : public Instantiable {
   Params genparams;
   TypeGen typegen;
-  ModuleDefGenFun genfun;
+  
+  //This is memory managed
+  GeneratorDef* def;
+  
   public :
     Generator(Namespace* ns,string name,Params genparams, TypeGen typegen, Params configparams=Params());
-    bool hasDef() const { return !!genfun; }
+    ~Generator();
     string toString() const;
     json toJson();
-    TypeGen getTypeGen() { return typegen;}
-    ModuleDefGenFun getDef() { return genfun;}
-    void addDef(ModuleDefGenFun fun) { genfun = fun;}
+    TypeGen getTypeGen() const { return typegen;}
+    bool hasDef() const { return !!def; }
+    GeneratorDef* getDef() const {return def;}
+    void setDef(GeneratorDef* def) { assert(!this->def); this->def = def;}
+    void setGeneratorDefFromFun(ModuleDefGenFun fun);
     Params getGenparams() {return genparams;}
 };
-
-class InstanceDAG {
-  //Provides a mapping from {ns,name} to counts of that instance
-  unordered_map<myPair<string,string>,uint> insts;
-  public:
-    InstanceDAG() {}
-    void insert(string ns, string name) {
-      insts[{ns,name}] +=1;
-      cout << "D Insert: " << ns << "." << name << " " << insts.count({ns,name}) << endl;
-    }
-    void remove(string ns, string name) {
-      if (insts.count({ns,name}) <=1) {
-        insts.erase({ns,name});
-      }
-      else {
-        insts[{ns,name}] -=1 ;
-      }
-      cout << "D Remove: " << ns << "." << name << " " << insts.count({ns,name}) << endl;
-    }
-    vector<myPair<string,string>> get() {
-      vector<myPair<string,string>> keys;
-      for (auto k : insts) keys.push_back(k.first);
-      return keys;
-    }
-};
-
 
 class Module : public Instantiable {
   Type* type;
   ModuleDef* def;
-  string verilog;
-  
-  InstanceDAG instanceDAG;
   
   //Memory Management
   vector<ModuleDef*> mdefList;
@@ -104,30 +81,16 @@ class Module : public Instantiable {
     Module(Namespace* ns,string name, Type* type,Params configparams) : Instantiable(MOD,ns,name,configparams), type(type), def(nullptr) {}
     ~Module();
     bool hasDef() const { return !!def; }
-    ModuleDef* getDef() { return def; } // TODO should probably throw error if does not exist
+    ModuleDef* getDef() const { return def; } // TODO should probably throw error if does not exist
+    void setDef(ModuleDef* def) { this->def = def;}
+    ModuleDef* newModuleDef();
+    
     string toString() const;
     json toJson();
     Type* getType() { return type;}
-    void addDef(ModuleDef* _def) { assert(!def); def = _def;}
-    void replaceDef(ModuleDef* _def) { def = _def;}
-    ModuleDef* newModuleDef();
-    void logInstanceAdd(string ns, string name) {
-      instanceDAG.insert(ns,name);
-    }
-    vector<myPair<string,string>> getInstanceDAG() { return instanceDAG.get();}
-    void logInstanceDel(string ns, string name) {
-      instanceDAG.remove(ns,name);
-    }
+    
     void print(void);
-    
-    
-    //TODO turn this into metadata
-    void addVerilog(string _v) {verilog = _v;}
-    
 };
-
-//void* allocateFromType(Type* t);
-//void deallocateFromType(Type* t, void* d);
 
 
 // Compiling functions.
@@ -143,16 +106,6 @@ void resolveDecls(Context* c, ModuleDef* m);
 
 //Only runs the moduleGens
 void runGenerators(Context* c, ModuleDef* m);
-
-
-// This 'typechecks' everything
-  //   Verifies all selects are valid
-  //   Verifies all connections are valid. type <==> FLIP(type)
-  //   Verifies inputs are only connected once
-
-//typedef map<ModuleDef*,TypedModuleDef*> typechecked_t;
-//typechecked_t* typecheck(Context* c, ModuleDef* m);
-
 
 // This verifies that there are no unconnected wires
 //void validate(TypedModuleDef* tm);

--- a/src/moduledef.cpp
+++ b/src/moduledef.cpp
@@ -51,18 +51,12 @@ Instance* ModuleDef::addInstance(string instname,Generator* gen, Args genargs,Ar
   Instance* inst = new Instance(this,instname,gen,type,genargs,config);
   instances[instname] = inst;
   
-  //Log the instance for use in the instance graph
-  module->logInstanceAdd(gen->getNamespace()->getName(),gen->getName());
-  
   return inst;
 }
 
 Instance* ModuleDef::addInstance(string instname,Module* m,Args config) {
   Instance* inst = new Instance(this,instname,m,m->getType(),Args(),config);
   instances[instname] = inst;
-  
-  //Log the instance
-  module->logInstanceAdd(m->getNamespace()->getName(),m->getName());
   
   return inst;
 }

--- a/src/moduledef.cpp
+++ b/src/moduledef.cpp
@@ -1,4 +1,6 @@
+
 #include "moduledef.hpp"
+#include "typegen.hpp"
 
 using namespace std;
 
@@ -44,9 +46,9 @@ Type* ModuleDef::getType() {return module->getType();}
 
 Instance* ModuleDef::addInstance(string instname,Generator* gen, Args genargs,Args config) {
   assert(instances.count(instname)==0);
-  //Should this type be resolved? Just create a typeGenInst for now
-  Context* c = gen->getContext();
-  Type* type = gen->getTypeGen().fun(c,genargs);
+  
+  //TODO Should this type be resolved? Just always get the type for now
+  Type* type = gen->getTypeGen()->getType(genargs);
   
   Instance* inst = new Instance(this,instname,gen,type,genargs,config);
   instances[instname] = inst;

--- a/src/namespace.cpp
+++ b/src/namespace.cpp
@@ -219,8 +219,8 @@ Module* Namespace::runGenerator(Generator* g, Args genargs, Type* t) {
   Module* mNew = this->newModuleDecl(mNewName,t);
   if (g->getDef()) {
     ModuleDef* mdef = mNew->newModuleDef();
-    g->getDef()(mdef,c,t,genargs);
-    mNew->addDef(mdef);
+    g->getDef()->run(mdef,c,t,genargs);
+    mNew->setDef(mdef);
   }
   genCache.emplace(gcp,mNew);
   return mNew;

--- a/src/namespace.cpp
+++ b/src/namespace.cpp
@@ -1,4 +1,5 @@
 #include "namespace.hpp"
+#include "typegen.hpp"
 
 using namespace std;
 
@@ -31,6 +32,7 @@ Namespace::~Namespace() {
   for (auto g : generatorList) delete g.second;
   for (auto n : namedTypeList) delete n.second;
   for (auto n : namedTypeGenCache) delete n.second;
+  for (auto tg : typeGenList) delete tg.second;
 }
 
 NamedType* Namespace::newNamedType(string name, string nameFlip, Type* raw) {
@@ -44,8 +46,8 @@ NamedType* Namespace::newNamedType(string name, string nameFlip, Type* raw) {
   namedTypeNameMap[name] = nameFlip;
 
   //Create two new NamedTypes
-  NamedType* named = new NamedType(this,name,raw,TypeGen(),Args());
-  NamedType* namedFlip = new NamedType(this,nameFlip,raw->getFlipped(),TypeGen(),Args());
+  NamedType* named = new NamedType(this,name,raw);
+  NamedType* namedFlip = new NamedType(this,nameFlip,raw->getFlipped());
   named->setFlipped(namedFlip);
   namedFlip->setFlipped(named);
   namedTypeList[name] = named;
@@ -53,6 +55,7 @@ NamedType* Namespace::newNamedType(string name, string nameFlip, Type* raw) {
   return named;
 }
 
+//TODO
 void Namespace::newNominalTypeGen(string name, string nameFlip, Params genparams, TypeGenFun fun) {
   //Make sure the name and its flip are different
   assert(name != nameFlip);
@@ -64,8 +67,8 @@ void Namespace::newNominalTypeGen(string name, string nameFlip, Params genparams
   typeGenNameMap[name] = nameFlip;
 
   //Create the TypeGens
-  TypeGen typegen(this,name,genparams,fun,false);
-  TypeGen typegenFlip(this,nameFlip,genparams,fun,true);
+  TypeGen* typegen = new TypeGenFromFun(this,name,genparams,fun,false);
+  TypeGen* typegenFlip = new TypeGenFromFun(this,nameFlip,genparams,fun,true);
   
   //Add typegens into list
   typeGenList[name] = typegen;
@@ -104,17 +107,14 @@ NamedType* Namespace::getNamedType(string name, Args genargs) {
     e.fatal();
     c->error(e);
   }
-  TypeGen tgen = typeGenList.at(name);
+  TypeGen* tgen = typeGenList.at(name);
   string nameFlip = typeGenNameMap.at(name);
-  TypeGen tgenFlip = typeGenList.at(nameFlip);
+  TypeGen* tgenFlip = typeGenList.at(nameFlip);
   NamedCacheParams ncpFlip(nameFlip,genargs);
 
-  //TODO for now just run the generator.
-  Type* raw = tgen.run(this->c,genargs);
-
   //Create two new named entries
-  NamedType* named = new NamedType(this,name,raw,tgen,genargs);
-  NamedType* namedFlip = new NamedType(this,nameFlip,raw->getFlipped(),tgenFlip,genargs);
+  NamedType* named = new NamedType(this,name,tgen,genargs);
+  NamedType* namedFlip = new NamedType(this,nameFlip,tgenFlip,genargs);
   named->setFlipped(namedFlip);
   namedFlip->setFlipped(named);
   namedTypeGenCache[ncp] = named;
@@ -126,7 +126,7 @@ void Namespace::newTypeGen(string name, Params genparams, TypeGenFun fun) {
   assert(namedTypeList.count(name)==0);
   assert(typeGenList.count(name)==0);
   
-  TypeGen typegen(this,name,genparams,fun);
+  TypeGen* typegen = new TypeGenFromFun(this,name,genparams,fun);
   
   //Add name to typeGenNameMap
   typeGenNameMap[name] = "";
@@ -135,17 +135,17 @@ void Namespace::newTypeGen(string name, Params genparams, TypeGenFun fun) {
 }
 
 //TODO deal with at errors
-TypeGen Namespace::getTypeGen(string name) {
+TypeGen* Namespace::getTypeGen(string name) {
   cout << "TypeGen name:" << name << endl;
   assert(typeGenList.count(name)>0);
-  TypeGen ret = typeGenList.at(name);
-  assert(ret.name==name);
+  TypeGen* ret = typeGenList.at(name);
+  assert(ret->getName()==name);
   return ret;
 }
 
 
 
-Generator* Namespace::newGeneratorDecl(string name, Params genparams, TypeGen typegen) {
+Generator* Namespace::newGeneratorDecl(string name, Params genparams, TypeGen* typegen) {
   //Make sure module does not already exist as a module or generator
   assert(moduleList.count(name)==0);
   assert(generatorList.count(name)==0);
@@ -219,7 +219,7 @@ Module* Namespace::runGenerator(Generator* g, Args genargs, Type* t) {
   Module* mNew = this->newModuleDecl(mNewName,t);
   if (g->getDef()) {
     ModuleDef* mdef = mNew->newModuleDef();
-    g->getDef()->run(mdef,c,t,genargs);
+    g->getDef()->createModuleDef(mdef,c,t,genargs);
     mNew->setDef(mdef);
   }
   genCache.emplace(gcp,mNew);

--- a/src/namespace.hpp
+++ b/src/namespace.hpp
@@ -49,8 +49,9 @@ class Namespace {
   
   //Caches the NamedTypes with args
   unordered_map<NamedCacheParams,NamedType*,NamedCacheParamsHasher> namedTypeGenCache;
-  //Mapping name to typegen and nameFlip
-  unordered_map<string,TypeGen> typeGenList;
+  
+  //Mapping name to typegen 
+  unordered_map<string,TypeGen*> typeGenList;
 
   //Save the unflipped names for json file
   unordered_map<string,string> namedTypeNameMap;
@@ -70,10 +71,10 @@ class Namespace {
     bool hasNamedType(string name);
     NamedType* getNamedType(string name);
     NamedType* getNamedType(string name, Args genargs);
-    TypeGen getTypeGen(string name);
+    TypeGen* getTypeGen(string name);
     bool hasTypeGen(string name) {return typeGenList.count(name)>0;}
 
-    Generator* newGeneratorDecl(string name, Params genparams, TypeGen typegen);
+    Generator* newGeneratorDecl(string name, Params genparams, TypeGen* typegen);
     Module* newModuleDecl(string name, Type* t,Params configparams=Params());
 
     Generator* getGenerator(string gname);

--- a/src/typegen.hpp
+++ b/src/typegen.hpp
@@ -1,0 +1,42 @@
+#ifndef TYPEGEN_HPP_
+#define TYPEGEN_HPP_
+
+#include "common.hpp"
+
+namespace CoreIR {
+
+class TypeGen {
+  Namespace* ns;
+  string name;
+  Params params;
+  bool flipped;
+  
+  //TODO maybe cache the types based off the args
+  public:
+    TypeGen(Namespace* ns, string name, Params params, bool flipped=false) : ns(ns), name(name), params(params), flipped(flipped) {}
+    virtual ~TypeGen() {}
+    virtual Type* createType(Context* c, Args args) = 0;
+    Type* getType(Args args) {
+      assert(checkParams(args,params) && "Argument types do not match params!");
+      Type* t = createType(ns->getContext(),args);
+      return flipped ? t->getFlipped() : t;
+    }
+    Namespace* getNamespace() const {return ns;}
+    string getName() const {return name;}
+    Params getParams() const {return params;}
+    bool isFlipped() const { return flipped;}
+};
+
+//Notice, the base class does the flipping for you in the function computeType
+class TypeGenFromFun : public TypeGen {
+  TypeGenFun fun;
+  
+  public:
+    TypeGenFromFun(Namespace* ns, string name, Params params, TypeGenFun fun, bool flipped=false) : TypeGen(ns,name,params,flipped), fun(fun) {}
+    Type* createType(Context* c, Args args) {
+      return fun(c,args);
+    }
+};
+
+}// CoreIR
+#endif //TYPEGEN_HPP_

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -1,4 +1,5 @@
 #include "types.hpp"
+#include "typegen.hpp"
 
 namespace CoreIR {
 
@@ -28,9 +29,12 @@ string RecordType::toString(void) const {
   return ret;
 }
 
-NamedType::NamedType(Namespace* ns, string name, Type* raw, TypeGen typegen, Args genargs) : Type(NAMED) ,ns(ns), name(name), raw(raw), typegen(typegen), genargs(genargs) {
+NamedType::NamedType(Namespace* ns, string name, TypeGen* typegen, Args genargs) : Type(NAMED) ,ns(ns), name(name), typegen(typegen), genargs(genargs) {
   //Check parameters here.
-  assert(checkParams(genargs,typegen.params));
+  assert(checkParams(genargs,typegen->getParams()));
+
+  //Run the typegen
+  raw = typegen->getType(genargs);
 }
 
 //TODO How to deal with select? For now just do a normal select off of raw

--- a/src/types.hpp
+++ b/src/types.hpp
@@ -67,10 +67,11 @@ class NamedType : public Type {
     
     Type* raw;
 
-    TypeGen typegen;
+    TypeGen* typegen;
     Args genargs;
   public :
-    NamedType(Namespace* ns, string name, Type* raw, TypeGen typegen, Args genargs);
+    NamedType(Namespace* ns, string name, Type* raw) : Type(NAMED), ns(ns), name(name), raw(raw), typegen(nullptr) {}
+    NamedType(Namespace* ns, string name, TypeGen* typegen, Args genargs);
     string toString(void) const { return name; } //TODO
     string getName() {return name;}
     Type* getRaw() {return raw;}

--- a/src/wireable.cpp
+++ b/src/wireable.cpp
@@ -57,11 +57,9 @@ Arg* Instance::getConfigValue(string s) {
 
 bool Instance::isGen() { return instRef->isKind(GEN);}
 bool Instance::hasDef() { return instRef->hasDef(); }
-void Instance::replace(Instantiable* _instRef, Args _config) {
-  this->moduledef->getModule()->logInstanceDel(instRef->getNamespace()->getName(),instRef->getName());
-  this->instRef = _instRef;
-  this->config = _config;
-  this->moduledef->getModule()->logInstanceAdd(_instRef->getNamespace()->getName(),_instRef->getName());
+void Instance::replace(Instantiable* instRef, Args config) {
+  this->instRef = instRef;
+  this->config = config;
 }
 
 

--- a/src/wireable.hpp
+++ b/src/wireable.hpp
@@ -69,7 +69,7 @@ class Instance : public Wireable {
     //Convinience functions
     bool isGen();
     bool hasDef();
-    void replace(Instantiable* _instRef, Args _config);
+    void replace(Instantiable* instRef, Args config);
 };
 
 class Select : public Wireable {

--- a/tests/run
+++ b/tests/run
@@ -1,4 +1,8 @@
 #!/bin/sh
 #cd unit; ./run -memcheck
+set -e
 cd unit; ./run; cd -
 cd unit-c; ./run; cd -
+GREEN='\033[0;32m'
+NC='\033[0m'
+echo "${GREEN} PASSED ALL TESTS!${NC}"

--- a/tests/unit/add4.cpp
+++ b/tests/unit/add4.cpp
@@ -44,7 +44,7 @@ int main() {
     def->wire(add_01->sel("out"),add_1->sel("in1"));
 
     def->wire(add_1->sel("out"),self->sel("out"));
-  add4_n->addDef(def);
+  add4_n->setDef(def);
   cout << "Checkign Errors 1" << endl;
   c->checkerrors();
   add4_n->print();

--- a/tests/unit/addmult.cpp
+++ b/tests/unit/addmult.cpp
@@ -34,7 +34,7 @@ int main() {
     def->wire(constinst->sel("out"),multinst->sel("in0"));
     def->wire(addinst->sel("out"),multinst->sel("in1"));
 
-  addmult->addDef(def);
+  addmult->setDef(def);
 
   addmult->print();
   

--- a/tests/unit/run
+++ b/tests/unit/run
@@ -1,6 +1,11 @@
 #!/bin/sh
 set -x #echo on
 echo "$1"
+
+#function mytest {
+#  "$@"
+#  local status = $?
+set -e
 if [[ -n $1 &&  "$1" -eq '-memcheck' ]]; then
   for file in build/*; do valgrind --error-exitcode=1 $file; done
 else


### PR DESCRIPTION
I did an overhaul of the way to run typegen functions and generators in order to make it more extensible.

Typegens now have a getType(Args) method which will run a virtual function called computeType(). This function can be overloaded from an inherited class (from TypeGen). This is a little nicer because now you can create TypeGens without having to pass in an ugly function pointer. I still allow you to pass in a function pointer though for the constructor.

This is also what I did for Generators. Generators now have a pointer to a GeneratorDef class which has a single method which will run the generator for you. In the same way, you can create generators by inheriting from the class and overloading the virtual function

Other minor fixes:
TypeGens are passed via pointers instead of values
addDef ->setDef (naming consistency)
Added actual Test passing checking for the unit tests