### PR TITLE
[python-api] Implement Instance.generator_args

### DIFF
--- a/bindings/python/coreir/__init__.py
+++ b/bindings/python/coreir/__init__.py
@@ -169,3 +169,6 @@ libcoreir_c.COREGetTypeKind.restype = ct.c_int # CORETypeKind is an enum
 
 libcoreir_c.CORETypeGetSize.argtypes = [COREType_p]
 libcoreir_c.CORETypeGetSize.restype = ct.c_uint
+
+libcoreir_c.COREInstanceGetGenArgs.argtypes = [COREWireable_p, ct.POINTER(ct.POINTER(ct.c_char_p)), ct.POINTER(ct.POINTER(COREArg_p)), ct.POINTER(ct.c_int)]
+libcoreir_c.COREInstanceGetGenArgs.restype = None

--- a/bindings/python/coreir/type.py
+++ b/bindings/python/coreir/type.py
@@ -15,6 +15,17 @@ class COREArg(ct.Structure):
 
 COREArg_p = ct.POINTER(COREArg)
 
+class Arg(CoreIRType):
+    @property
+    def value(self):
+        type = libcoreir_c.COREGetArgKind(self.ptr)
+        # type enum values defined in include/coreir-c/coreir-args.h
+        if type == 0:
+            return libcoreir_c.COREArgIntGet(self.ptr)
+        elif type == 1:
+            return libcoreir_c.COREArgStringGet(self.ptr).decode()
+        raise NotImplementedError()
+
 class Args(CoreIRType):
     pass
 

