### PR TITLE
[python-bindings] Add more namespace and instantiable API functions

### DIFF
--- a/bindings/python/coreir/__init__.py
+++ b/bindings/python/coreir/__init__.py
@@ -183,6 +183,12 @@ libcoreir_c.COREInstanceGetGenArgs.restype = None
 libcoreir_c.CORENamespaceGetInstantiable.argtypes = [CORENamespace_p, ct.c_char_p]
 libcoreir_c.CORENamespaceGetInstantiable.restype = COREInstantiable_p
 
+libcoreir_c.CORENamespaceGetGenerator.argtypes = [CORENamespace_p, ct.c_char_p]
+libcoreir_c.CORENamespaceGetGenerator.restype = COREInstantiable_p
+
+libcoreir_c.CORENamespaceGetModule.argtypes = [CORENamespace_p, ct.c_char_p]
+libcoreir_c.CORENamespaceGetModule.restype = COREInstantiable_p
+
 libcoreir_c.COREInstantiableGetName.argtypes = [COREInstantiable_p]
 libcoreir_c.COREInstantiableGetName.restype = ct.c_char_p
 

--- a/bindings/python/coreir/__init__.py
+++ b/bindings/python/coreir/__init__.py
@@ -185,3 +185,6 @@ libcoreir_c.CORENamespaceGetInstantiable.restype = COREInstantiable_p
 
 libcoreir_c.COREInstantiableGetName.argtypes = [COREInstantiable_p]
 libcoreir_c.COREInstantiableGetName.restype = ct.c_char_p
+
+libcoreir_c.COREInstantiableGetKind.argtypes = [COREInstantiable_p]
+libcoreir_c.COREInstantiableGetKind.restype = ct.c_int

--- a/bindings/python/coreir/__init__.py
+++ b/bindings/python/coreir/__init__.py
@@ -4,9 +4,9 @@ import platform
 import os
 from coreir.lib import load_shared_lib, libcoreir_c
 from coreir.context import COREContext, COREContext_p, Context, COREMapKind, COREMapKind_STR2ARG_MAP, COREMapKind_STR2PARAM_MAP, COREMapKind_STR2ARG_MAP
-from coreir.module import COREModule, COREModule_p, COREModuleDef, COREModuleDef_p, ModuleDef, Module, \
+from coreir.module import Module, COREModule, COREModule_p, COREModuleDef, COREModuleDef_p, ModuleDef, Module, \
         COREDirectedInstance_p, COREDirectedConnection_p, COREDirectedModule_p
-from coreir.instantiable import COREInstantiable_p
+from coreir.instantiable import Instantiable, COREInstantiable_p
 from coreir.namespace import CORENamespace, CORENamespace_p
 from coreir.type import COREType, COREType_p, CoreIRType, Params, Args, COREArg, COREArg_p, Type
 from coreir.wireable import COREWireable_p
@@ -64,6 +64,9 @@ libcoreir_c.COREModuleGetDef.restype = COREModuleDef_p
 
 libcoreir_c.COREModuleDefAddModuleInstance.argtypes = [COREModuleDef_p, ct.c_char_p, COREModule_p, ct.c_void_p]
 libcoreir_c.COREModuleDefAddModuleInstance.restype = COREWireable_p
+
+libcoreir_c.COREModuleDefAddGeneratorInstance.argtypes = [COREModuleDef_p, ct.c_char_p, COREInstantiable_p, ct.c_void_p, ct.c_void_p]
+libcoreir_c.COREModuleDefAddGeneratorInstance.restype = COREWireable_p
 
 libcoreir_c.COREModuleDefGetInterface.argtypes = [COREModuleDef_p]
 libcoreir_c.COREModuleDefGetInterface.restype = COREWireable_p

--- a/bindings/python/coreir/instantiable.py
+++ b/bindings/python/coreir/instantiable.py
@@ -13,3 +13,16 @@ class Instantiable(CoreIRType):
     @property
     def name(self):
         return libcoreir_c.COREInstantiableGetName(self.ptr).decode()
+
+    @property
+    def kind(self):
+        kind = libcoreir_c.COREInstantiableGetKind(self.ptr)
+        if kind == 0:
+            return Module
+        elif kind == 1:
+            return Generator
+        raise NotImplementedError()
+
+
+class Generator(Instantiable):
+    pass

