### PR TITLE
Python API minor refactor

### DIFF
--- a/bindings/python/coreir/wireable.py
+++ b/bindings/python/coreir/wireable.py
@@ -47,6 +47,7 @@ class Select(Wireable):
 
 
 class Instance(Wireable):
+    @property
     def module_name(self):
         name = libcoreir_c.COREGetInstRefName(self.ptr)
         return name.decode()

--- a/tests/bindings/python/test_coreir.py
+++ b/tests/bindings/python/test_coreir.py
@@ -23,7 +23,7 @@ def test_save_module():
         configparams
     )
     add8_inst = module_def.add_module_instance("adder", add8,c.newArgs({"init":5}))
-    print(add8_inst.module_name())
+    assert add8_inst.module_name == "add8"
     print(add8_inst.get_config_value("init"))
     add8_in1 = add8_inst.select("in1")
     add8_in2 = add8_inst.select("in2")


### PR DESCRIPTION
instance.module_name() -> instance.module_name (changed to property method)