### PR TITLE
API convenience added

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,12 @@ all:
 test:
 	make -C tests
 	cd tests; ./run
+	
+pytest:
+	pip install -e bindings/python
+	pip3 install -e bindings/python
+	cd tests
+	pytest;
 
 install:
 	make -C src build/coreir.so
@@ -22,7 +28,4 @@ travis:
 	make clean
 	make installosx
 	make test
-	pip install -e bindings/python
-	pip3 install -e bindings/python
-	cd tests
-	pytest;
+	make pytest

--- a/bindings/python/coreir/__init__.py
+++ b/bindings/python/coreir/__init__.py
@@ -179,8 +179,8 @@ coreir_lib.COREWireableGetModuleDef.restype = COREModuleDef_p
 coreir_lib.COREWireableSelect.argtypes = [COREWireable_p, ct.c_char_p]
 coreir_lib.COREWireableSelect.restype = CORESelect_p
 
-coreir_lib.COREWireableGetAncestors.argtypes = [COREWireable_p, ct.POINTER(ct.c_int)]
-coreir_lib.COREWireableGetAncestors.restype = ct.POINTER(ct.c_char_p)
+coreir_lib.COREWireableGetSelectPath.argtypes = [COREWireable_p, ct.POINTER(ct.c_int)]
+coreir_lib.COREWireableGetSelectPath.restype = ct.POINTER(ct.c_char_p)
 
 coreir_lib.COREModuleDefSelect.argtypes = [COREModuleDef_p, ct.c_char_p]
 coreir_lib.COREModuleDefSelect.restype = CORESelect_p
@@ -218,9 +218,9 @@ class Wireable(CoreIRType):
         result = coreir_lib.COREWireableGetConnectedWireables(self.ptr, ct.byref(size))
         return [Wireable(result[i],self.context) for i in range(size.value)]
 
-    def get_ancestors(self):
+    def get_selectpath(self):
         size = ct.c_int()
-        result = coreir_lib.COREWireableGetAncestors(self.ptr, ct.byref(size))
+        result = coreir_lib.COREWireableGetSelectPath(self.ptr, ct.byref(size))
         return [result[i].decode() for i in range(size.value)]
 
     def select(self, field):

--- a/bindings/python/test/test_coreir.py
+++ b/bindings/python/test/test_coreir.py
@@ -120,7 +120,7 @@ def test_wireable():
     actual = [get_pointer_addr(wireable.ptr) for wireable in _input.get_connected_wireables()]
     assert get_pointer_addr(add8_in1.ptr) in actual
     assert get_pointer_addr(add8_in2.ptr) in actual
-    for expected, actual in zip(['adder', 'out'], add8_out.get_ancestors()):
+    for expected, actual in zip(['adder', 'out'], add8_out.get_selectpath()):
         assert expected == actual
 
     wireable = module_def.select("self")

--- a/lib/coreir-c/coreir-c.cpp
+++ b/lib/coreir-c/coreir-c.cpp
@@ -262,15 +262,14 @@ extern "C" {
     return rcast<COREModule*>(rcast<ModuleDef*>(m)->getModule());
   }
 
-  const char** COREWireableGetAncestors(COREWireable* w, int* num_ancestors) {
-    WirePath path = rcast<Wireable*>(w)->getPath();
+  const char** COREWireableGetSelectPath(COREWireable* w, int* num_selects) {
+    SelectPath path = rcast<Wireable*>(w)->getSelectPath();
     Context* c = rcast<Wireable*>(w)->getContext();
-    path.second.insert(path.second.begin(), path.first);
-    int size = path.second.size();
-    *num_ancestors = size;
+    int size = path.size();
+    *num_selects = size;
     const char** arr = c->newConstStringArray(size);
     for (int i = 0; i < size; i++) {
-      arr[i] = path.second[i].c_str();
+      arr[i] = path[i].c_str();
     }
     return arr;
   }

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -1,5 +1,9 @@
 #include "common.hpp"
 #include <cassert>
+#include <string>
+#include <sstream>
+#include <vector>
+#include <iterator>
 
 //#include "coreir.hpp"
 //#include "typedcoreir.hpp"
@@ -35,6 +39,21 @@ string Params2Str(Params genparams) {
     ret = ret + it->first + ": " + Param2Str(it->second) + ((it==genparams.begin()) ? "" : ",");
   }
   return ret + ")";
+}
+
+std::vector<std::string> splitString(const std::string &s, char delim) {
+    std::vector<std::string> elems;
+    std::stringstream ss;
+    ss.str(s);
+    std::string item;
+    while (std::getline(ss, item, delim)) {
+      elems.push_back(item);
+    }
+    return elems;
+}
+
+bool hasChar(const std::string s, char c) {
+  return s.find_first_of(c) !=string::npos;
 }
 
 