--- a/bindings/python/coreir/module.py
+++ b/bindings/python/coreir/module.py
@@ -24,6 +24,13 @@ class ModuleDef(CoreIRType):
         assert isinstance(config,Args)
         return Instance(libcoreir_c.COREModuleDefAddModuleInstance(self.ptr, str.encode(name), module.ptr,config.ptr),self.context)
 
+    def add_generator_instance(self, name, generator, genargs, config=None):
+        if config is None:
+            config = self.context.newArgs()
+        assert isinstance(genargs, Args)
+        assert isinstance(config, Args)
+        return Instance(libcoreir_c.COREModuleDefAddGeneratorInstance(self.ptr, str.encode(name), generator.ptr, genargs.ptr, config.ptr), self.context)
+
     @property
     def interface(self):
         return Interface(libcoreir_c.COREModuleDefGetInterface(self.ptr),self.context)

--- a/bindings/python/coreir/namespace.py
+++ b/bindings/python/coreir/namespace.py
@@ -2,7 +2,7 @@ import ctypes as ct
 from coreir.type import CoreIRType, Type, Params
 from coreir.module import Module
 from coreir.lib import libcoreir_c
-from coreir.instantiable import Instantiable
+from coreir.instantiable import Instantiable, Generator
 from coreir.util import LazyDict
 
 class CORENamespace(ct.Structure):
@@ -15,6 +15,8 @@ class Namespace(CoreIRType):
     def __init__(self, ptr, context):
         super(Namespace, self).__init__(ptr, context)
         self.instantiables = LazyDict(self, Instantiable, libcoreir_c.CORENamespaceGetInstantiable)
+        self.generators = LazyDict(self, Generator, libcoreir_c.CORENamespaceGetGenerator)
+        self.modules = LazyDict(self, Module, libcoreir_c.CORENamespaceGetModule)
 
     @property
     def name(self):

--- a/include/coreir-c/coreir.h
+++ b/include/coreir-c/coreir.h
@@ -44,6 +44,8 @@ extern COREDirectedModule* COREModuleGetDirectedModule(COREModule* module);
 //Errors:
 //  Invalid arg: instance name already exists
 extern COREWireable* COREModuleDefAddModuleInstance(COREModuleDef* module_def, char* name, COREModule* module, void* config); //config will be Args*
+extern COREWireable* COREModuleDefAddGeneratorInstance(COREModuleDef* module_def, char* name, COREInstantiable* generator, void* genargs, void* config);
+
 extern COREWireable* COREModuleDefGetInterface(COREModuleDef* m);
 extern COREArg* COREGetConfigValue(COREWireable* i, char* s); 
 

--- a/include/coreir-c/coreir.h
+++ b/include/coreir-c/coreir.h
@@ -82,5 +82,6 @@ extern COREDirectedConnection** COREDirectedInstanceGetInputs(COREDirectedInstan
 void COREInstanceGetGenArgs(COREWireable* core_instance, char*** names, COREArg** args, int* num_args);
 
 extern const char* COREInstantiableGetName(COREInstantiable* instantiable);
+extern int COREInstantiableGetKind(COREInstantiable* instantiable);
 
 #endif //COREIR_C_H_

--- a/include/coreir-c/coreir.h
+++ b/include/coreir-c/coreir.h
@@ -32,6 +32,8 @@ extern const char* COREGetInstRefName(COREWireable* iref);
 //  Invalid arg: Module name already exists
 extern COREModule* CORENewModule(CORENamespace* ns, char* name, COREType* type, void* configparams);
 extern COREInstantiable* CORENamespaceGetInstantiable(CORENamespace* _namespace, const char* name);
+extern COREInstantiable* CORENamespaceGetGenerator(CORENamespace* _namespace, const char* name);
+extern COREInstantiable* CORENamespaceGetModule(CORENamespace* _namespace, const char* name);
 
 extern void COREPrintModule(COREModule* m);
 extern COREModuleDef* COREModuleNewDef(COREModule* m);

--- a/src/lib/coreir-c/coreir-c.cpp
+++ b/src/lib/coreir-c/coreir-c.cpp
@@ -227,6 +227,14 @@ extern "C" {
       return rcast<COREInstantiable*>(rcast<Namespace*>(_namespace)->getInstantiable(std::string(name)));
   }
 
+  COREInstantiable* CORENamespaceGetGenerator(CORENamespace* _namespace, const char* name) {
+      return rcast<COREInstantiable*>(rcast<Namespace*>(_namespace)->getGenerator(std::string(name)));
+  }
+
+  COREInstantiable* CORENamespaceGetModule(CORENamespace* _namespace, const char* name) {
+      return rcast<COREInstantiable*>(rcast<Namespace*>(_namespace)->getModule(std::string(name)));
+  }
+
   const char** COREDirectedConnectionGetSrc(COREDirectedConnection* directed_connection, int* path_len) {
       DirectedConnection* conn = rcast<DirectedConnection*>(directed_connection);
       ConstSelectPath path = conn->getConstSrc();

--- a/src/lib/coreir-c/coreir-c.cpp
+++ b/src/lib/coreir-c/coreir-c.cpp
@@ -371,6 +371,10 @@ extern "C" {
       return rcast<Instantiable*>(instantiable)->getName().c_str();
   }
 
+  int COREInstantiableGetKind(COREInstantiable* instantiable) {
+      return rcast<Instantiable*>(instantiable)->getKind();
+  }
+
 
 }//extern "C"
 }//CoreIR namespace

