### PR TITLE
Add initial support for instantiable to python bindings

### DIFF
--- a/bindings/python/coreir/__init__.py
+++ b/bindings/python/coreir/__init__.py
@@ -6,6 +6,7 @@ from coreir.lib import load_shared_lib, libcoreir_c
 from coreir.context import COREContext, COREContext_p, Context, COREMapKind, COREMapKind_STR2ARG_MAP, COREMapKind_STR2PARAM_MAP, COREMapKind_STR2ARG_MAP
 from coreir.module import COREModule, COREModule_p, COREModuleDef, COREModuleDef_p, ModuleDef, Module, \
         COREDirectedInstance_p, COREDirectedConnection_p, COREDirectedModule_p
+from coreir.instantiable import COREInstantiable_p
 from coreir.namespace import CORENamespace, CORENamespace_p
 from coreir.type import COREType, COREType_p, CoreIRType, Params, Args, COREArg, COREArg_p, Type
 from coreir.wireable import COREWireable_p
@@ -178,3 +179,9 @@ libcoreir_c.CORETypeGetSize.restype = ct.c_uint
 
 libcoreir_c.COREInstanceGetGenArgs.argtypes = [COREWireable_p, ct.POINTER(ct.POINTER(ct.c_char_p)), ct.POINTER(ct.POINTER(COREArg_p)), ct.POINTER(ct.c_int)]
 libcoreir_c.COREInstanceGetGenArgs.restype = None
+
+libcoreir_c.CORENamespaceGetInstantiable.argtypes = [CORENamespace_p, ct.c_char_p]
+libcoreir_c.CORENamespaceGetInstantiable.restype = COREInstantiable_p
+
+libcoreir_c.COREInstantiableGetName.argtypes = [COREInstantiable_p]
+libcoreir_c.COREInstantiableGetName.restype = ct.c_char_p

--- a/bindings/python/coreir/instantiable.py
+++ b/bindings/python/coreir/instantiable.py
@@ -1,0 +1,15 @@
+import ctypes as ct
+from coreir.type import CoreIRType, Type, Params
+from coreir.module import Module
+from coreir.lib import libcoreir_c
+
+class COREInstantiable(ct.Structure):
+    pass
+
+COREInstantiable_p = ct.POINTER(COREInstantiable)
+
+
+class Instantiable(CoreIRType):
+    @property
+    def name(self):
+        return libcoreir_c.COREInstantiableGetName(self.ptr).decode()

--- a/bindings/python/coreir/namespace.py
+++ b/bindings/python/coreir/namespace.py
@@ -2,6 +2,8 @@ import ctypes as ct
 from coreir.type import CoreIRType, Type, Params
 from coreir.module import Module
 from coreir.lib import libcoreir_c
+from coreir.instantiable import Instantiable
+from coreir.util import LazyDict
 
 class CORENamespace(ct.Structure):
     pass
@@ -10,6 +12,10 @@ CORENamespace_p = ct.POINTER(CORENamespace)
 
 
 class Namespace(CoreIRType):
+    def __init__(self, ptr, context):
+        super(Namespace, self).__init__(ptr, context)
+        self.instantiables = LazyDict(self, Instantiable, libcoreir_c.CORENamespaceGetInstantiable)
+
     @property
     def name(self):
         return libcoreir_c.CORENamespaceGetName(self.ptr).decode()

--- a/bindings/python/coreir/util.py
+++ b/bindings/python/coreir/util.py
@@ -1,0 +1,19 @@
+class LazyDict:
+    """
+    Lazy object that implements the ``dict[key]`` interface. Instead
+    of building the dictionary explicitly for every call to config, we wait for
+    the indexing function to be called and then use the api function
+    """
+    def __init__(self, parent, return_type, api_function):
+        self.parent = parent
+        self.return_type = return_type
+        self.api_function = api_function
+
+    def __getitem__(self, key):
+        return self.return_type(
+                   self.api_function(self.parent.ptr,
+                                     str.encode(key)),
+                   self.parent.context)
+
+    def __setitem__(self, key, value):
+        raise NotImplementedError()

--- a/include/coreir-c/coreir.h
+++ b/include/coreir-c/coreir.h
@@ -31,6 +31,7 @@ extern const char* COREGetInstRefName(COREWireable* iref);
 //Errors:
 //  Invalid arg: Module name already exists
 extern COREModule* CORENewModule(CORENamespace* ns, char* name, COREType* type, void* configparams);
+extern COREInstantiable* CORENamespaceGetInstantiable(CORENamespace* _namespace, const char* name);
 
 extern void COREPrintModule(COREModule* m);
 extern COREModuleDef* COREModuleNewDef(COREModule* m);
@@ -79,5 +80,7 @@ extern COREDirectedConnection** COREDirectedInstanceGetInputs(COREDirectedInstan
 // END   : directedview
 
 void COREInstanceGetGenArgs(COREWireable* core_instance, char*** names, COREArg** args, int* num_args);
+
+extern const char* COREInstantiableGetName(COREInstantiable* instantiable);
 
 #endif //COREIR_C_H_

--- a/include/coreir-c/ctypes.h
+++ b/include/coreir-c/ctypes.h
@@ -13,6 +13,7 @@ typedef struct COREWireable COREWireable;
 typedef struct COREConnection COREConnection;
 typedef struct COREWirePath COREWirePath;
 typedef struct COREArg COREArg;
+typedef struct COREInstantiable COREInstantiable;
 
 typedef struct COREDirectedConnection COREDirectedConnection;
 typedef struct COREDirectedModule COREDirectedModule;

--- a/src/lib/coreir-c/coreir-c.cpp
+++ b/src/lib/coreir-c/coreir-c.cpp
@@ -222,6 +222,10 @@ extern "C" {
   const char* CORENamespaceGetName(CORENamespace* n) {
     return rcast<Namespace*>(n)->getName().c_str();
   }
+  
+  COREInstantiable* CORENamespaceGetInstantiable(CORENamespace* _namespace, const char* name) {
+      return rcast<COREInstantiable*>(rcast<Namespace*>(_namespace)->getInstantiable(std::string(name)));
+  }
 
   const char** COREDirectedConnectionGetSrc(COREDirectedConnection* directed_connection, int* path_len) {
       DirectedConnection* conn = rcast<DirectedConnection*>(directed_connection);
@@ -362,6 +366,11 @@ extern "C" {
           count++;
       }
   }
+
+  const char* COREInstantiableGetName(COREInstantiable* instantiable) {
+      return rcast<Instantiable*>(instantiable)->getName().c_str();
+  }
+
 
 }//extern "C"
 }//CoreIR namespace

--- a/tests/bindings/python/test_namespace.py
+++ b/tests/bindings/python/test_namespace.py
@@ -1,0 +1,10 @@
+import coreir
+
+
+def test_get_name():
+    context = coreir.Context()
+    assert context.G.name == "_G"
+    stdlib = context.load_library("stdlib")
+    assert stdlib.name == "stdlib"
+    add_instantiable = stdlib.instantiables["add"]
+    assert add_instantiable.name == "add"


### PR DESCRIPTION
Also refactors the LazyDict pattern to be reusable across modules (Used by namespaces and instances now)