--- a/src/common.hpp
+++ b/src/common.hpp
@@ -61,7 +61,7 @@ class Interface;
 class Instance;
 class Select;
 
-typedef std::pair<string,vector<string>> WirePath;
+typedef vector<string> SelectPath;
 typedef myPair<Wireable*,Wireable*> Connection;
 
 
@@ -78,6 +78,8 @@ bool isNumber(string s);
 string Param2Str(Param);
 string Params2Str(Params);
 Param Str2Param(string s);
+vector<std::string> splitString(const string &s, char delim);
+bool hasChar(const std::string s, char c);
 
 
 } //CoreIR namespace

--- a/src/fileIO.cpp
+++ b/src/fileIO.cpp
@@ -184,14 +184,8 @@ Module* loadModule(Context* c, string filename, bool* err) {
       //Connections
       if (jdef.count("connections")) {
         for (auto jcon : jdef.at("connections").get<vector<vector<json>>>()) {
-          vector<string> wA = jcon[0].get<vector<string>>();
-          vector<string> wB = jcon[1].get<vector<string>>();
-          string instA = wA[0];
-          string instB = wB[0];
-          wA.erase(wA.begin());
-          wB.erase(wB.begin());
-          WirePath pathA = {instA,wA};
-          WirePath pathB = {instB,wB};
+          vector<string> pathA = jcon[0].get<vector<string>>();
+          vector<string> pathB = jcon[1].get<vector<string>>();
           mdef->wire(pathA,pathB);
         }
       }
@@ -461,9 +455,9 @@ json ModuleDef::toJson() {
 }
 
 json Wireable2Json(Wireable* w) {
-  WirePath path = w->getPath();
-  json j = json::array({path.first});
-  for (auto str : path.second) j.push_back(str);
+  json j;
+  SelectPath path = w->getSelectPath();
+  for (auto str : path) j.push_back(str);
   return j;
 }
 

--- a/src/moduledef.cpp
+++ b/src/moduledef.cpp
@@ -1,6 +1,7 @@
 
 #include "moduledef.hpp"
 #include "typegen.hpp"
+#include <iterator>
 
 using namespace std;
 
@@ -99,18 +100,31 @@ void ModuleDef::wire(Wireable* a, Wireable* b) {
   }
 }
 