--- a/src/lib/coreir-c/coreir-c.cpp
+++ b/src/lib/coreir-c/coreir-c.cpp
@@ -106,6 +106,10 @@ extern "C" {
     return rcast<COREWireable*>(rcast<ModuleDef*>(module_def)->addInstance(string(name),rcast<Module*>(module),*rcast<Args*>(config)));
   }
 
+  COREWireable* COREModuleDefAddGeneratorInstance(COREModuleDef* module_def, char* name, COREInstantiable* generator, void* genargs, void* config) {
+    return rcast<COREWireable*>(rcast<ModuleDef*>(module_def)->addInstance(string(name),rcast<Generator*>(generator), *rcast<Args*>(genargs), *rcast<Args*>(config)));
+  }
+
   void COREModuleSetDef(COREModule* module, COREModuleDef* module_def) {
     rcast<Module*>(module)->setDef(rcast<ModuleDef*>(module_def));
   }

--- a/tests/bindings/python/test_namespace.py
+++ b/tests/bindings/python/test_namespace.py
@@ -1,4 +1,5 @@
 import coreir
+import test_utils
 
 
 def test_get_name():
@@ -8,4 +9,8 @@ def test_get_name():
     assert stdlib.name == "stdlib"
     add_instantiable = stdlib.instantiables["add"]
     assert add_instantiable.name == "add"
-    assert add_instantiable.kind == Generator
+    assert add_instantiable.kind == coreir.instantiable.Generator
+
+    add_generator = stdlib.generators["add"]
+    assert add_generator.name == "add"
+    test_utils.assert_pointers_equal(add_generator.ptr, add_instantiable.ptr)

--- a/tests/bindings/python/test_namespace.py
+++ b/tests/bindings/python/test_namespace.py
@@ -8,3 +8,4 @@ def test_get_name():
     assert stdlib.name == "stdlib"
     add_instantiable = stdlib.instantiables["add"]
     assert add_instantiable.name == "add"
+    assert add_instantiable.kind == Generator

--- a/tests/bindings/python/test_namespace.py
+++ b/tests/bindings/python/test_namespace.py
@@ -14,3 +14,9 @@ def test_get_name():
     add_generator = stdlib.generators["add"]
     assert add_generator.name == "add"
     test_utils.assert_pointers_equal(add_generator.ptr, add_instantiable.ptr)
+
+    module_typ = context.Record({"input": context.Array(8, context.BitIn()), "output": context.Array(9, context.Bit())})
+    module = context.G.new_module("multiply_by_2", module_typ)
+    module_def = module.new_definition()
+    add8_inst = module_def.add_generator_instance("add8_inst", add_generator, context.newArgs({"width":8}))
+    assert add8_inst.generator_args["width"].value == 8


### PR DESCRIPTION
Added functions summarized below:
```c
extern COREWireable* COREModuleDefAddGeneratorInstance(COREModuleDef* module_def, char* name, COREInstantiable* generator, void* genargs, void* config);
extern COREInstantiable* CORENamespaceGetGenerator(CORENamespace* _namespace, const char* name);
extern COREInstantiable* CORENamespaceGetModule(CORENamespace* _namespace, const char* name);
extern int COREInstantiableGetKind(COREInstantiable* instantiable);
```