### PR TITLE
Linebuffer fix

### DIFF
--- a/include/coreir-lib/commonlib.h
+++ b/include/coreir-lib/commonlib.h
@@ -1,0 +1,15 @@
+#ifndef COREIR_COMMONLIB_H_
+#define COREIR_COMMONLIB_H_
+
+#include "coreir-macros.h"
+#include "coreir-c/ctypes.h"
+
+#ifdef __cplusplus
+#include "coreir.h"
+COREIR_GEN_CPP_API_DECLARATION_FOR_LIBRARY(commonlib);
+#endif
+
+COREIR_GEN_C_API_DECLARATION_FOR_LIBRARY(commonlib);
+
+
+#endif //COREIR_COMMONLIB_HPP_

--- a/src/lib/libs/cgralib.cpp
+++ b/src/lib/libs/cgralib.cpp
@@ -160,18 +160,22 @@ Namespace* CoreIRLoadLibrary_cgralib(Context* c) {
     // connect the stencil outputs
     for (uint i = 0; i < stencil_height; ++i) {
       for (uint j = 0; j < stencil_width; ++j) {
+        // delays correspond to earlier pixels
+        uint iflip = (stencil_height - 1) - i;
+        uint jflip = (stencil_width - 1) - j;
+
         if (j == 0) {
           // the first column comes from input/mem
           if (i == 0) {
-            def->connect({"self","in"}, {"self","out",std::to_string(i),std::to_string(j)});
+            def->connect({"self","in"}, {"self","out",std::to_string(iflip),std::to_string(jflip)});
           } else {
             std::string mem_name = mem_prefix + std::to_string(i);
-            def->connect({mem_name, "rdata"}, {"self","out",std::to_string(i),std::to_string(j)});
+            def->connect({mem_name, "rdata"}, {"self","out",std::to_string(iflip),std::to_string(jflip)});
           }
         } else {
           // rest come from registers
           std::string reg_name = reg_prefix + std::to_string(i) + "_" + std::to_string(j);
-          def->connect({reg_name, "out"}, {"self","out",std::to_string(i),std::to_string(j)});
+          def->connect({reg_name, "out"}, {"self","out",std::to_string(iflip),std::to_string(jflip)});
         }
       }
     }    

--- a/src/lib/libs/commonlib.cpp
+++ b/src/lib/libs/commonlib.cpp
@@ -1,0 +1,125 @@
+#include "coreir-lib/commonlib.h"
+
+COREIR_GEN_C_API_DEFINITION_FOR_LIBRARY(commonlib);
+
+using namespace CoreIR;
+
+Namespace* CoreIRLoadLibrary_commonlib(Context* c) {
+  
+  Namespace* commonlib = c->newNamespace("commonlib");
+ 
+  /////////////////////////////////
+  // Commonlib Types
+  /////////////////////////////////
+  Params widthparams = Params({{"width",AINT}});
+
+  //Single bit types
+  commonlib->newNamedType("clk","clkIn",c->Bit());
+  commonlib->newNamedType("rst","rstIn",c->Bit());
+  
+  //Common Function types
+  commonlib->newTypeGen(
+    "binary",
+    widthparams,
+    [](Context* c, Args args) {
+      uint width = args.at("width")->get<ArgInt>();
+      return c->Record({
+        {"in",c->BitIn()->Arr(width)->Arr(2)},
+        {"out",c->Bit()->Arr(width)}
+      });
+    }
+  );
+  commonlib->newTypeGen(
+    "unary",
+    widthparams,
+    [](Context* c, Args args) {
+      uint width = args.at("width")->get<ArgInt>();
+      return c->Record({
+        {"in",c->BitIn()->Arr(width)},
+        {"out",c->Bit()->Arr(width)}
+      });
+    }
+  );
+  commonlib->newTypeGen(
+    "binaryReduce",
+    widthparams,
+    [](Context* c, Args args) {
+      uint width = args.at("width")->get<ArgInt>();
+      return c->Record({
+        {"in",c->BitIn()->Arr(width)->Arr(2)},
+        {"out",c->Bit()}
+      });
+    }
+  );
+  commonlib->newTypeGen(
+    "unaryReduce",
+    widthparams,
+    [](Context* c, Args args) {
+      uint width = args.at("width")->get<ArgInt>();
+      return c->Record({
+        {"in",c->BitIn()->Arr(width)},
+        {"out",c->Bit()}
+      });
+    }
+  );
+  //For repeat
+  commonlib->newTypeGen(
+    "unaryExpand",
+    widthparams,
+    [](Context* c, Args args) {
+      uint width = args.at("width")->get<ArgInt>();
+      return c->Record({
+        {"in",c->BitIn()},
+        {"out",c->Bit()->Arr(width)}
+      });
+    }
+  );
+  //For mux
+  commonlib->newTypeGen(
+    "ternary",
+    widthparams,
+    [](Context* c, Args args) {
+      uint width = args.at("width")->get<ArgInt>();
+      return c->Record({
+        {"in",c->Record({
+          {"data",c->BitIn()->Arr(width)->Arr(2)},
+          {"bit",c->BitIn()}
+        })},
+        {"out",c->Bit()->Arr(width)}
+      });
+    }
+  );
+  
+  /////////////////////////////////
+  // Commonlib bitwise primitives
+  //   
+  /////////////////////////////////
+  //commonlib_bitwise(c,commonlib);
+
+  /////////////////////////////////
+  // Commonlib Arithmetic primitives
+  //   umin,smin,umax,smax
+  /////////////////////////////////
+
+  //Lazy way:
+  unordered_map<string,vector<string>> opmap({
+    {"unary",{}},
+    {"unaryReduce",{}},
+    {"binary",{
+     "umin","smin","umax","smax"
+    }},
+    {"binaryReduce",{
+    }},
+    {"ternary",{}},
+  });
+  
+  //Add all the generators (with widthparams)
+  for (auto tmap : opmap) {
+    TypeGen* tg = commonlib->getTypeGen(tmap.first);
+    for (auto op : tmap.second) {
+      commonlib->newGeneratorDecl(op,tg,widthparams);
+    }
+  }
+
+  return commonlib;
+}

--- a/src/lib/libs/stdlib.cpp
+++ b/src/lib/libs/stdlib.cpp
@@ -28,25 +28,29 @@ Namespace* CoreIRLoadLibrary_stdlib(Context* c) {
   
   //Common Function types
   stdlib->newTypeGen(
-    "binary",
-    widthparams,
-    [](Context* c, Args args) {
-      uint width = args.at("width")->get<ArgInt>();
-      return c->Record({
-        {"in",c->BitIn()->Arr(width)->Arr(2)},
-        {"out",c->Bit()->Arr(width)}
-      });
-    }
-  );
-  stdlib->newTypeGen(
     "unary",
     widthparams,
     [](Context* c, Args args) {
       uint width = args.at("width")->get<ArgInt>();
+      Type* ptype = c->Bit()->Arr(width);
+      if (width==1) ptype = c->Bit();
       return c->Record({
-        {"in",c->BitIn()->Arr(width)},
-        {"out",c->Bit()->Arr(width)}
-      });
+          {"in",c->Flip(ptype)},
+            {"out",ptype}
+        });
+    }
+  );
+  stdlib->newTypeGen(
+    "binary",
+    widthparams,
+    [](Context* c, Args args) {
+      uint width = args.at("width")->get<ArgInt>();
+      Type* ptype = c->Bit()->Arr(width);
+      if (width==1) ptype = c->Bit();
+      return c->Record({
+          {"in",c->Flip(ptype)->Arr(2)},
+            {"out",ptype}
+        });
     }
   );
   stdlib->newTypeGen(

--- a/src/moduledef.cpp
+++ b/src/moduledef.cpp
@@ -80,7 +80,7 @@ Wireable* ModuleDef::sel(SelectPath path) {
 
 
 Instance* ModuleDef::addInstance(string instname,Generator* gen, Args genargs,Args config) {
-  assert(instances.count(instname)==0);
+  ASSERT(instances.count(instname)==0, "Already have an instance named: " + instname);
   
   Instance* inst = new Instance(this,instname,gen,genargs,config);
   instances[instname] = inst;


### PR DESCRIPTION
Linebuffer was hooking things up incorrectly (note that a delay through a register/mem means that it will be the earlier pixels; therefore we need to "flip" horizontally and vertically)

Also added commonlib, which contains max/min functions.
Stdlib was updated to fix the case when the bitwidth is 1.