### PR TITLE
[python-api] Add support for ArrayType.getLen()

### DIFF
--- a/bindings/python/coreir/__init__.py
+++ b/bindings/python/coreir/__init__.py
@@ -157,3 +157,10 @@ libcoreir_c.COREDirectedInstanceGetInputs.restype = ct.POINTER(COREDirectedConne
 
 libcoreir_c.COREDirectedInstanceGetOutputs.argtypes = [COREDirectedInstance_p, ct.POINTER(ct.c_int)]
 libcoreir_c.COREDirectedInstanceGetOutputs.restype = ct.POINTER(COREDirectedConnection_p)
+
+libcoreir_c.COREArrayTypeGetLen.argtypes = [COREType_p]
+libcoreir_c.COREArrayTypeGetLen.restype = ct.c_uint
+
+libcoreir_c.COREGetTypeKind.argtypes = [COREType_p]
+libcoreir_c.COREGetTypeKind.restype = ct.c_int # CORETypeKind is an enum
+

--- a/bindings/python/coreir/type.py
+++ b/bindings/python/coreir/type.py
@@ -1,5 +1,6 @@
 import ctypes as ct
 from coreir.base import CoreIRType
+from coreir.lib import libcoreir_c
 
 class COREType(ct.Structure):
     pass
@@ -20,3 +21,17 @@ class Args(CoreIRType):
 class Type(CoreIRType):
     def print_(self):  # _ because print is a keyword in py2
         libcoreir_c.COREPrintType(self.ptr)
+
+    def __len__(self):
+        # TypeKind enum defined in src/types.hpp
+        kind = libcoreir_c.COREGetTypeKind(self.ptr)
+        if kind != 2:  # Not a TK_Array
+            type_name = {
+                0: "Bit",
+                1: "BitIn",
+                3: "Record",
+                4: "Named",
+                5: "Any"
+            }[kind]
+            raise Exception("`len` called on a non Array Type ({})".format(type_name))
+        return libcoreir_c.COREArrayTypeGetLen(self.ptr)

--- a/tests/bindings/python/test_types.py
+++ b/tests/bindings/python/test_types.py
@@ -1,0 +1,13 @@
+import coreir
+
+
+def test_array_len():
+    context = coreir.Context()
+    array_type = context.Array(8, context.BitIn())
+    assert len(array_type) == 8
+    bit_type = context.BitIn()
+    try:
+        len(bit_type)
+        assert False, "Calling len on a non array type should throw an exception"
+    except Exception as e:
+        assert str(e) == "`len` called on a non Array Type (BitIn)"


### PR DESCRIPTION
Python API now supports the following functionality
```python
>>> import coreir
>>> context = coreir.Context()
>>> array_type = context.Array(8, context.BitIn())
>>> len(array_type)
8
>>> bit_type = context.BitIn()
>>> len(bit_type)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "..../coreir/bindings/python/coreir/type.py", line 36, in __len__
    raise Exception("`len` called on a non Array Type ({})".format(type_name))
Exception: `len` called on a non Array Type (BitIn)
```

Partially addresses #71