### PR TITLE
[python-bindings] refactor interface - Instance.get_config_value(key) -> Instance.config[key].value

### DIFF
--- a/bindings/python/coreir/wireable.py
+++ b/bindings/python/coreir/wireable.py
@@ -67,7 +67,7 @@ class InstanceConfigLazyDict:
 
 class Instance(Wireable):
     def __init__(self, ptr, context):
-        super().__init__(ptr, context)
+        super(Instance, self).__init__(ptr, context)
         self.config = InstanceConfigLazyDict(self)
 
     @property

--- a/bindings/python/coreir/wireable.py
+++ b/bindings/python/coreir/wireable.py
@@ -46,22 +46,34 @@ class Select(Wireable):
     #     return Wireable(libcoreir_c.CORESelectGetParent(self.ptr))
 
 
+class InstanceConfigLazyDict:
+    """
+    Lazy object that implements the ``instance.config[key]`` interface. Instead
+    of building the dictionary explicitly for every call to config, we wait for
+    the indexing function to be called and use the
+    ``libcoreir_c.COREGetConfigValue`` API
+    """
+    def __init__(self, parent_instance):
+        self.parent_instance = parent_instance
+
+    def __getitem__(self, key):
+        return Arg(libcoreir_c.COREGetConfigValue(self.parent_instance.ptr,
+                                                  str.encode(key)),
+                   self.parent_instance.context)
+
+    def __setitem__(self, key, value):
+        raise NotImplementedError()
+
+
 class Instance(Wireable):
+    def __init__(self, ptr, context):
+        super().__init__(ptr, context)
+        self.config = InstanceConfigLazyDict(self)
+
     @property
     def module_name(self):
         name = libcoreir_c.COREGetInstRefName(self.ptr)
         return name.decode()
-
-    def get_config_value(self, key):
-        arg = libcoreir_c.COREGetConfigValue(self.ptr,str.encode(key))
-        type = libcoreir_c.COREGetArgKind(arg)
-        # type enum values defined in include/coreir-c/coreir-args.h
-        if type == 0:
-            return libcoreir_c.COREArgIntGet(arg)
-        elif type == 1:
-            return libcoreir_c.COREArgStringGet(arg).decode()
-        
-        raise NotImplementedError
 
     @property
     def generator_args(self):

--- a/tests/bindings/python/test_coreir.py
+++ b/tests/bindings/python/test_coreir.py
@@ -24,7 +24,7 @@ def test_save_module():
     )
     add8_inst = module_def.add_module_instance("adder", add8,c.newArgs({"init":5}))
     assert add8_inst.module_name == "add8"
-    print(add8_inst.get_config_value("init"))
+    assert add8_inst.config["init"].value == 5
     add8_in1 = add8_inst.select("in1")
     add8_in2 = add8_inst.select("in2")
     add8_out = add8_inst.select("out")


### PR DESCRIPTION
Makes the interface more pythonic and consistent with `Instance.generator_args`.  Uses the same C-api logic so this is purely a cosmetic change in the Python bindings.

@cdonovick The interface changes from `add8_inst.get_config_value("init")` to `add8_inst.config["init"].value` (note that indexing `instance.config` returns an `Arg` object which is unpacked with the `.value`)

Closes #110 