### PR TITLE
Initial implementation of FIRRTL primitive wrapper generator

### DIFF
--- a/tools/gen_firrtl_modules.py
+++ b/tools/gen_firrtl_modules.py
@@ -1,0 +1,92 @@
+import itertools
+from collections import namedtuple
+
+
+class Source:
+    def __init__(self):
+        self._source = ""
+
+    def add_line(self, text=""):
+        self._source += text + "\n"
+
+    def __str__(self):
+        return self._source
+
+
+prim = namedtuple("prim", ["name", "in_types", "return_types"])
+
+
+UInt = "UInt"
+SInt = "SInt"
+
+source = Source()
+standard_in_types = tuple(itertools.product((UInt, SInt), (UInt, SInt)))
+
+binary_ops = [
+    prim("add",  standard_in_types, (UInt, SInt, SInt, SInt)),
+    prim("sub",  standard_in_types, (SInt, SInt, SInt, SInt)),
+    prim("mul",  standard_in_types, (UInt, SInt, SInt, SInt)),
+    prim("div",  standard_in_types, (UInt, SInt, SInt, SInt)),
+    prim("mod",  standard_in_types, (UInt, UInt, SInt, SInt)),
+    prim("lt",   standard_in_types, (UInt, UInt, UInt, UInt)),
+    prim("leq",  standard_in_types, (UInt, UInt, UInt, UInt)),
+    prim("gt",   standard_in_types, (UInt, UInt, UInt, UInt)),
+    prim("geq",  standard_in_types, (UInt, UInt, UInt, UInt)),
+    prim("eq",   standard_in_types, (UInt, UInt, UInt, UInt)),
+    prim("neq",  standard_in_types, (UInt, UInt, UInt, UInt)),
+    prim("dshl", ((UInt, UInt), (UInt, SInt)), (UInt, SInt)),
+    prim("dshr", ((UInt, UInt), (UInt, SInt)), (UInt, SInt)),
+    prim("and",  standard_in_types, (UInt, UInt, UInt, UInt)),
+    prim("or",   standard_in_types, (UInt, UInt, UInt, UInt)),
+    prim("xor",  standard_in_types, (UInt, UInt, UInt, UInt)),
+    prim("cat",  standard_in_types, (UInt, UInt, UInt, UInt)),
+]
+
+types = ["UInt", "SInt"]
+
+def get_primitive_arg(name, typ):
+    if typ == SInt:
+        name = "asSInt({})".format(name)
+    return name
+
+
+for op in binary_ops:
+    for (in0_type, in1_type), out_type in zip(op.in_types, op.return_types):
+        source.add_line("  module {}_{}_{} :".format(op.name, in0_type, in1_type))
+        source.add_line("    input in0  : UInt")
+        source.add_line("    input in1  : UInt")
+        source.add_line("    output out : UInt")
+        source.add_line()
+        in0 = get_primitive_arg("in0", in0_type)
+        in1 = get_primitive_arg("in1", in1_type)
+        result = "{}({}, {})".format(op.name, in0, in1)
+        if out_type == SInt:
+            result = "asUInt({})".format(result)
+        source.add_line("    out <= {}".format(result))
+        source.add_line()
+
+unary_ops = [
+    prim("cvt", (UInt, SInt), (SInt, SInt)),
+    prim("neg", (UInt, SInt), (SInt, SInt)),
+    prim("not", (UInt, SInt), (UInt, UInt)),
+    prim("andr", (UInt, SInt), (UInt, UInt)),
+    prim("orr",  (UInt, SInt), (UInt, UInt)),
+    prim("xorr", (UInt, SInt), (UInt, UInt)),
+]
+
+for op in unary_ops:
+    for in_type, out_type in zip(op.in_types, op.return_types):
+        source.add_line("  module {}_{} :".format(op.name, in_type))
+        source.add_line("    input in   : UInt")
+        source.add_line("    output out : UInt")
+        source.add_line()
+        _in = get_primitive_arg("in", in_type)
+        result = "{}({})".format(op.name, _in)
+        if out_type == SInt:
+            result = "asUInt({})".format(result)
+        source.add_line("    out <= {}".format(result))
+        source.add_line()
+
+with open("primitive_wrappers.fir", "w") as output:
+    output.write(str(source))
+

