### PR TITLE
Fix bad assert

### DIFF
--- a/bindings/python/coreir/context.py
+++ b/bindings/python/coreir/context.py
@@ -71,7 +71,7 @@ class Context:
           elif type(v) is str:
             args.append(libcoreir_c.COREArgString(self.context,ct.c_char_p(str.encode(v))))
           else:
-              raise NotImplementedError()
+            raise NotImplementedError()
 
         keys = (ct.c_char_p * len(fields))(*(str.encode(key) for key in fields.keys()))
         values = (COREArg_p * len(fields))(*(arg for arg in args))

--- a/bindings/python/coreir/context.py
+++ b/bindings/python/coreir/context.py
@@ -71,7 +71,7 @@ class Context:
           elif type(v) is str:
             args.append(libcoreir_c.COREArgString(self.context,ct.c_char_p(str.encode(v))))
           else:
-            assert(False,"NYI!")
+              raise NotImplementedError()
 
         keys = (ct.c_char_p * len(fields))(*(str.encode(key) for key in fields.keys()))
         values = (COREArg_p * len(fields))(*(arg for arg in args))


### PR DESCRIPTION
`assert(False,"NYI!")` always evaluate as `True` because  `bool((False,"NYI!"))==True`.
The statement you meant was
`assert False,"NYI!"`
However, why `assert False` when you can `raise NotImplementedError`?
