### PR TITLE
[python-api] Add support for getting type of a wireable

### DIFF
--- a/bindings/python/coreir/__init__.py
+++ b/bindings/python/coreir/__init__.py
@@ -119,6 +119,9 @@ libcoreir_c.COREWireableSelect.restype = COREWireable_p
 libcoreir_c.COREWireableGetSelectPath.argtypes = [COREWireable_p, ct.POINTER(ct.c_int)]
 libcoreir_c.COREWireableGetSelectPath.restype = ct.POINTER(ct.c_char_p)
 
+libcoreir_c.COREWireableGetType.argtypes = [COREWireable_p]
+libcoreir_c.COREWireableGetType.restype = COREType_p
+
 libcoreir_c.COREModuleDefSelect.argtypes = [COREModuleDef_p, ct.c_char_p]
 libcoreir_c.COREModuleDefSelect.restype = COREWireable_p
 

--- a/bindings/python/coreir/type.py
+++ b/bindings/python/coreir/type.py
@@ -22,16 +22,20 @@ class Type(CoreIRType):
     def print_(self):  # _ because print is a keyword in py2
         libcoreir_c.COREPrintType(self.ptr)
 
-    def __len__(self):
+    @property
+    def kind(self):
         # TypeKind enum defined in src/types.hpp
         kind = libcoreir_c.COREGetTypeKind(self.ptr)
-        if kind != 2:  # Not a TK_Array
-            type_name = {
-                0: "Bit",
-                1: "BitIn",
-                3: "Record",
-                4: "Named",
-                5: "Any"
-            }[kind]
-            raise Exception("`len` called on a non Array Type ({})".format(type_name))
+        return {
+            0: "Bit",
+            1: "BitIn",
+            2: "Array",
+            3: "Record",
+            4: "Named",
+            5: "Any"
+        }[kind]
+
+    def __len__(self):
+        if self.kind != "Array":  # Not a TK_Array
+            raise Exception("`len` called on a {}".format(self.kind))
         return libcoreir_c.COREArrayTypeGetLen(self.ptr)

--- a/bindings/python/coreir/wireable.py
+++ b/bindings/python/coreir/wireable.py
@@ -1,6 +1,7 @@
 import ctypes as ct
 from coreir.base import CoreIRType
 from coreir.lib import libcoreir_c
+from coreir.type import Type
 import coreir.module
 
 class COREWireable(ct.Structure):
@@ -32,6 +33,10 @@ class Wireable(CoreIRType):
     @property
     def module(self):
         return self.module_def.module
+
+    @property
+    def type(self):
+        return Type(libcoreir_c.COREWireableGetType(self.ptr), self.context)
 
 
 class Select(Wireable):

--- a/include/coreir-c/coreir.h
+++ b/include/coreir-c/coreir.h
@@ -60,6 +60,7 @@ extern COREModule* COREModuleDefGetModule(COREModuleDef* m);
 extern const char** COREWireableGetSelectPath(COREWireable* w, int* num_selects);
 extern void COREPrintErrors(COREContext* c);
 extern const char* CORENamespaceGetName(CORENamespace* n);
+extern COREType* COREWireableGetType(COREWireable* wireable);
 
 // BEGIN : directedview
 extern const char** COREDirectedConnectionGetSrc(COREDirectedConnection* directed_connection);

--- a/src/lib/coreir-c/coreir-c.cpp
+++ b/src/lib/coreir-c/coreir-c.cpp
@@ -194,6 +194,10 @@ extern "C" {
     return rcast<COREWireable*>(rcast<Wireable*>(w)->sel(string(sel)));
   }
 
+  COREType* COREWireableGetType(COREWireable* wireable) {
+    return rcast<COREType*>(rcast<Wireable*>(wireable)->getType());
+  }
+
   COREWireable* COREModuleDefSelect(COREModuleDef* m, char* name) {
     return rcast<COREWireable*>(rcast<ModuleDef*>(m)->sel(string(name)));
   }

--- a/tests/bindings/python/test_types.py
+++ b/tests/bindings/python/test_types.py
@@ -10,4 +10,4 @@ def test_array_len():
         len(bit_type)
         assert False, "Calling len on a non array type should throw an exception"
     except Exception as e:
-        assert str(e) == "`len` called on a non Array Type (BitIn)"
+        assert str(e) == "`len` called on a BitIn"

--- a/tests/bindings/python/test_wireable.py
+++ b/tests/bindings/python/test_wireable.py
@@ -5,7 +5,6 @@ def test_get_type():
     c = coreir.Context()
     module_typ = c.Record({"input": c.Array(8, c.BitIn()), "output": c.Array(9, c.Bit())})
     module = c.G.new_module("multiply_by_2", module_typ)
-    # module.print()
     module_def = module.new_definition()
     wireable = module_def.interface
     assert wireable.type.kind == "Record"

--- a/tests/bindings/python/test_wireable.py
+++ b/tests/bindings/python/test_wireable.py
@@ -1,0 +1,11 @@
+import coreir
+
+
+def test_get_type():
+    c = coreir.Context()
+    module_typ = c.Record({"input": c.Array(8, c.BitIn()), "output": c.Array(9, c.Bit())})
+    module = c.G.new_module("multiply_by_2", module_typ)
+    # module.print()
+    module_def = module.new_definition()
+    wireable = module_def.interface
+    assert wireable.type.kind == "Record"


### PR DESCRIPTION
`wireable.type` returns a `Type` object

Example:
```python
>>> import coreir
>>> c = coreir.Context()
>>> module_typ = c.Record({"input": c.Array(8, c.BitIn()), "output": c.Array(9, c.Bit())})
>>> module = c.G.new_module("multiply_by_2", module_typ)
>>> module_def = module.new_definition()
>>> wireable = module_def.interface
>>> wireable.type
<coreir.type.Type object at 0x102fa4470>
>>> wireable.type.kind
'Record'
```