### PR TITLE
Initial Python support for directed view API

### DIFF
--- a/bindings/python/coreir/__init__.py
+++ b/bindings/python/coreir/__init__.py
@@ -448,7 +448,7 @@ class COREDirectedModule(ct.Structure):
 
 COREDirectedModule_p = ct.POINTER(COREModule)
 
-coreir_lib.COREDirectedModuleSel.argtypes = [COREDirectedModule_p, ct.POINTER(ct.c_char_p()), ct.c_int]
+coreir_lib.COREDirectedModuleSel.argtypes = [COREDirectedModule_p, ct.POINTER(ct.c_char_p), ct.c_int]
 coreir_lib.COREDirectedModuleSel.restype = COREWireable_p
 
 coreir_lib.COREDirectedModuleGetInstances.argtypes = [COREDirectedModule_p, ct.byref(ct.c_int)]

--- a/bindings/python/coreir/__init__.py
+++ b/bindings/python/coreir/__init__.py
@@ -465,6 +465,9 @@ coreir_lib.COREDirectedModuleGetInputs.restype = ct.POINTER(COREDirectedConnecti
 coreir_lib.COREDirectedModuleGetOutputs.argtypes = [COREDirectedModule_p, ct.POINTER(ct.c_int)]
 coreir_lib.COREDirectedModuleGetOutputs.restype = ct.POINTER(COREDirectedConnection_p)
 
+coreir_lib.COREDirectedModuleGetConnections.argtypes = [COREDirectedModule_p, ct.POINTER(ct.c_int)]
+coreir_lib.COREDirectedModuleGetConnections.restype = ct.POINTER(COREDirectedConnection_p)
+
 coreir_lib.COREDirectedConnectionGetSrc.argtypes = [COREDirectedConnection_p, ct.POINTER(ct.c_int)]
 coreir_lib.COREDirectedConnectionGetSrc.restype = ct.POINTER(ct.c_char_p)
 

--- a/bindings/python/coreir/__init__.py
+++ b/bindings/python/coreir/__init__.py
@@ -487,10 +487,10 @@ class DirectedConnection(CoreIRType):
 
 class DirectedModule(CoreIRType):
     def sel(self, path):
-        arr = ct.POINTER(ct.c_char_p()) * len(path);
+        arr = (ct.c_char_p * len(path))();
         for i, item in enumerate(path):
             arr[i] = item.encode()
-        return Wireable(coreir_lib.COREDirectedModuleSel(arr, len(path)), self.context)
+        return Wireable(coreir_lib.COREDirectedModuleSel(self.ptr, arr, len(path)), self.context)
 
     def get_connections(self):
         num_connections = ct.c_int()

--- a/bindings/python/coreir/__init__.py
+++ b/bindings/python/coreir/__init__.py
@@ -143,8 +143,8 @@ coreir_lib.COREModuleDefGetInterface.restype = COREInterface_p
 coreir_lib.COREModuleDefGetInstances.argtypes = [COREModuleDef_p, ct.POINTER(ct.c_int)]
 coreir_lib.COREModuleDefGetInstances.restype = ct.POINTER(COREInstance_p)
 
-coreir_lib.COREModuleNewDirectedView.argtypes = [COREModule_p]
-coreir_lib.COREModuleNewDirectedView.restype = COREDirectedModule_p
+coreir_lib.COREModuleNewDirectedModule.argtypes = [COREModule_p]
+coreir_lib.COREModuleNewDirectedModule.restype = COREDirectedModule_p
 
 coreir_lib.COREGetInstRefName.argtypes = [COREInstance_p]
 coreir_lib.COREGetInstRefName.restype = ct.c_char_p
@@ -329,8 +329,8 @@ class Module(CoreIRType):
     def new_definition(self):
         return ModuleDef(coreir_lib.COREModuleNewDef(self.ptr),self.context)
 
-    def new_directed_view(self):
-        return DirectedModule(coreir_lib.COREModuleNewDirectedView(self.ptr), self.context)
+    def new_directed_module(self):
+        return DirectedModule(coreir_lib.COREModuleNewDirectedModule(self.ptr), self.context)
 
     def get_definition(self):
         return ModuleDef(coreir_lib.COREModuleGetDef(self.ptr),self.context)

--- a/bindings/python/coreir/__init__.py
+++ b/bindings/python/coreir/__init__.py
@@ -451,19 +451,19 @@ COREDirectedModule_p = ct.POINTER(COREModule)
 coreir_lib.COREDirectedModuleSel.argtypes = [COREDirectedModule_p, ct.POINTER(ct.c_char_p), ct.c_int]
 coreir_lib.COREDirectedModuleSel.restype = COREWireable_p
 
-coreir_lib.COREDirectedModuleGetInstances.argtypes = [COREDirectedModule_p, ct.byref(ct.c_int)]
+coreir_lib.COREDirectedModuleGetInstances.argtypes = [COREDirectedModule_p, ct.POINTER(ct.c_int)]
 coreir_lib.COREDirectedModuleGetInstances.restype = ct.POINTER(COREDirectedConnection_p)
 
-coreir_lib.COREDirectedModuleGetInputs.argtypes = [COREDirectedModule_p, ct.byref(ct.c_int)]
+coreir_lib.COREDirectedModuleGetInputs.argtypes = [COREDirectedModule_p, ct.POINTER(ct.c_int)]
 coreir_lib.COREDirectedModuleGetInputs.restype = ct.POINTER(COREDirectedConnection_p)
 
-coreir_lib.COREDirectedModuleGetOutputs.argtypes = [COREDirectedModule_p, ct.byref(ct.c_int)]
+coreir_lib.COREDirectedModuleGetOutputs.argtypes = [COREDirectedModule_p, ct.POINTER(ct.c_int)]
 coreir_lib.COREDirectedModuleGetOutputs.restype = ct.POINTER(COREDirectedConnection_p)
 
-coreir_lib.COREDirectedConnectionGetSrc.argtypes = [COREDirectedConnection_p, ct.byref(ct.c_int)]
+coreir_lib.COREDirectedConnectionGetSrc.argtypes = [COREDirectedConnection_p, ct.POINTER(ct.c_int)]
 coreir_lib.COREDirectedConnectionGetSrc.restype = ct.POINTER(ct.c_char_p)
 
-coreir_lib.COREDirectedConnectionGetSnk.argtypes = [COREDirectedConnection_p, ct.byref(ct.c_int)]
+coreir_lib.COREDirectedConnectionGetSnk.argtypes = [COREDirectedConnection_p, ct.POINTER(ct.c_int)]
 coreir_lib.COREDirectedConnectionGetSnk.restype = ct.POINTER(ct.c_char_p)
 
 

--- a/bindings/python/coreir/__init__.py
+++ b/bindings/python/coreir/__init__.py
@@ -72,6 +72,16 @@ class COREConnection(ct.Structure):
 
 COREConnection_p = ct.POINTER(COREConnection)
 
+class COREDirectedConnection(ct.Structure):
+    pass
+
+COREDirectedConnection_p = ct.POINTER(COREDirectedConnection)
+
+class COREDirectedModule(ct.Structure):
+    pass
+
+COREDirectedModule_p = ct.POINTER(COREDirectedModule)
+
 COREMapKind = ct.c_int
 COREMapKind_STR2TYPE_ORDEREDMAP = COREMapKind(0)
 COREMapKind_STR2PARAM_MAP = COREMapKind(1)
@@ -132,6 +142,9 @@ coreir_lib.COREModuleDefGetInterface.restype = COREInterface_p
 
 coreir_lib.COREModuleDefGetInstances.argtypes = [COREModuleDef_p, ct.POINTER(ct.c_int)]
 coreir_lib.COREModuleDefGetInstances.restype = ct.POINTER(COREInstance_p)
+
+coreir_lib.COREModuleNewDirectedView.argtypes = [COREModule_p]
+coreir_lib.COREModuleNewDirectedView.restype = COREDirectedModule_p
 
 coreir_lib.COREGetInstRefName.argtypes = [COREInstance_p]
 coreir_lib.COREGetInstRefName.restype = ct.c_char_p
@@ -316,6 +329,9 @@ class Module(CoreIRType):
     def new_definition(self):
         return ModuleDef(coreir_lib.COREModuleNewDef(self.ptr),self.context)
 
+    def new_directed_view(self):
+        return DirectedModule(coreir_lib.COREModuleNewDirectedView(self.ptr), self.context)
+
     def get_definition(self):
         return ModuleDef(coreir_lib.COREModuleGetDef(self.ptr),self.context)
 
@@ -437,17 +453,6 @@ class Context:
     def __del__(self):
         coreir_lib.COREDeleteContext(self.context)
 
-
-class COREDirectedConnection(ct.Structure):
-    pass
-
-COREDirectedConnection_p = ct.POINTER(COREDirectedConnection)
-
-class COREDirectedModule(ct.Structure):
-    pass
-
-COREDirectedModule_p = ct.POINTER(COREModule)
-
 coreir_lib.COREDirectedModuleSel.argtypes = [COREDirectedModule_p, ct.POINTER(ct.c_char_p), ct.c_int]
 coreir_lib.COREDirectedModuleSel.restype = COREWireable_p
 
@@ -468,11 +473,13 @@ coreir_lib.COREDirectedConnectionGetSnk.restype = ct.POINTER(ct.c_char_p)
 
 
 class DirectedConnection(CoreIRType):
+    @property
     def source(self):
         size = ct.c_int()
         result = coreir_lib.COREDirectedConnectionGetSrc(self.ptr, ct.byref(size))
         return [result[i].decode() for i in range(size.value)]
 
+    @property
     def sink(self):
         size = ct.c_int()
         result = coreir_lib.COREDirectedConnectionGetSnk(self.ptr, ct.byref(size))
@@ -483,19 +490,19 @@ class DirectedModule(CoreIRType):
         arr = ct.POINTER(ct.c_char_p()) * len(path);
         for i, item in enumerate(path):
             arr[i] = item.encode()
-        return Wireable(coreir_lib.COREDirectedModuleSel(arr, len(path)))
+        return Wireable(coreir_lib.COREDirectedModuleSel(arr, len(path)), self.context)
 
     def get_connections(self):
         num_connections = ct.c_int()
         result = coreir_lib.COREDirectedModuleGetConnections(self.ptr, ct.byref(num_connections))
-        return [DirectedConnection(result[i]) for i in range(num_connections.value)]
+        return [DirectedConnection(result[i], self.context) for i in range(num_connections.value)]
 
     def get_inputs(self):
         num_connections = ct.c_int()
         result = coreir_lib.COREDirectedModuleGetInputs(self.ptr, ct.byref(num_connections))
-        return [DirectedConnection(result[i]) for i in range(num_connections.value)]
+        return [DirectedConnection(result[i], self.context) for i in range(num_connections.value)]
 
     def get_outputs(self):
         num_connections = ct.c_int()
         result = coreir_lib.COREDirectedModuleGetOutputs(self.ptr, ct.byref(num_connections))
-        return [DirectedConnection(result[i]) for i in range(num_connections.value)]
+        return [DirectedConnection(result[i], self.context) for i in range(num_connections.value)]

--- a/bindings/python/test/test_coreir.py
+++ b/bindings/python/test/test_coreir.py
@@ -196,8 +196,23 @@ def test_directed_module():
     module_def.wire(add8_inst3.select("out"), interface.select("output"))
     module.add_definition(module_def)
     directed_module = module.new_directed_view()
+
+    # check inputs
+    expected = [["adder1", "in1"], ["adder1", "in2"], ["adder2", "in1"], ["adder2", "in2"]]
     for input in directed_module.get_inputs():
-        print(input.source)
+        assert input.source == ["self", "input"]
+        assert input.sink in expected, "Unexpected sink {}".format(input.sink)
+        expected.remove(input.sink)
+    assert len(expected) == 0, "Did not find {}".format(expected)
+
+    # check outputs
+    expected = [["adder3", "out"]]
+    for output in directed_module.get_outputs():
+        assert output.sink == ["self", "output"]
+        assert output.source in expected, "Unexpected source {}".format(input.sink)
+        expected.remove(output.source)
+    assert len(expected) == 0, "Did not find {}".format(expected)
+
 
 if __name__ == "__main__":
     test_directed_module()

--- a/bindings/python/test/test_coreir.py
+++ b/bindings/python/test/test_coreir.py
@@ -215,6 +215,21 @@ def test_directed_module():
 
     assert get_pointer_addr(directed_module.sel(["adder3", "out"]).ptr) == get_pointer_addr(add8_inst3.select("out").ptr)
 
+    expected = [
+        (['adder3', 'out'], ['self', 'output']),
+        (['adder2', 'out'], ['adder3', 'in2']),
+        (['adder1', 'out'], ['adder3', 'in1']),
+        (['self', 'input'], ['adder1', 'in1']),
+        (['self', 'input'], ['adder2', 'in1']),
+        (['self', 'input'], ['adder1', 'in2']),
+        (['self', 'input'], ['adder2', 'in2'])
+    ]
+    for directed_connection in directed_module.get_connections():
+        actual = (directed_connection.source, directed_connection.sink)
+        assert actual in expected
+        expected.remove(actual)
+    assert len(expected) == 0
+
 
 if __name__ == "__main__":
     test_directed_module()

--- a/bindings/python/test/test_coreir.py
+++ b/bindings/python/test/test_coreir.py
@@ -213,6 +213,8 @@ def test_directed_module():
         expected.remove(output.source)
     assert len(expected) == 0, "Did not find {}".format(expected)
 
+    assert get_pointer_addr(directed_module.sel(["adder3", "out"]).ptr) == get_pointer_addr(add8_inst3.select("out").ptr)
+
 
 if __name__ == "__main__":
     test_directed_module()

--- a/bindings/python/test/test_coreir.py
+++ b/bindings/python/test/test_coreir.py
@@ -1,11 +1,5 @@
 import coreir
-import ctypes as ct
-
-def get_pointer_addr(ptr):
-    return ct.cast(ptr, ct.c_void_p).value
-
-def assert_pointers_equal(ptr1, ptr2):
-    assert get_pointer_addr(ptr1) == get_pointer_addr(ptr2)
+from test_utils import get_pointer_addr, assert_pointers_equal
 
 
 def test_load_library():
@@ -170,69 +164,6 @@ def test_module_def_get_connections():
         seen.append(pair)
     assert len(seen) == len(expected_conns)
 
-def test_directed_module():
-    c = coreir.Context()
-    module_typ = c.Record({"input": c.Array(8, c.BitIn()), "output": c.Array(9, c.Bit())})
-    module = c.G.new_module("multiply_by_4", module_typ)
-    # module.print()
-    module_def = module.new_definition()
-    add8 = c.G.new_module("add8",
-        c.Record({
-            "in1": c.Array(8, c.BitIn()),
-            "in2": c.Array(8, c.BitIn()),
-            "out": c.Array(9, c.Bit())
-        })
-    )
-    add8_inst1 = module_def.add_module_instance("adder1", add8)
-    add8_inst2 = module_def.add_module_instance("adder2", add8)
-    add8_inst3 = module_def.add_module_instance("adder3", add8)
-    interface = module_def.get_interface()
-    _input = interface.select("input")
-    for adder in [add8_inst1, add8_inst2]:
-        module_def.wire(_input, adder.select("in1"))
-        module_def.wire(_input, adder.select("in2"))
-    module_def.wire(add8_inst1.select("out"), add8_inst3.select("in1"))
-    module_def.wire(add8_inst2.select("out"), add8_inst3.select("in2"))
-    module_def.wire(add8_inst3.select("out"), interface.select("output"))
-    module.add_definition(module_def)
-    directed_module = module.new_directed_view()
-
-    # check inputs
-    expected = [["adder1", "in1"], ["adder1", "in2"], ["adder2", "in1"], ["adder2", "in2"]]
-    for input in directed_module.get_inputs():
-        assert input.source == ["self", "input"]
-        assert input.sink in expected, "Unexpected sink {}".format(input.sink)
-        expected.remove(input.sink)
-    assert len(expected) == 0, "Did not find {}".format(expected)
-
-    # check outputs
-    expected = [["adder3", "out"]]
-    for output in directed_module.get_outputs():
-        assert output.sink == ["self", "output"]
-        assert output.source in expected, "Unexpected source {}".format(input.sink)
-        expected.remove(output.source)
-    assert len(expected) == 0, "Did not find {}".format(expected)
-
-    assert get_pointer_addr(directed_module.sel(["adder3", "out"]).ptr) == get_pointer_addr(add8_inst3.select("out").ptr)
-
-    expected = [
-        (['adder3', 'out'], ['self', 'output']),
-        (['adder2', 'out'], ['adder3', 'in2']),
-        (['adder1', 'out'], ['adder3', 'in1']),
-        (['self', 'input'], ['adder1', 'in1']),
-        (['self', 'input'], ['adder2', 'in1']),
-        (['self', 'input'], ['adder1', 'in2']),
-        (['self', 'input'], ['adder2', 'in2'])
-    ]
-    for directed_connection in directed_module.get_connections():
-        actual = (directed_connection.source, directed_connection.sink)
-        assert actual in expected
-        expected.remove(actual)
-    assert len(expected) == 0
-
-
-if __name__ == "__main__":
-    test_directed_module()
 # def test():
 #     c = coreir.Context()
 #     # any = c.Any()

--- a/bindings/python/test/test_directedview.py
+++ b/bindings/python/test/test_directedview.py
@@ -1,0 +1,68 @@
+import coreir
+import ctypes as ct
+from test_utils import get_pointer_addr
+
+
+def test_directed_module():
+    c = coreir.Context()
+    module_typ = c.Record({"input": c.Array(8, c.BitIn()), "output": c.Array(9, c.Bit())})
+    module = c.G.new_module("multiply_by_4", module_typ)
+    # module.print()
+    module_def = module.new_definition()
+    add8 = c.G.new_module("add8",
+        c.Record({
+            "in1": c.Array(8, c.BitIn()),
+            "in2": c.Array(8, c.BitIn()),
+            "out": c.Array(9, c.Bit())
+        })
+    )
+    add8_inst1 = module_def.add_module_instance("adder1", add8)
+    add8_inst2 = module_def.add_module_instance("adder2", add8)
+    add8_inst3 = module_def.add_module_instance("adder3", add8)
+    interface = module_def.get_interface()
+    _input = interface.select("input")
+    for adder in [add8_inst1, add8_inst2]:
+        module_def.wire(_input, adder.select("in1"))
+        module_def.wire(_input, adder.select("in2"))
+    module_def.wire(add8_inst1.select("out"), add8_inst3.select("in1"))
+    module_def.wire(add8_inst2.select("out"), add8_inst3.select("in2"))
+    module_def.wire(add8_inst3.select("out"), interface.select("output"))
+    module.add_definition(module_def)
+    directed_module = module.new_directed_view()
+
+    # check inputs
+    expected = [["adder1", "in1"], ["adder1", "in2"], ["adder2", "in1"], ["adder2", "in2"]]
+    for input in directed_module.get_inputs():
+        assert input.source == ["self", "input"]
+        assert input.sink in expected, "Unexpected sink {}".format(input.sink)
+        expected.remove(input.sink)
+    assert len(expected) == 0, "Did not find {}".format(expected)
+
+    # check outputs
+    expected = [["adder3", "out"]]
+    for output in directed_module.get_outputs():
+        assert output.sink == ["self", "output"]
+        assert output.source in expected, "Unexpected source {}".format(input.sink)
+        expected.remove(output.source)
+    assert len(expected) == 0, "Did not find {}".format(expected)
+
+    assert get_pointer_addr(directed_module.sel(["adder3", "out"]).ptr) == get_pointer_addr(add8_inst3.select("out").ptr)
+
+    expected = [
+        (['adder3', 'out'], ['self', 'output']),
+        (['adder2', 'out'], ['adder3', 'in2']),
+        (['adder1', 'out'], ['adder3', 'in1']),
+        (['self', 'input'], ['adder1', 'in1']),
+        (['self', 'input'], ['adder2', 'in1']),
+        (['self', 'input'], ['adder1', 'in2']),
+        (['self', 'input'], ['adder2', 'in2'])
+    ]
+    for directed_connection in directed_module.get_connections():
+        actual = (directed_connection.source, directed_connection.sink)
+        assert actual in expected
+        expected.remove(actual)
+    assert len(expected) == 0
+
+
+if __name__ == "__main__":
+    test_directed_module()

--- a/bindings/python/test/test_directedview.py
+++ b/bindings/python/test/test_directedview.py
@@ -28,7 +28,7 @@ def test_directed_module():
     module_def.wire(add8_inst2.select("out"), add8_inst3.select("in2"))
     module_def.wire(add8_inst3.select("out"), interface.select("output"))
     module.add_definition(module_def)
-    directed_module = module.new_directed_view()
+    directed_module = module.new_directed_module()
 
     # check inputs
     expected = [["adder1", "in1"], ["adder1", "in2"], ["adder2", "in1"], ["adder2", "in2"]]

--- a/bindings/python/test/test_utils.py
+++ b/bindings/python/test/test_utils.py
@@ -1,0 +1,7 @@
+import ctypes as ct
+
+def get_pointer_addr(ptr):
+    return ct.cast(ptr, ct.c_void_p).value
+
+def assert_pointers_equal(ptr1, ptr2):
+    assert get_pointer_addr(ptr1) == get_pointer_addr(ptr2)

--- a/include/coreir-c/coreir.h
+++ b/include/coreir-c/coreir.h
@@ -75,5 +75,16 @@ extern const char** COREWireableGetAncestors(COREWireable* w, int* num_ancestors
 extern void COREPrintErrors(COREContext* c);
 extern const char* CORENamespaceGetName(CORENamespace* n);
 
+// BEGIN : directedview
+extern CORESelectPath COREDirectedConnectionGetSrc(COREDirectedConnection* directed_connection);
+extern CORESelectPath COREDirectedConnectionGetSnk(COREDirectedConnection* directed_connection);
+
+extern COREDirectedModule* CORENewDirectedModule(COREModule* m);
+extern COREWireable* COREDirectedModuleSel(COREDirectedModule* directed_module, CORESelectPath path);
+extern COREDirectedConnection** COREDirectedModuleGetConnections(COREDirectedModule* directed_module);
+extern COREDirectedInstance** COREDirectedModuleGetInstances(COREDirectedModule* directed_module);
+extern COREDirectedConnection** COREDirectedModuleGetInputs(COREDirectedModule* directed_module);
+extern COREDirectedConnection** COREDirectedModuleGetOutputs(COREDirectedModule* directed_module);
+// END   : directedview
 
 #endif //COREIR_C_H_

--- a/include/coreir-c/coreir.h
+++ b/include/coreir-c/coreir.h
@@ -49,6 +49,7 @@ extern void COREPrintModule(COREModule* m);
 extern COREModuleDef* COREModuleNewDef(COREModule* m);
 extern COREModuleDef* COREModuleGetDefs(COREModule* m);
 void COREModuleAddDef(COREModule* module, COREModuleDef* module_def);
+extern COREDirectedModule* COREModuleNewDirectedView(COREModule* module);
 
 //Errors:
 //  Invalid arg: instance name already exists

--- a/include/coreir-c/coreir.h
+++ b/include/coreir-c/coreir.h
@@ -76,15 +76,15 @@ extern void COREPrintErrors(COREContext* c);
 extern const char* CORENamespaceGetName(CORENamespace* n);
 
 // BEGIN : directedview
-extern CORESelectPath COREDirectedConnectionGetSrc(COREDirectedConnection* directed_connection);
-extern CORESelectPath COREDirectedConnectionGetSnk(COREDirectedConnection* directed_connection);
+extern const char** COREDirectedConnectionGetSrc(COREDirectedConnection* directed_connection);
+extern const char** COREDirectedConnectionGetSnk(COREDirectedConnection* directed_connection);
 
 extern COREDirectedModule* CORENewDirectedModule(COREModule* m);
-extern COREWireable* COREDirectedModuleSel(COREDirectedModule* directed_module, CORESelectPath path);
-extern COREDirectedConnection** COREDirectedModuleGetConnections(COREDirectedModule* directed_module);
-extern COREDirectedInstance** COREDirectedModuleGetInstances(COREDirectedModule* directed_module);
-extern COREDirectedConnection** COREDirectedModuleGetInputs(COREDirectedModule* directed_module);
-extern COREDirectedConnection** COREDirectedModuleGetOutputs(COREDirectedModule* directed_module);
+extern COREWireable* COREDirectedModuleSel(COREDirectedModule* directed_module, const char** path);
+extern COREDirectedConnection** COREDirectedModuleGetConnections(COREDirectedModule* directed_module, int* num_connections);
+extern COREDirectedInstance** COREDirectedModuleGetInstances(COREDirectedModule* directed_module, int* num_instances);
+extern COREDirectedConnection** COREDirectedModuleGetInputs(COREDirectedModule* directed_module, int* num_connections);
+extern COREDirectedConnection** COREDirectedModuleGetOutputs(COREDirectedModule* directed_module, int* num_connections);
 // END   : directedview
 
 #endif //COREIR_C_H_

--- a/include/coreir-c/coreir.h
+++ b/include/coreir-c/coreir.h
@@ -49,7 +49,7 @@ extern void COREPrintModule(COREModule* m);
 extern COREModuleDef* COREModuleNewDef(COREModule* m);
 extern COREModuleDef* COREModuleGetDefs(COREModule* m);
 void COREModuleAddDef(COREModule* module, COREModuleDef* module_def);
-extern COREDirectedModule* COREModuleNewDirectedView(COREModule* module);
+extern COREDirectedModule* COREModuleNewDirectedModule(COREModule* module);
 
 //Errors:
 //  Invalid arg: instance name already exists

--- a/include/coreir-c/ctypes.h
+++ b/include/coreir-c/ctypes.h
@@ -15,9 +15,13 @@ typedef struct COREWireable COREWireable;
 typedef struct COREInstance COREInstance;
 typedef struct COREInterface COREInterface;
 typedef struct CORESelect CORESelect;
+typedef struct CORESelectPath CORESelectPath;
 typedef struct COREConnection COREConnection;
 typedef struct COREWirePath COREWirePath;
 typedef struct COREArg COREArg;
+typedef struct COREDirectedConnection COREDirectedConnection;
+typedef struct COREDirectedModule COREDirectedModule;
+typedef struct COREDirectedInstance COREDirectedInstance;
 
 typedef enum {
     STR2TYPE_ORDEREDMAP = 0,

--- a/include/coreir-c/ctypes.h
+++ b/include/coreir-c/ctypes.h
@@ -15,7 +15,6 @@ typedef struct COREWireable COREWireable;
 typedef struct COREInstance COREInstance;
 typedef struct COREInterface COREInterface;
 typedef struct CORESelect CORESelect;
-typedef struct CORESelectPath CORESelectPath;
 typedef struct COREConnection COREConnection;
 typedef struct COREWirePath COREWirePath;
 typedef struct COREArg COREArg;

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -18,10 +18,14 @@ Context::~Context() {
   for (auto it : paramsList) delete it;
   for (auto it : libs) delete it.second;
   for (auto it : instanceArrays) free(it);
-  for (auto it : connectionArrays) free(it);
   for (auto it : connectionPtrArrays) free(it);
+  for (auto it : connectionArrays) free(it);
   for (auto it : wireableArrays) free(it);
   for (auto it : constStringArrays) free(it);
+  for (auto it : directedConnectionPtrArrays) free(it);
+  for (auto it : directedConnectionArrays) free(it);
+  for (auto it : directedInstancePtrArrays) free(it);
+  for (auto it : directedInstanceArrays) free(it);
  
   delete cache;
 }
@@ -172,6 +176,30 @@ Wireable** Context::newWireableArray(int size) {
   Wireable** arr = (Wireable**) malloc(sizeof(Wireable*) * size);
   wireableArrays.push_back(arr);
   return arr;
+}
+
+DirectedConnection* Context::newDirectedConnectionArray(int size) {
+    DirectedConnection* arr = (DirectedConnection*) malloc(sizeof(DirectedConnection) * size);
+    directedConnectionArrays.push_back(arr);
+    return arr;
+}
+
+DirectedConnection** Context::newDirectedConnectionPtrArray(int size) {
+    DirectedConnection** arr = (DirectedConnection**) malloc(sizeof(DirectedConnection*) * size);
+    directedConnectionPtrArrays.push_back(arr);
+    return arr;
+}
+
+DirectedInstance* Context::newDirectedInstanceArray(int size) {
+    DirectedInstance* arr = (DirectedInstance*) malloc(sizeof(DirectedInstance) * size);
+    directedInstanceArrays.push_back(arr);
+    return arr;
+}
+
+DirectedInstance** Context::newDirectedInstancePtrArray(int size) {
+    DirectedInstance** arr = (DirectedInstance**) malloc(sizeof(DirectedInstance*) * size);
+    directedInstancePtrArrays.push_back(arr);
+    return arr;
 }
 
 Arg* Context::argInt(int i) { 

--- a/src/context.hpp
+++ b/src/context.hpp
@@ -7,6 +7,7 @@
 #include "error.hpp"
 #include "common.hpp"
 #include "casting/casting.hpp"
+#include "directedview.hpp"
 
 #include <string>
 #include <unordered_set>
@@ -39,6 +40,10 @@ class Context {
   vector<Connection**> connectionPtrArrays;
   vector<Wireable**> wireableArrays;
   vector<const char**> constStringArrays;
+  vector<DirectedConnection*> directedConnectionArrays;
+  vector<DirectedConnection**> directedConnectionPtrArrays;
+  vector<DirectedInstance*> directedInstanceArrays;
+  vector<DirectedInstance**> directedInstancePtrArrays;
 
   public :
     Context();
@@ -98,6 +103,11 @@ class Context {
     Connection** newConnectionPtrArray(int size);
     Wireable** newWireableArray(int size);
     const char** newConstStringArray(int size);
+    DirectedConnection* newDirectedConnectionArray(int size);
+    DirectedConnection** newDirectedConnectionPtrArray(int size);
+    DirectedInstance* newDirectedInstanceArray(int size);
+    DirectedInstance** newDirectedInstancePtrArray(int size);
+
 
 };
 

--- a/src/directedview.cpp
+++ b/src/directedview.cpp
@@ -16,21 +16,23 @@ DirectedConnection::DirectedConnection(Connection& c) : c(c) {
   assert(!tb->isUnknown() && !tb->isMixed());
   if (ta->isInput()) {
     assert(tb->isOutput());
-    src = wb->getSelectPath();
-    snk = wa->getSelectPath();
+    src = wb;
+    snk = wa;
   }
   else {
     assert(ta->isOutput() && tb->isInput());
-    src = wa->getSelectPath();
-    snk = wb->getSelectPath();
+    src = wa;
+    snk = wb;
   }
 }
 
 Context* DirectedConnection::getContext() {
     // assumes the parent connection has wireables with the same context
-    assert(c.first->getContext() == c.second->getContext());
+    assert(&c.first->getContext() == &c.second->getContext());
     return c.first->getContext();
 }
+SelectPath DirectedConnection::getSrc() { return src->getSelectPath();}
+SelectPath DirectedConnection::getSnk() { return snk->getSelectPath();}
 
 DirectedModule::DirectedModule(Module* m) : m(m) {
   assert(m->hasDef() && "Does not have def!");

--- a/src/directedview.cpp
+++ b/src/directedview.cpp
@@ -28,7 +28,7 @@ DirectedConnection::DirectedConnection(Connection& c) : c(c) {
 
 Context* DirectedConnection::getContext() {
     // assumes the parent connection has wireables with the same context
-    assert(&c.first->getContext() == &c.second->getContext());
+    assert(c.first->getContext() == c.second->getContext());
     return c.first->getContext();
 }
 SelectPath DirectedConnection::getSrc() { return src->getSelectPath();}

--- a/src/directedview.cpp
+++ b/src/directedview.cpp
@@ -44,6 +44,8 @@ DirectedModule::DirectedModule(Module* m) : m(m) {
   outputs = ins["self"];
 }
 
+Context* DirectedModule::getContext() { return m->getContext(); }
+
 Wireable* DirectedModule::sel(SelectPath path) {
   return m->getDef()->sel(path);
 }

--- a/src/directedview.cpp
+++ b/src/directedview.cpp
@@ -26,6 +26,12 @@ DirectedConnection::DirectedConnection(Connection& c) : c(c) {
   }
 }
 
+Context* DirectedConnection::getContext() {
+    // assumes the parent connection has wireables with the same context
+    assert(c.first->getContext() == c.second->getContext());
+    return c.first->getContext();
+}
+
 DirectedModule::DirectedModule(Module* m) : m(m) {
   assert(m->hasDef() && "Does not have def!");
   std::map<string,DirectedConnections> ins;

--- a/src/directedview.hpp
+++ b/src/directedview.hpp
@@ -15,12 +15,12 @@ typedef std::vector<DirectedInstance> DirectedInstances;
 class DirectedConnection {
   Connection c;
 
-  SelectPath src;
-  SelectPath snk;
+  Wireable* src;
+  Wireable* snk;
   public:
     DirectedConnection(Connection& c);
-    SelectPath getSrc() { return src;}
-    SelectPath getSnk() { return snk;}
+    SelectPath getSrc();
+    SelectPath getSnk();
     Context* getContext();
     Connection operator->() {return c;}
 };

--- a/src/directedview.hpp
+++ b/src/directedview.hpp
@@ -44,6 +44,7 @@ class DirectedModule {
     DirectedInstances getInstances() { return insts;}
     DirectedConnections getInputs() { return inputs;}
     DirectedConnections getOutputs() { return outputs;}
+    Context* getContext();
     Module* operator->() {return m;}
 };
 

--- a/src/directedview.hpp
+++ b/src/directedview.hpp
@@ -21,6 +21,7 @@ class DirectedConnection {
     DirectedConnection(Connection& c);
     SelectPath getSrc() { return src;}
     SelectPath getSnk() { return snk;}
+    Context* getContext();
     Connection operator->() {return c;}
 };
 

--- a/src/instantiable.cpp
+++ b/src/instantiable.cpp
@@ -88,15 +88,14 @@ string Generator::toString() const {
 }
 
 DirectedModule* Module::newDirectedModule() {
-    DirectedModule* directed_module = new DirectedModule(this);
-    directedModuleList.push_back(directed_module);
-    return directed_module;
+    directedModule = new DirectedModule(this);
+    return directedModule;
 }
 
 Module::~Module() {
   
   for (auto md : mdefList) delete md;
-  for (auto directedModule : directedModuleList) delete directedModule;
+  delete directedModule;
 }
 
 string Module::toString() const {
@@ -108,5 +107,11 @@ void Module::print(void) {
   if(def) def->print();
 
 }
+
+void Module::setDef(ModuleDef* def) {
+    delete this->directedModule;
+    this->directedModule = nullptr;
+    this->def = def;
+};
 
 }//CoreIR namespace

--- a/src/instantiable.cpp
+++ b/src/instantiable.cpp
@@ -87,9 +87,16 @@ string Generator::toString() const {
   return ret;
 }
 
+DirectedModule* Module::newDirectedView() {
+    DirectedModule* directed_module = new DirectedModule(this);
+    directedModuleList.push_back(directed_module);
+    return directed_module;
+}
+
 Module::~Module() {
   
   for (auto md : mdefList) delete md;
+  for (auto directedModule : directedModuleList) delete directedModule;
 }
 
 string Module::toString() const {

--- a/src/instantiable.cpp
+++ b/src/instantiable.cpp
@@ -87,7 +87,7 @@ string Generator::toString() const {
   return ret;
 }
 
-DirectedModule* Module::newDirectedView() {
+DirectedModule* Module::newDirectedModule() {
     DirectedModule* directed_module = new DirectedModule(this);
     directedModuleList.push_back(directed_module);
     return directed_module;

--- a/src/instantiable.hpp
+++ b/src/instantiable.hpp
@@ -88,15 +88,15 @@ class Module : public Instantiable {
   
   //Memory Management
   vector<ModuleDef*> mdefList;
-  vector<DirectedModule*> directedModuleList;
+  DirectedModule* directedModule;
 
   public :
-    Module(Namespace* ns,string name, Type* type,Params configparams) : Instantiable(IK_Module,ns,name,configparams), type(type), def(nullptr) {}
+    Module(Namespace* ns,string name, Type* type,Params configparams) : Instantiable(IK_Module,ns,name,configparams), type(type), def(nullptr), directedModule(nullptr) {}
     ~Module();
     static bool classof(const Instantiable* i) {return i->getKind()==IK_Module;}
     bool hasDef() const { return !!def; }
     ModuleDef* getDef() const { return def; } 
-    void setDef(ModuleDef* def) { this->def = def;}
+    void setDef(ModuleDef* def);
     ModuleDef* newModuleDef();
     DirectedModule* newDirectedModule();
     

--- a/src/instantiable.hpp
+++ b/src/instantiable.hpp
@@ -15,6 +15,7 @@
 #include "generatordef.hpp"
 
 #include "metadata.hpp"
+#include "directedview.hpp"
 
 using json = nlohmann::json;
 using namespace std;
@@ -87,6 +88,7 @@ class Module : public Instantiable {
   
   //Memory Management
   vector<ModuleDef*> mdefList;
+  vector<DirectedModule*> directedModuleList;
 
   public :
     Module(Namespace* ns,string name, Type* type,Params configparams) : Instantiable(IK_Module,ns,name,configparams), type(type), def(nullptr) {}
@@ -96,6 +98,7 @@ class Module : public Instantiable {
     ModuleDef* getDef() const { return def; } 
     void setDef(ModuleDef* def) { this->def = def;}
     ModuleDef* newModuleDef();
+    DirectedModule* newDirectedView();
     
     string toString() const;
     json toJson();

--- a/src/instantiable.hpp
+++ b/src/instantiable.hpp
@@ -98,7 +98,7 @@ class Module : public Instantiable {
     ModuleDef* getDef() const { return def; } 
     void setDef(ModuleDef* def) { this->def = def;}
     ModuleDef* newModuleDef();
-    DirectedModule* newDirectedView();
+    DirectedModule* newDirectedModule();
     
     string toString() const;
     json toJson();

--- a/src/lib/coreir-c/coreir-c.cpp
+++ b/src/lib/coreir-c/coreir-c.cpp
@@ -152,8 +152,8 @@ extern "C" {
     rcast<Module*>(module)->setDef(rcast<ModuleDef*>(module_def));
   }
 
-  COREDirectedModule* COREModuleNewDirectedView(COREModule* module) {
-      return rcast<COREDirectedModule*>(rcast<Module*>(module)->newDirectedView());
+  COREDirectedModule* COREModuleNewDirectedModule(COREModule* module) {
+      return rcast<COREDirectedModule*>(rcast<Module*>(module)->newDirectedModule());
   }
 
   void COREModuleDefWire(COREModuleDef* module_def, COREWireable* a, COREWireable* b) {
@@ -309,7 +309,7 @@ extern "C" {
   }
 
   COREDirectedModule* CORENewDirectedModule(COREModule* module) {
-      return rcast<COREDirectedModule*>(rcast<Module*>(module)->newDirectedView());
+      return rcast<COREDirectedModule*>(rcast<Module*>(module)->newDirectedModule());
   }
 
   COREWireable* COREDirectedModuleSel(COREDirectedModule* directed_module, const char** path, int path_len) {

--- a/src/lib/coreir-c/coreir-c.cpp
+++ b/src/lib/coreir-c/coreir-c.cpp
@@ -277,5 +277,73 @@ extern "C" {
   const char* CORENamespaceGetName(CORENamespace* n) {
     return rcast<Namespace*>(n)->getName().c_str();
   }
+
+  COREDirectedModule* CORENewDirectedModule(COREModule* module) {
+      return rcast<COREDirectedModule*>(rcast<Module*>(module)->newDirectedView());
+  }
+
+  COREWireable* COREDirectedModuleSel(COREDirectedModule* directed_module, CORESelectPath* path) {
+      return rcast<COREWireable*>(rcast<DirectedModule*>(directed_module)->sel(*rcast<SelectPath*>(path)));
+  }
+
+  COREDirectedConnection** COREDirectedModuleGetConnections(COREDirectedModule* directed_module) {
+      DirectedModule* module = rcast<DirectedModule*>(directed_module);
+      DirectedConnections directed_connections = module->getConnections();
+      int size = directed_connections.size();
+      DirectedConnection* arr = module->getContext()->newDirectedConnectionArray(size);
+      DirectedConnection** ptr_arr = module->getContext()->newDirectedConnectionPtrArray(size);
+      for (auto directed_connection : directed_connections) {
+          *arr = directed_connection;
+          *ptr_arr = arr;
+          arr++;
+          ptr_arr++;
+      }
+      return rcast<COREDirectedConnection**>(ptr_arr);
+  }
+  
+  COREDirectedInstance** COREDirectedModuleGetInstances(COREDirectedModule* directed_module) { 
+      DirectedModule* module = rcast<DirectedModule*>(directed_module);
+      DirectedInstances directed_instances = module->getInstances();
+      int size = directed_instances.size();
+      DirectedInstance* arr = module->getContext()->newDirectedInstanceArray(size);
+      DirectedInstance** ptr_arr = module->getContext()->newDirectedInstancePtrArray(size);
+      for (auto directed_instance : directed_instances) {
+          *arr = directed_instance;
+          *ptr_arr = arr;
+          arr++;
+          ptr_arr++;
+      }
+      return rcast<COREDirectedInstance**>(ptr_arr);
+  }
+
+  COREDirectedConnection** COREDirectedModuleGetInputs(COREDirectedModule* directed_module) {
+      DirectedModule* module = rcast<DirectedModule*>(directed_module);
+      DirectedConnections inputs = module->getInputs();
+      int size = inputs.size();
+      DirectedConnection* arr = module->getContext()->newDirectedConnectionArray(size);
+      DirectedConnection** ptr_arr = module->getContext()->newDirectedConnectionPtrArray(size);
+      for (auto input : inputs) {
+          *arr = input;
+          *ptr_arr = arr;
+          arr++;
+          ptr_arr++;
+      }
+      return rcast<COREDirectedConnection**>(ptr_arr);
+  }
+
+  COREDirectedConnection** COREDirectedModuleGetOutputs(COREDirectedModule* directed_module) {
+      DirectedModule* module = rcast<DirectedModule*>(directed_module);
+      DirectedConnections outputs = module->getOutputs();
+      DirectedConnection* arr = module->getContext()->newDirectedConnectionArray(outputs.size());
+      DirectedConnection** ptr_arr = module->getContext()->newDirectedConnectionPtrArray(outputs.size());
+      for (auto output : outputs) {
+          *arr = output;
+          *ptr_arr = arr;
+          arr++;
+          ptr_arr++;
+      }
+      return rcast<COREDirectedConnection**>(arr);
+  }
+
 }//extern "C"
 }//CoreIR namespace

--- a/src/lib/coreir-c/coreir-c.cpp
+++ b/src/lib/coreir-c/coreir-c.cpp
@@ -152,6 +152,10 @@ extern "C" {
     rcast<Module*>(module)->setDef(rcast<ModuleDef*>(module_def));
   }
 
+  COREDirectedModule* COREModuleNewDirectedView(COREModule* module) {
+      return rcast<COREDirectedModule*>(rcast<Module*>(module)->newDirectedView());
+  }
+
   void COREModuleDefWire(COREModuleDef* module_def, COREWireable* a, COREWireable* b) {
     rcast<ModuleDef*>(module_def)->wire(rcast<Wireable*>(a), rcast<Wireable*>(b));
   }
@@ -282,13 +286,13 @@ extern "C" {
       DirectedConnection* conn = rcast<DirectedConnection*>(directed_connection);
       SelectPath path = conn->getSrc();
       Context* c = conn->getContext();
-      int size = path.size();
-      *path_len = size;
-      const char** arr = c->newConstStringArray(size);
-      for (int i = 0; i < size; i ++) {
-          arr[i] = path[i].c_str();
-      }
-      return arr;
+      // int size = path.size();
+      // *path_len = size;
+      // const char** arr = c->newConstStringArray(size);
+      // for (int i = 0; i < size; i ++) {
+      //     arr[i] = path[i].c_str();
+      // }
+      // return arr;
   }
 
   const char** COREDirectedConnectionGetSnk(COREDirectedConnection* directed_connection, int* path_len) {
@@ -323,11 +327,11 @@ extern "C" {
       *num_connections = size;
       DirectedConnection* arr = module->getContext()->newDirectedConnectionArray(size);
       DirectedConnection** ptr_arr = module->getContext()->newDirectedConnectionPtrArray(size);
+      int i = 0;
       for (auto directed_connection : directed_connections) {
-          *arr = directed_connection;
-          *ptr_arr = arr;
-          arr++;
-          ptr_arr++;
+          arr[i] = directed_connection;
+          ptr_arr[i] = &arr[i];
+          i++;
       }
       return rcast<COREDirectedConnection**>(ptr_arr);
   }
@@ -339,11 +343,11 @@ extern "C" {
       *num_instances = size;
       DirectedInstance* arr = module->getContext()->newDirectedInstanceArray(size);
       DirectedInstance** ptr_arr = module->getContext()->newDirectedInstancePtrArray(size);
+      int i = 0;
       for (auto directed_instance : directed_instances) {
-          *arr = directed_instance;
-          *ptr_arr = arr;
-          arr++;
-          ptr_arr++;
+          arr[i] = directed_instance;
+          ptr_arr[i] = &arr[i];
+          i++;
       }
       return rcast<COREDirectedInstance**>(ptr_arr);
   }
@@ -355,11 +359,10 @@ extern "C" {
       *num_connections = size;
       DirectedConnection* arr = module->getContext()->newDirectedConnectionArray(size);
       DirectedConnection** ptr_arr = module->getContext()->newDirectedConnectionPtrArray(size);
+      int i = 0;
       for (auto input : inputs) {
-          *arr = input;
-          *ptr_arr = arr;
-          arr++;
-          ptr_arr++;
+          ptr_arr[i] = &input;
+          i++;
       }
       return rcast<COREDirectedConnection**>(ptr_arr);
   }
@@ -371,11 +374,11 @@ extern "C" {
       *num_connections = size;
       DirectedConnection* arr = module->getContext()->newDirectedConnectionArray(size);
       DirectedConnection** ptr_arr = module->getContext()->newDirectedConnectionPtrArray(size);
+      int i = 0;
       for (auto output : outputs) {
-          *arr = output;
-          *ptr_arr = arr;
-          arr++;
-          ptr_arr++;
+          arr[i] = output;
+          ptr_arr[i] = &arr[i];
+          i++;
       }
       return rcast<COREDirectedConnection**>(arr);
   }

--- a/src/lib/coreir-c/coreir-c.cpp
+++ b/src/lib/coreir-c/coreir-c.cpp
@@ -278,18 +278,49 @@ extern "C" {
     return rcast<Namespace*>(n)->getName().c_str();
   }
 
+  const char** COREDirectedConnectionGetSrc(COREDirectedConnection* directed_connection, int* path_len) {
+      DirectedConnection* conn = rcast<DirectedConnection*>(directed_connection);
+      SelectPath path = conn->getSrc();
+      Context* c = conn->getContext();
+      int size = path.size();
+      *path_len = size;
+      const char** arr = c->newConstStringArray(size);
+      for (int i = 0; i < size; i ++) {
+          arr[i] = path[i].c_str();
+      }
+      return arr;
+  }
+
+  const char** COREDirectedConnectionGetSnk(COREDirectedConnection* directed_connection, int* path_len) {
+      DirectedConnection* conn = rcast<DirectedConnection*>(directed_connection);
+      SelectPath path = conn->getSnk();
+      Context* c = conn->getContext();
+      int size = path.size();
+      *path_len = size;
+      const char** arr = c->newConstStringArray(size);
+      for (int i = 0; i < size; i ++) {
+          arr[i] = path[i].c_str();
+      }
+      return arr;
+  }
+
   COREDirectedModule* CORENewDirectedModule(COREModule* module) {
       return rcast<COREDirectedModule*>(rcast<Module*>(module)->newDirectedView());
   }
 
-  COREWireable* COREDirectedModuleSel(COREDirectedModule* directed_module, CORESelectPath* path) {
-      return rcast<COREWireable*>(rcast<DirectedModule*>(directed_module)->sel(*rcast<SelectPath*>(path)));
+  COREWireable* COREDirectedModuleSel(COREDirectedModule* directed_module, const char** path, int path_len) {
+      SelectPath select_path;
+      for (int i = 0; i < path_len; i++) {
+          select_path.push_back(std::string(path[i]));
+      }
+      return rcast<COREWireable*>(rcast<DirectedModule*>(directed_module)->sel(select_path));
   }
 
-  COREDirectedConnection** COREDirectedModuleGetConnections(COREDirectedModule* directed_module) {
+  COREDirectedConnection** COREDirectedModuleGetConnections(COREDirectedModule* directed_module, int* num_connections) {
       DirectedModule* module = rcast<DirectedModule*>(directed_module);
       DirectedConnections directed_connections = module->getConnections();
       int size = directed_connections.size();
+      *num_connections = size;
       DirectedConnection* arr = module->getContext()->newDirectedConnectionArray(size);
       DirectedConnection** ptr_arr = module->getContext()->newDirectedConnectionPtrArray(size);
       for (auto directed_connection : directed_connections) {
@@ -301,10 +332,11 @@ extern "C" {
       return rcast<COREDirectedConnection**>(ptr_arr);
   }
   
-  COREDirectedInstance** COREDirectedModuleGetInstances(COREDirectedModule* directed_module) { 
+  COREDirectedInstance** COREDirectedModuleGetInstances(COREDirectedModule* directed_module, int* num_instances) { 
       DirectedModule* module = rcast<DirectedModule*>(directed_module);
       DirectedInstances directed_instances = module->getInstances();
       int size = directed_instances.size();
+      *num_instances = size;
       DirectedInstance* arr = module->getContext()->newDirectedInstanceArray(size);
       DirectedInstance** ptr_arr = module->getContext()->newDirectedInstancePtrArray(size);
       for (auto directed_instance : directed_instances) {
@@ -316,10 +348,11 @@ extern "C" {
       return rcast<COREDirectedInstance**>(ptr_arr);
   }
 
-  COREDirectedConnection** COREDirectedModuleGetInputs(COREDirectedModule* directed_module) {
+  COREDirectedConnection** COREDirectedModuleGetInputs(COREDirectedModule* directed_module, int* num_connections) {
       DirectedModule* module = rcast<DirectedModule*>(directed_module);
       DirectedConnections inputs = module->getInputs();
       int size = inputs.size();
+      *num_connections = size;
       DirectedConnection* arr = module->getContext()->newDirectedConnectionArray(size);
       DirectedConnection** ptr_arr = module->getContext()->newDirectedConnectionPtrArray(size);
       for (auto input : inputs) {
@@ -331,11 +364,13 @@ extern "C" {
       return rcast<COREDirectedConnection**>(ptr_arr);
   }
 
-  COREDirectedConnection** COREDirectedModuleGetOutputs(COREDirectedModule* directed_module) {
+  COREDirectedConnection** COREDirectedModuleGetOutputs(COREDirectedModule* directed_module, int* num_connections) {
       DirectedModule* module = rcast<DirectedModule*>(directed_module);
       DirectedConnections outputs = module->getOutputs();
-      DirectedConnection* arr = module->getContext()->newDirectedConnectionArray(outputs.size());
-      DirectedConnection** ptr_arr = module->getContext()->newDirectedConnectionPtrArray(outputs.size());
+      int size = outputs.size();
+      *num_connections = size;
+      DirectedConnection* arr = module->getContext()->newDirectedConnectionArray(size);
+      DirectedConnection** ptr_arr = module->getContext()->newDirectedConnectionPtrArray(size);
       for (auto output : outputs) {
           *arr = output;
           *ptr_arr = arr;

--- a/src/lib/coreir-c/coreir-c.cpp
+++ b/src/lib/coreir-c/coreir-c.cpp
@@ -286,13 +286,13 @@ extern "C" {
       DirectedConnection* conn = rcast<DirectedConnection*>(directed_connection);
       SelectPath path = conn->getSrc();
       Context* c = conn->getContext();
-      // int size = path.size();
-      // *path_len = size;
-      // const char** arr = c->newConstStringArray(size);
-      // for (int i = 0; i < size; i ++) {
-      //     arr[i] = path[i].c_str();
-      // }
-      // return arr;
+      int size = path.size();
+      *path_len = size;
+      const char** arr = c->newConstStringArray(size);
+      for (int i = 0; i < size; i ++) {
+          arr[i] = path[i].c_str();
+      }
+      return arr;
   }
 
   const char** COREDirectedConnectionGetSnk(COREDirectedConnection* directed_connection, int* path_len) {
@@ -361,7 +361,8 @@ extern "C" {
       DirectedConnection** ptr_arr = module->getContext()->newDirectedConnectionPtrArray(size);
       int i = 0;
       for (auto input : inputs) {
-          ptr_arr[i] = &input;
+          arr[i] = input;
+          ptr_arr[i] = &arr[i];
           i++;
       }
       return rcast<COREDirectedConnection**>(ptr_arr);
@@ -380,7 +381,7 @@ extern "C" {
           ptr_arr[i] = &arr[i];
           i++;
       }
-      return rcast<COREDirectedConnection**>(arr);
+      return rcast<COREDirectedConnection**>(ptr_arr);
   }
 
 }//extern "C"

--- a/src/wireable.cpp
+++ b/src/wireable.cpp
@@ -29,7 +29,7 @@ Select* Wireable::sel(uint selStr) { return sel(to_string(selStr)); }
 // TODO This might be slow due to insert on a vector. Maybe use Deque?
 SelectPath Wireable::getSelectPath() {
   Wireable* top = this;
-  vector<string> path;
+  SelectPath path;
   while(auto s = dyn_cast<Select>(top)) {
     path.insert(path.begin(), s->getSelStr());
     top = s->getParent();


### PR DESCRIPTION
Introduces `DirectedConnection` and `DirectedModule` types in python.

`DirectedModule`s are created with `module.new_directed_view()`
Supported API functions
* `DirectedModule.sel(path)`
* `DirectedModule.get_inputs()`
* `DirectedModule.get_outputs()`
* `DirectedModule.get_connections()`

`DirectedConnection`s are returned by `get_connections`, `get_inputs`, and `get_outputs`
Support API functions:
* `DirectedConnection.source` (property method)
* `DirectedConnection.sink` (property method)