--- a/include/coreir-c/coreir.h
+++ b/include/coreir-c/coreir.h
@@ -76,4 +76,6 @@ extern COREDirectedConnection** COREDirectedInstanceGetOutputs(COREDirectedInsta
 extern COREDirectedConnection** COREDirectedInstanceGetInputs(COREDirectedInstance* directed_instance, int* num_connections);
 // END   : directedview
 
+void COREInstanceGetGenArgs(COREWireable* core_instance, char*** names, COREArg** args, int* num_args);
+
 #endif //COREIR_C_H_

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -14,6 +14,7 @@ Context::~Context() {
   
   //for (auto it : genargsList) delete it;
   for (auto it : argList) delete it;
+  for (auto it : argPtrArrays) free(it);
   for (auto it : recordParamsList) delete it;
   for (auto it : paramsList) delete it;
   for (auto it : libs) delete it.second;
@@ -22,6 +23,8 @@ Context::~Context() {
   for (auto it : connectionArrays) free(it);
   for (auto it : wireableArrays) free(it);
   for (auto it : constStringArrays) free(it);
+  for (auto it : stringArrays) free(it);
+  for (auto it : stringBuffers) free(it);
   for (auto it : directedConnectionPtrArrays) free(it);
   for (auto it : directedInstancePtrArrays) free(it);
  
@@ -154,6 +157,12 @@ Args* Context::newArgs() {
   return args;
 }
 
+Arg** Context::newArgPtrArray(int size) {
+    Arg** arr = (Arg**) malloc(sizeof(Arg*) * size);
+    argPtrArrays.push_back(arr);
+    return arr;
+}
+
 Instance** Context::newInstanceArray(int size) {
   Instance** arr = (Instance**) malloc(sizeof(Instance*) * size);
   instanceArrays.push_back(arr);
@@ -175,6 +184,18 @@ Connection** Context::newConnectionPtrArray(int size) {
 const char** Context::newConstStringArray(int size) {
     const char** arr = (const char**) malloc(sizeof(const char*) * size);
     constStringArrays.push_back(arr);
+    return arr;
+}
+
+char** Context::newStringArray(int size) {
+    char** arr = (char**) malloc(sizeof(char*) * size);
+    stringArrays.push_back(arr);
+    return arr;
+}
+
+char* Context::newStringBuffer(int size) {
+    char* arr = (char*) malloc(sizeof(char) * size);
+    stringBuffers.push_back(arr);
     return arr;
 }
 

--- a/src/context.hpp
+++ b/src/context.hpp
@@ -34,6 +34,7 @@ class Context {
   
   vector<Arg*> argList;
   vector<Args*> argsList;
+  vector<Arg**> argPtrArrays;
   vector<RecordParams*> recordParamsList;
   vector<Params*> paramsList;
   vector<Instance**> instanceArrays;
@@ -41,6 +42,8 @@ class Context {
   vector<Connection**> connectionPtrArrays;
   vector<Wireable**> wireableArrays;
   vector<const char**> constStringArrays;
+  vector<char**> stringArrays;
+  vector<char*> stringBuffers;
   vector<DirectedConnection*> directedConnectionArrays;
   vector<DirectedConnection**> directedConnectionPtrArrays;
   vector<DirectedInstance**> directedInstancePtrArrays;
@@ -100,11 +103,14 @@ class Context {
     }
 
 
+    Arg** newArgPtrArray(int size);
     Instance** newInstanceArray(int size);
     Connection* newConnectionArray(int size);
     Connection** newConnectionPtrArray(int size);
     Wireable** newWireableArray(int size);
     const char** newConstStringArray(int size);
+    char** newStringArray(int size);
+    char* newStringBuffer(int size);
     DirectedConnection** newDirectedConnectionPtrArray(int size);
     DirectedInstance** newDirectedInstancePtrArray(int size);
 

--- a/src/lib/coreir-c/coreir-c.cpp
+++ b/src/lib/coreir-c/coreir-c.cpp
@@ -348,5 +348,23 @@ extern "C" {
       return rcast<COREDirectedConnection**>(ptr_arr);
   }
 
+  void COREInstanceGetGenArgs(COREWireable* core_instance, char*** names, COREArg*** args, int* num_args) {
+      Instance* instance = rcast<Instance*>(core_instance);
+      Args genArgs = instance->getGenargs();
+      int size = genArgs.size();
+      Context* context = instance->getContext();
+      *names = context->newStringArray(size);
+      *args  = (COREArg**) context->newArgPtrArray(size);
+      *num_args = size;
+      int count = 0;
+      for (std::pair<std::string, Arg*> element : genArgs) {
+          std::size_t name_length = element.first.size();
+          (*names)[count] = context->newStringBuffer(name_length + 1);
+          memcpy((*names)[count], element.first.c_str(), name_length + 1);
+          (*args)[count] = rcast<COREArg*>(element.second);
+          count++;
+      }
+  }
+
 }//extern "C"
 }//CoreIR namespace

--- a/tests/bindings/python/genargs.json
+++ b/tests/bindings/python/genargs.json
@@ -1,0 +1,200 @@
+{
+  "namespaces": {
+    "_G": {
+      "modules": {
+        "Top": {
+          "def": {
+            "connections": [
+              [
+                [
+                  "r4",
+                  "out"
+                ],
+                [
+                  "io1",
+                  "in"
+                ]
+              ],
+              [
+                [
+                  "r3",
+                  "out"
+                ],
+                [
+                  "r4",
+                  "in"
+                ]
+              ],
+              [
+                [
+                  "c0",
+                  "out"
+                ],
+                [
+                  "p0",
+                  "data",
+                  "in",
+                  "0"
+                ]
+              ],
+              [
+                [
+                  "p0",
+                  "data",
+                  "out"
+                ],
+                [
+                  "r1",
+                  "in"
+                ]
+              ],
+              [
+                [
+                  "r0",
+                  "out"
+                ],
+                [
+                  "p0",
+                  "data",
+                  "in",
+                  "1"
+                ]
+              ],
+              [
+                [
+                  "r2",
+                  "out"
+                ],
+                [
+                  "r3",
+                  "in"
+                ]
+              ],
+              [
+                [
+                  "r1",
+                  "out"
+                ],
+                [
+                  "r2",
+                  "in"
+                ]
+              ],
+              [
+                [
+                  "io0",
+                  "out"
+                ],
+                [
+                  "r0",
+                  "in"
+                ]
+              ]
+            ],
+            "instances": {
+              "c0": {
+                "configargs": {
+                  "value": 795
+                },
+                "genargs": {
+                  "width": 16
+                },
+                "generatorref": [
+                  "cgralib",
+                  "Const"
+                ]
+              },
+              "io0": {
+                "configargs": {
+                  "mode": "i"
+                },
+                "genargs": {
+                  "width": 16
+                },
+                "generatorref": [
+                  "cgralib",
+                  "IO"
+                ]
+              },
+              "io1": {
+                "configargs": {
+                  "mode": "o"
+                },
+                "genargs": {
+                  "width": 16
+                },
+                "generatorref": [
+                  "cgralib",
+                  "IO"
+                ]
+              },
+              "p0": {
+                "configargs": {
+                  "op": "add"
+                },
+                "genargs": {
+                  "numin": 2,
+                  "width": 16
+                },
+                "generatorref": [
+                  "cgralib",
+                  "PE"
+                ]
+              },
+              "r0": {
+                "genargs": {
+                  "width": 16
+                },
+                "generatorref": [
+                  "cgralib",
+                  "Reg"
+                ]
+              },
+              "r1": {
+                "genargs": {
+                  "width": 16
+                },
+                "generatorref": [
+                  "cgralib",
+                  "Reg"
+                ]
+              },
+              "r2": {
+                "genargs": {
+                  "width": 16
+                },
+                "generatorref": [
+                  "cgralib",
+                  "Reg"
+                ]
+              },
+              "r3": {
+                "genargs": {
+                  "width": 16
+                },
+                "generatorref": [
+                  "cgralib",
+                  "Reg"
+                ]
+              },
+              "r4": {
+                "genargs": {
+                  "width": 16
+                },
+                "generatorref": [
+                  "cgralib",
+                  "Reg"
+                ]
+              }
+            }
+          },
+          "type": "Any"
+        }
+      }
+    }
+  },
+  "top": [
+    "_G",
+    "Top"
+  ]
+}

--- a/tests/bindings/python/test_genargs.py
+++ b/tests/bindings/python/test_genargs.py
@@ -1,0 +1,20 @@
+import coreir
+import os
+
+
+def test_genargs():
+    context = coreir.Context()
+    cgra = context.load_library("cgralib")
+    mod = context.load_from_file(os.path.join(os.path.dirname(os.path.realpath(__file__)), "genargs.json"))
+    for instance in mod.definition.instances:
+        for name, arg in instance.generator_args.items():
+            if name == "width":
+                assert arg.value == 16
+            elif name == "numin":
+                assert arg.value == 2
+            else:
+                assert False, "Should not reach this statement"
+
+
+if __name__ == "__main__":
+    test_genargs()


### PR DESCRIPTION
So I managed to implement `Instance.generator_args` for @cdonovick 
It uses triple pointers to convert from a C++ `unordered_map` to a c array of strings (array of chars) and an array of Arg*. The Python API ingests these arrays as well as a number of key,value pairs and reconstructs the map in Python.
I'm entirely open to a cleaner interface/implementation for this, but it works and we're agile?

Also, should we think about bindings calling back to context to free up memory when objects are destructed? 