### PR TITLE
type_traits.h has unique ifndef to work with Halide ; make->(MAKE)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 all:
 
 test:
-	make -C tests
+	$(MAKE) -C tests
 	cd tests; ./run
-	
+
 pytest:
 	pip install -e bindings/python
 	pip3 install -e bindings/python
@@ -11,21 +11,21 @@ pytest:
 	pytest;
 
 install:
-	make -C src build/coreir.so
-	make -C src/lib so
+	$(MAKE) -C src build/coreir.so
+	$(MAKE) -C src/lib so
 
 osx:
-	make -C src build/coreir.dylib
-	make -C src/lib dylib
+	$(MAKE) -C src build/coreir.dylib
+	$(MAKE) -C src/lib dylib
 
 clean:
 	rm -rf lib/*
-	make -C src clean
-	make -C src/lib clean
-	make -C tests clean
+	$(MAKE) -C src clean
+	$(MAKE) -C src/lib clean
+	$(MAKE) -C tests clean
 
 travis:
-	make clean
-	make osx
-	make test
-	make pytest
+	$(MAKE) clean
+	$(MAKE) osx
+	$(MAKE) test
+	$(MAKE) pytest

--- a/src/casting/type_traits.h
+++ b/src/casting/type_traits.h
@@ -12,8 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef LLVM_SUPPORT_TYPE_TRAITS_H
-#define LLVM_SUPPORT_TYPE_TRAITS_H
+#ifndef COREIR_SUPPORT_TYPE_TRAITS_H
+#define COREIR_SUPPORT_TYPE_TRAITS_H
 
 #include <type_traits>
 #include <utility>

--- a/src/lib/Makefile
+++ b/src/lib/Makefile
@@ -1,22 +1,22 @@
 
 
 all:
-	make -C coreir-c
-	make -C passes
-	make -C libs
+	$(MAKE) -C coreir-c
+	$(MAKE) -C passes
+	$(MAKE) -C libs
 
 so:
-	make -C coreir-c so
-	make -C passes so
-	make -C libs so
+	$(MAKE) -C coreir-c so
+	$(MAKE) -C passes so
+	$(MAKE) -C libs so
 
 dylib:
-	make -C coreir-c dylib
-	make -C passes dylib
-	make -C libs dylib
+	$(MAKE) -C coreir-c dylib
+	$(MAKE) -C passes dylib
+	$(MAKE) -C libs dylib
 
 
 clean:
-	make -C coreir-c clean
-	make -C passes clean
-	make -C libs clean
+	$(MAKE) -C coreir-c clean
+	$(MAKE) -C passes clean
+	$(MAKE) -C libs clean

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,11 +1,11 @@
 
 
 all:
-	make -C unit
-	make -C unit-c
-	make -C cgra
+	$(MAKE) -C unit
+	$(MAKE) -C unit-c
+	$(MAKE) -C cgra
 
 clean:
-	make -C unit clean
-	make -C unit-c clean
-	make -C cgra clean
+	$(MAKE) -C unit clean
+	$(MAKE) -C unit-c clean
+	$(MAKE) -C cgra clean

--- a/tools/typecheck/Makefile
+++ b/tools/typecheck/Makefile
@@ -10,5 +10,5 @@ CXXFLAGS = -std=c++11  -Wall  -fPIC
 all: ../build/typecheck
 
 ../build/typecheck: typecheck.cpp
-	make -C ../../src
+	$(MAKE) -C ../../src
 	$(CXX) $(CXXFLAGS) $(INCS) -o $@ $< ../../build/coreir.a


### PR DESCRIPTION
I changed the include guard for type_traits.h to a new name, since it was conflicting with llvm's version with the same name. This caused problems when I included coreir as well as llvm headers.

In addition, I changed all "make"s in Makefiles to "$(MAKE)" so that one can pass various options when recursively calling make. (For example, make -j4 install in the root directory now passes).