-void ModuleDef::wire(WirePath pathA, WirePath pathB) {
-  Wireable* curA = this->sel(pathA.first);
-  Wireable* curB = this->sel(pathB.first);
-  for (auto str : pathA.second) curA = curA->sel(str);
-  for (auto str : pathB.second) curB = curB->sel(str);
-  this->wire(curA,curB);
+void ModuleDef::wire(SelectPath pathA, SelectPath pathB) {
+  this->wire(this->sel(pathA),this->sel(pathB));
 }
 
+void ModuleDef::wire(string pathA, string pathB) {
+  this->wire(this->sel(pathA),this->sel(pathB));
+}
 
+//Can pass in either a single instance name
+//Or pass in a '.' deleminated string
 Wireable* ModuleDef::sel(string s) { 
+  if (hasChar(s,'.')) {
+    SelectPath path = splitString(s,'.');
+    return this->sel(path);
+  }
   if (s=="self") return interface;
   else return instances[s]; 
+}
+
+Wireable* ModuleDef::sel(SelectPath path) {
+  Wireable* cur = this->sel(path[0]);
+  for (auto it = std::next(path.begin()); it != path.end(); ++it) {
+    cur = cur->sel(*it);
+  }
+  return cur;
 }
 
 

--- a/src/moduledef.hpp
+++ b/src/moduledef.hpp
@@ -49,8 +49,10 @@ class ModuleDef {
     Instance* addInstance(Instance* i); //copys info about i
     Interface* getInterface(void) {return interface;}
     Wireable* sel(string s);
+    Wireable* sel(SelectPath path);
     void wire(Wireable* a, Wireable* b);
-    void wire(WirePath a, WirePath b);
+    void wire(SelectPath pathA, SelectPath pathB);
+    void wire(string pathA, string pathB);
     json toJson();
     
 };

--- a/src/wireable.cpp
+++ b/src/wireable.cpp
@@ -27,16 +27,20 @@ Select* Wireable::sel(string selStr) {
 Select* Wireable::sel(uint selStr) { return sel(to_string(selStr)); }
 
 // TODO This might be slow due to insert on a vector. Maybe use Deque?
-WirePath Wireable::getPath() {
+SelectPath Wireable::getSelectPath() {
   Wireable* top = this;
   vector<string> path;
   while(auto s = dyn_cast<Select>(top)) {
     path.insert(path.begin(), s->getSelStr());
     top = s->getParent();
   }
-  if (isa<Interface>(top)) return {"self",path};
-  string instname = cast<Instance>(top)->getInstname();
-  return {instname, path};
+  if (isa<Interface>(top)) 
+    path.insert(path.begin(), "self");
+  else { //This should be an instance
+    string instname = cast<Instance>(top)->getInstname();
+    path.insert(path.begin(), instname);
+  }
+  return path;
 }
 
 Context* Wireable::getContext() { return moduledef->getContext();}

--- a/src/wireable.hpp
+++ b/src/wireable.hpp
@@ -36,10 +36,9 @@ class Wireable {
     Select* sel(string);
     Select* sel(uint);
   
-    // Convinience function
     // if this wireable is from add3inst.a.b[0], then this will look like
-    // {add3inst,{a,b,0}}
-    WirePath getPath();
+    // {add3inst,a,b,0}
+    SelectPath getSelectPath();
     string wireableKind2Str(WireableKind wb);
 };
 

--- a/tests/unit-c/Makefile
+++ b/tests/unit-c/Makefile
@@ -10,7 +10,7 @@ ifeq ($(COREIRCONFIG),g++-4.9)
 CXX = g++-4.9
 endif
 
-CXXFLAGS = -std=c++11  -Wall  -fPIC
+CXXFLAGS = -std=c++11  -Wall  -fPIC -Werror
 CFLAGS = -Wall -fPIC
 
 ifdef COREDEBUG

--- a/tests/unit-c/ctest.c
+++ b/tests/unit-c/ctest.c
@@ -35,7 +35,6 @@ int main() {
   void* cp = CORENewMap(c,cpkeys,cpparams,2,STR2PARAM_MAP);
 
   COREModule* lut4 = CORENewModule(ns,"LUT4",lut4type,cp);
-  
 
   COREModule* m = CORENewModule(ns,"Main",COREBitIn(c),NULL);
 
@@ -49,11 +48,19 @@ int main() {
   cargs[1] = COREInt2Arg(c,13);
 
   void* config = CORENewMap(c,ckeys,cargs,2,STR2ARG_MAP);
-  
 
-
-
-  COREModuleDefAddModuleInstance(mdef, "ctop",lut4,config);
+  COREInstance* inst = COREModuleDefAddModuleInstance(mdef, "ctop",lut4,config);
+  (void) inst;
+  //TODO once the C api is changed
+  /*
+  COREWireable* sel1 = COREInstanceSelect(inst,"in");
+  COREWireable* sel2 = COREWireableSelect(sel1,"4");
+  int num_selects
+  const char** selpath = COREWireableGetSelectPath(sel2, &num_selects);
+  assert(num_selects==2);
+  assert(strcmp(selpath[0],"in")==0);
+  assert(strcmp(selpath[1],"4")==0);
+  */
 
   COREModuleAddDef(m,mdef);
 

--- a/tests/unit/Makefile
+++ b/tests/unit/Makefile
@@ -10,7 +10,7 @@ ifeq ($(COREIRCONFIG),g++-4.9)
 CXX = g++-4.9
 endif
 
-CXXFLAGS = -std=c++11  -Wall  -fPIC
+CXXFLAGS = -std=c++11  -Wall  -fPIC -Werror
 
 ifdef COREDEBUG
 CXXFLAGS += -O0 -g3 -D_GLIBCXX_DEBUG 

--- a/tests/unit/connect.cpp
+++ b/tests/unit/connect.cpp
@@ -23,18 +23,20 @@ int main() {
   Module* mod = g->newModuleDecl("mod",mType);
   ModuleDef* def = mod->newModuleDef();
     Wireable* self = def->sel("self");
-    Wireable* i0 = def->addInstance("c0",const16,{{"width",c->argInt(16)}});
+    Wireable* i0 = def->addInstance("i0",const16,{{"width",c->argInt(16)}});
     def->wire(i0->sel("out"),self->sel("out"));
     def->wire(i0->sel("out"),self->sel("out"));
     def->wire(self->sel("out"),i0->sel("out"));
+    //Also check other wiring format
     def->wire(self->sel("out")->sel(0),i0->sel("out")->sel(2));
+    def->wire("self.out.2","i0.out.4");
   
   mod->setDef(def);
   cout << "Checkign Errors 1" << endl;
   c->checkerrors();
   
-  //Verify that the number of connections is only 2. 
-  assert(def->getConnections().size() == 2);
+  //Verify that the number of connections is only 3. 
+  assert(def->getConnections().size() == 3);
 
   deleteContext(c);
   


### PR DESCRIPTION
changed WirePath to SelectPath for better naming. 
changed ancestors to selectpath for better naming. 
changed SelectPath to just be a vector of strings instead of the weird pair thing. 
Add the ability to specify wiring and selects by a '.' deleminated naming convention (More compact to write!)
Updated the connection unit test to use this notation.

Also added an assertion on sel to prevent segfaults for bad select