--- a/tools/primitive_wrappers.fir
+++ b/tools/primitive_wrappers.fir
@@ -1,0 +1,520 @@
+  module add_UInt_UInt :
+    input in0  : UInt
+    input in1  : UInt
+    output out : UInt
+
+    out <= add(in0, in1)
+
+  module add_UInt_SInt :
+    input in0  : UInt
+    input in1  : UInt
+    output out : UInt
+
+    out <= asUInt(add(in0, asSInt(in1)))
+
+  module add_SInt_UInt :
+    input in0  : UInt
+    input in1  : UInt
+    output out : UInt
+
+    out <= asUInt(add(asSInt(in0), in1))
+
+  module add_SInt_SInt :
+    input in0  : UInt
+    input in1  : UInt
+    output out : UInt
+
+    out <= asUInt(add(asSInt(in0), asSInt(in1)))
+
+  module sub_UInt_UInt :
+    input in0  : UInt
+    input in1  : UInt
+    output out : UInt
+
+    out <= asUInt(sub(in0, in1))
+
+  module sub_UInt_SInt :
+    input in0  : UInt
+    input in1  : UInt
+    output out : UInt
+
+    out <= asUInt(sub(in0, asSInt(in1)))
+
+  module sub_SInt_UInt :
+    input in0  : UInt
+    input in1  : UInt
+    output out : UInt
+
+    out <= asUInt(sub(asSInt(in0), in1))
+
+  module sub_SInt_SInt :
+    input in0  : UInt
+    input in1  : UInt
+    output out : UInt
+
+    out <= asUInt(sub(asSInt(in0), asSInt(in1)))
+
+  module mul_UInt_UInt :
+    input in0  : UInt
+    input in1  : UInt
+    output out : UInt
+
+    out <= mul(in0, in1)
+
+  module mul_UInt_SInt :
+    input in0  : UInt
+    input in1  : UInt
+    output out : UInt
+
+    out <= asUInt(mul(in0, asSInt(in1)))
+
+  module mul_SInt_UInt :
+    input in0  : UInt
+    input in1  : UInt
+    output out : UInt
+
+    out <= asUInt(mul(asSInt(in0), in1))
+
+  module mul_SInt_SInt :
+    input in0  : UInt
+    input in1  : UInt
+    output out : UInt
+
+    out <= asUInt(mul(asSInt(in0), asSInt(in1)))
+
+  module div_UInt_UInt :
+    input in0  : UInt
+    input in1  : UInt
+    output out : UInt
+
+    out <= div(in0, in1)
+
+  module div_UInt_SInt :
+    input in0  : UInt
+    input in1  : UInt
+    output out : UInt
+
+    out <= asUInt(div(in0, asSInt(in1)))
+
+  module div_SInt_UInt :
+    input in0  : UInt
+    input in1  : UInt
+    output out : UInt
+
+    out <= asUInt(div(asSInt(in0), in1))
+
+  module div_SInt_SInt :
+    input in0  : UInt
+    input in1  : UInt
+    output out : UInt
+
+    out <= asUInt(div(asSInt(in0), asSInt(in1)))
+
+  module mod_UInt_UInt :
+    input in0  : UInt
+    input in1  : UInt
+    output out : UInt
+
+    out <= mod(in0, in1)
+
+  module mod_UInt_SInt :
+    input in0  : UInt
+    input in1  : UInt
+    output out : UInt
+
+    out <= mod(in0, asSInt(in1))
+
+  module mod_SInt_UInt :
+    input in0  : UInt
+    input in1  : UInt
+    output out : UInt
+
+    out <= asUInt(mod(asSInt(in0), in1))
+
+  module mod_SInt_SInt :
+    input in0  : UInt
+    input in1  : UInt
+    output out : UInt
+
+    out <= asUInt(mod(asSInt(in0), asSInt(in1)))
+
+  module lt_UInt_UInt :
+    input in0  : UInt
+    input in1  : UInt
+    output out : UInt
+
+    out <= lt(in0, in1)
+
+  module lt_UInt_SInt :
+    input in0  : UInt
+    input in1  : UInt
+    output out : UInt
+
+    out <= lt(in0, asSInt(in1))
+
+  module lt_SInt_UInt :
+    input in0  : UInt
+    input in1  : UInt
+    output out : UInt
+
+    out <= lt(asSInt(in0), in1)
+
+  module lt_SInt_SInt :
+    input in0  : UInt
+    input in1  : UInt
+    output out : UInt
+
+    out <= lt(asSInt(in0), asSInt(in1))
+
+  module leq_UInt_UInt :
+    input in0  : UInt
+    input in1  : UInt
+    output out : UInt
+
+    out <= leq(in0, in1)
+
+  module leq_UInt_SInt :
+    input in0  : UInt
+    input in1  : UInt
+    output out : UInt
+
+    out <= leq(in0, asSInt(in1))
+
+  module leq_SInt_UInt :
+    input in0  : UInt
+    input in1  : UInt
+    output out : UInt
+
+    out <= leq(asSInt(in0), in1)
+
+  module leq_SInt_SInt :
+    input in0  : UInt
+    input in1  : UInt
+    output out : UInt
+
+    out <= leq(asSInt(in0), asSInt(in1))
+
+  module gt_UInt_UInt :
+    input in0  : UInt
+    input in1  : UInt
+    output out : UInt
+
+    out <= gt(in0, in1)
+
+  module gt_UInt_SInt :
+    input in0  : UInt
+    input in1  : UInt
+    output out : UInt
+
+    out <= gt(in0, asSInt(in1))
+
+  module gt_SInt_UInt :
+    input in0  : UInt
+    input in1  : UInt
+    output out : UInt
+
+    out <= gt(asSInt(in0), in1)
+
+  module gt_SInt_SInt :
+    input in0  : UInt
+    input in1  : UInt
+    output out : UInt
+
+    out <= gt(asSInt(in0), asSInt(in1))
+
+  module geq_UInt_UInt :
+    input in0  : UInt
+    input in1  : UInt
+    output out : UInt
+
+    out <= geq(in0, in1)
+
+  module geq_UInt_SInt :
+    input in0  : UInt
+    input in1  : UInt
+    output out : UInt
+
+    out <= geq(in0, asSInt(in1))
+
+  module geq_SInt_UInt :
+    input in0  : UInt
+    input in1  : UInt
+    output out : UInt
+
+    out <= geq(asSInt(in0), in1)
+
+  module geq_SInt_SInt :
+    input in0  : UInt
+    input in1  : UInt
+    output out : UInt
+
+    out <= geq(asSInt(in0), asSInt(in1))
+
+  module eq_UInt_UInt :
+    input in0  : UInt
+    input in1  : UInt
+    output out : UInt
+
+    out <= eq(in0, in1)
+
+  module eq_UInt_SInt :
+    input in0  : UInt
+    input in1  : UInt
+    output out : UInt
+
+    out <= eq(in0, asSInt(in1))
+
+  module eq_SInt_UInt :
+    input in0  : UInt
+    input in1  : UInt
+    output out : UInt
+
+    out <= eq(asSInt(in0), in1)
+
+  module eq_SInt_SInt :
+    input in0  : UInt
+    input in1  : UInt
+    output out : UInt
+
+    out <= eq(asSInt(in0), asSInt(in1))
+
+  module neq_UInt_UInt :
+    input in0  : UInt
+    input in1  : UInt
+    output out : UInt
+
+    out <= neq(in0, in1)
+
+  module neq_UInt_SInt :
+    input in0  : UInt
+    input in1  : UInt
+    output out : UInt
+
+    out <= neq(in0, asSInt(in1))
+
+  module neq_SInt_UInt :
+    input in0  : UInt
+    input in1  : UInt
+    output out : UInt
+
+    out <= neq(asSInt(in0), in1)
+
+  module neq_SInt_SInt :
+    input in0  : UInt
+    input in1  : UInt
+    output out : UInt
+
+    out <= neq(asSInt(in0), asSInt(in1))
+
+  module dshl_UInt_UInt :
+    input in0  : UInt
+    input in1  : UInt
+    output out : UInt
+
+    out <= dshl(in0, in1)
+
+  module dshl_UInt_SInt :
+    input in0  : UInt
+    input in1  : UInt
+    output out : UInt
+
+    out <= asUInt(dshl(in0, asSInt(in1)))
+
+  module dshr_UInt_UInt :
+    input in0  : UInt
+    input in1  : UInt
+    output out : UInt
+
+    out <= dshr(in0, in1)
+
+  module dshr_UInt_SInt :
+    input in0  : UInt
+    input in1  : UInt
+    output out : UInt
+
+    out <= asUInt(dshr(in0, asSInt(in1)))
+
+  module and_UInt_UInt :
+    input in0  : UInt
+    input in1  : UInt
+    output out : UInt
+
+    out <= and(in0, in1)
+
+  module and_UInt_SInt :
+    input in0  : UInt
+    input in1  : UInt
+    output out : UInt
+
+    out <= and(in0, asSInt(in1))
+
+  module and_SInt_UInt :
+    input in0  : UInt
+    input in1  : UInt
+    output out : UInt
+
+    out <= and(asSInt(in0), in1)
+
+  module and_SInt_SInt :
+    input in0  : UInt
+    input in1  : UInt
+    output out : UInt
+
+    out <= and(asSInt(in0), asSInt(in1))
+
+  module or_UInt_UInt :
+    input in0  : UInt
+    input in1  : UInt
+    output out : UInt
+
+    out <= or(in0, in1)
+
+  module or_UInt_SInt :
+    input in0  : UInt
+    input in1  : UInt
+    output out : UInt
+
+    out <= or(in0, asSInt(in1))
+
+  module or_SInt_UInt :
+    input in0  : UInt
+    input in1  : UInt
+    output out : UInt
+
+    out <= or(asSInt(in0), in1)
+
+  module or_SInt_SInt :
+    input in0  : UInt
+    input in1  : UInt
+    output out : UInt
+
+    out <= or(asSInt(in0), asSInt(in1))
+
+  module xor_UInt_UInt :
+    input in0  : UInt
+    input in1  : UInt
+    output out : UInt
+
+    out <= xor(in0, in1)
+
+  module xor_UInt_SInt :
+    input in0  : UInt
+    input in1  : UInt
+    output out : UInt
+
+    out <= xor(in0, asSInt(in1))
+
+  module xor_SInt_UInt :
+    input in0  : UInt
+    input in1  : UInt
+    output out : UInt
+
+    out <= xor(asSInt(in0), in1)
+
+  module xor_SInt_SInt :
+    input in0  : UInt
+    input in1  : UInt
+    output out : UInt
+
+    out <= xor(asSInt(in0), asSInt(in1))
+
+  module cat_UInt_UInt :
+    input in0  : UInt
+    input in1  : UInt
+    output out : UInt
+
+    out <= cat(in0, in1)
+
+  module cat_UInt_SInt :
+    input in0  : UInt
+    input in1  : UInt
+    output out : UInt
+
+    out <= cat(in0, asSInt(in1))
+
+  module cat_SInt_UInt :
+    input in0  : UInt
+    input in1  : UInt
+    output out : UInt
+
+    out <= cat(asSInt(in0), in1)
+
+  module cat_SInt_SInt :
+    input in0  : UInt
+    input in1  : UInt
+    output out : UInt
+
+    out <= cat(asSInt(in0), asSInt(in1))
+
+  module cvt_UInt :
+    input in   : UInt
+    output out : UInt
+
+    out <= asUInt(cvt(in))
+
+  module cvt_SInt :
+    input in   : UInt
+    output out : UInt
+
+    out <= asUInt(cvt(asSInt(in)))
+
+  module neg_UInt :
+    input in   : UInt
+    output out : UInt
+
+    out <= asUInt(neg(in))
+
+  module neg_SInt :
+    input in   : UInt
+    output out : UInt
+
+    out <= asUInt(neg(asSInt(in)))
+
+  module not_UInt :
+    input in   : UInt
+    output out : UInt
+
+    out <= not(in)
+
+  module not_SInt :
+    input in   : UInt
+    output out : UInt
+
+    out <= not(asSInt(in))
+
+  module andr_UInt :
+    input in   : UInt
+    output out : UInt
+
+    out <= andr(in)
+
+  module andr_SInt :
+    input in   : UInt
+    output out : UInt
+
+    out <= andr(asSInt(in))
+
+  module orr_UInt :
+    input in   : UInt
+    output out : UInt
+
+    out <= orr(in)
+
+  module orr_SInt :
+    input in   : UInt
+    output out : UInt
+
+    out <= orr(asSInt(in))
+
+  module xorr_UInt :
+    input in   : UInt
+    output out : UInt
+
+    out <= xorr(in)
+
+  module xorr_SInt :
+    input in   : UInt
+    output out : UInt
+
+    out <= xorr(asSInt(in))
+


### PR DESCRIPTION
* Treats all inputs/outputs as UInts. It uses the `as{UInt,SInt}` ops to "cast" them before/after the primitive.
* These don't take into account the widths (i.e. the output of an `add` op is a different width than the coreir `add`). We can either try to insert that logic into the wrappers, or we can emit "select" operators around primitive ops to make sure the output widths match coreir semantics.