### PR TITLE
Patch register primitive

### DIFF
--- a/bindings/python/coreir/__init__.py
+++ b/bindings/python/coreir/__init__.py
@@ -22,6 +22,9 @@ libcoreir_c.CORENewMap.restype = ct.c_void_p
 
 libcoreir_c.CORENewContext.restype = COREContext_p
 
+libcoreir_c.COREContextNamed.argtypes = [COREContext_p, ct.c_char_p, ct.c_char_p]
+libcoreir_c.COREContextNamed.restype = COREType_p
+
 libcoreir_c.COREPrintErrors.argtypes = [COREContext_p]
 
 libcoreir_c.COREAny.argtypes = [COREContext_p]

--- a/bindings/python/coreir/context.py
+++ b/bindings/python/coreir/context.py
@@ -102,3 +102,8 @@ class Context:
 
     def __del__(self):
         libcoreir_c.COREDeleteContext(self.context)
+
+    def get_named_typed(self, namespace, type_name):
+        return Type(
+            libcoreir_c.COREContextNamed(self.context, str.encode(namespace), str.encode(type_name)),
+            self)

--- a/include/coreir-c/coreir.h
+++ b/include/coreir-c/coreir.h
@@ -18,6 +18,7 @@ void* CORENewMap(COREContext* c, void* keys, void* values, uint len, COREMapKind
 //Context COREreater/deleters
 extern COREContext* CORENewContext();
 extern void COREDeleteContext(COREContext*);
+extern COREType* COREContextNamedType(COREContext* context, const char* namespace_, const char* type_name);
 
 
 extern COREModule* CORELoadModule(COREContext* c, char* filename, COREBool* err);

--- a/src/coreir-c/coreir-c.cpp
+++ b/src/coreir-c/coreir-c.cpp
@@ -58,6 +58,10 @@ extern "C" {
   void COREDeleteContext(COREContext* c) {
     deleteContext(rcast<Context*>(c));
   }
+
+  COREType* COREContextNamed(COREContext* context, const char* namespace_, const char* type_name) {
+      return rcast<COREType*>(rcast<Context*>(context)->Named(std::string(namespace_), std::string(type_name)));
+  }
   
   //TODO change the name of this function
   const char* COREGetInstRefName(COREWireable* iref) {
@@ -400,6 +404,8 @@ extern "C" {
   int COREInstantiableGetKind(COREInstantiable* instantiable) {
       return rcast<Instantiable*>(instantiable)->getKind();
   }
+
+
 
 
 }//extern "C"

--- a/src/ir/coreirprims.cpp
+++ b/src/ir/coreirprims.cpp
@@ -139,8 +139,9 @@ void coreirprims_state(Context* c, Namespace* coreirprims) {
     assert(!(clr && rst));
 
     RecordParams r({
-        {"in",c->BitIn()->Arr(width)},
-        {"out",c->Bit()->Arr(width)}
+        {"in" , c->BitIn()->Arr(width)},
+        {"clk", c->Named("coreir", "clkIn")},
+        {"out", c->Bit()->Arr(width)}
     });
     if (en) r.push_back({"en",c->BitIn()});
     if (clr) r.push_back({"clr",c->BitIn()});

--- a/tests/bindings/python/test_coreir.py
+++ b/tests/bindings/python/test_coreir.py
@@ -166,6 +166,11 @@ def test_module_def_connections():
 
     assert len(seen) == len(expected_conns)
 
+def test_context():
+    context = coreir.Context()
+    _type = context.get_named_typed("coreir", "clkIn")
+    assert _type.kind == "Named"
+
 if __name__ == "__main__":
     test_save_module()
 

--- a/tools/vgenstdlib.py
+++ b/tools/vgenstdlib.py
@@ -146,9 +146,9 @@ if __name__ == "__main__":
     #clr = bit 2
     #en = bit 3
     def rexpr(clr,en):
-      expr = "D"
+      expr = "in"
       if (clr):
-        expr = "(clr ? INIT : D)"
+        expr = "(clr ? INIT : in)"
       if (en):
         expr = "en ? %s : r" % expr
       return expr
@@ -170,7 +170,7 @@ if __name__ == "__main__":
       else:
         body += "    r <= %s;\n" % rexpr(clr,en)
       body += "  end\n"
-      body += "  assign Q = r;"
+      body += "  assign out = r;"
       name = "Reg_" + ("P" if posedge else "N")
       if (rst):
         name += "R"
@@ -182,9 +182,9 @@ if __name__ == "__main__":
       v.add_param("WIDTH",16)
       if (rst or clr):
         v.add_param("INIT",0)
-      v.add_input("D","WIDTH")
+      v.add_input("in","WIDTH")
       v.add_input("clk",1)
-      v.add_output("Q","WIDTH")
+      v.add_output("out","WIDTH")
       if (rst):
         v.add_input("rst",1)
       if (clr):


### PR DESCRIPTION
* Changes `D`, `Q` to `in`, `out` in the Verilog register primitives
* Adds `clk` input to `reg` primitive
* Adds support for `Context::Named(string ns, string name)` in the python API
