### PR TITLE
Patch wire clock pass test

### DIFF
--- a/src/passes/wireclockpass.cpp
+++ b/src/passes/wireclockpass.cpp
@@ -8,7 +8,7 @@ bool WireClockPass::runOnModule(Module* module) {
 
     ModuleDef* definition = module->getDef();
 
-    RecordType* type = (RecordType*) definition->getType();  // FIXME: Can I assume this is always a RecordType
+    RecordType* type = cast<RecordType>(definition->getType());  // FIXME: Can I assume this is always a RecordType
     string clkInName;
     for (auto field : type->getRecord()) {
         if (field.second == this->clockType) {
@@ -22,7 +22,7 @@ bool WireClockPass::runOnModule(Module* module) {
 
     bool clockWired = false;
     for (auto instance : definition->getInstances()) {
-        RecordType* instanceType = (RecordType*) instance.second->getType();
+        RecordType* instanceType = cast<RecordType>(instance.second->getType());
         for (auto field : instanceType->getRecord()) {
             std::cout << field.first << std::endl;
             if (field.second == this->clockType) {

--- a/tests/unit/wire_clock_pass.cpp
+++ b/tests/unit/wire_clock_pass.cpp
@@ -22,7 +22,11 @@ int main() {
     passManager->addPass(wireClock, 0);
 
     passManager->run();
-    saveToFile(global, "_shift_register_wired_clock.json", shift_register);
+    ModuleDef* definition = shift_register->getDef();
+    Wireable* topClock = definition->sel("self.CLK");
+    for (auto instance : definition->getInstances()) {
+        ASSERT(definition->hasConnection(topClock, instance.second->sel("clk")), "Wire Clock Pass Test Failed, not all clocks wired up.");
+    }
 
     deleteContext(context);
     return 0;

--- a/tests/unit/wire_clock_pass.cpp
+++ b/tests/unit/wire_clock_pass.cpp
@@ -15,15 +15,18 @@ int main() {
         context->printerrors();
         return 1;
     }
-    shift_register->print();
+    // shift_register->print();
+    ModuleDef* definition = shift_register->getDef();
+    Wireable* topClock = definition->sel("self.CLK");
 
     PassManager* passManager = new PassManager(global);
     WireClockPass* wireClock = new WireClockPass(clockInType);
     passManager->addPass(wireClock, 0);
 
+    for (auto instance : definition->getInstances()) {
+        ASSERT(!definition->hasConnection(topClock, instance.second->sel("clk")), "Wire Clock Pass: Initial module definition should not have clocks wired.");
+    }
     passManager->run();
-    ModuleDef* definition = shift_register->getDef();
-    Wireable* topClock = definition->sel("self.CLK");
     for (auto instance : definition->getInstances()) {
         ASSERT(definition->hasConnection(topClock, instance.second->sel("clk")), "Wire Clock Pass Test Failed, not all clocks wired up.");
     }

--- a/tests/unit/wire_clock_pass.cpp
+++ b/tests/unit/wire_clock_pass.cpp
@@ -23,12 +23,19 @@ int main() {
     WireClockPass* wireClock = new WireClockPass(clockInType);
     passManager->addPass(wireClock, 0);
 
+    // First check that clocks aren't wired
     for (auto instance : definition->getInstances()) {
-        ASSERT(!definition->hasConnection(topClock, instance.second->sel("clk")), "Wire Clock Pass: Initial module definition should not have clocks wired.");
+        ASSERT(!definition->hasConnection(topClock, instance.second->sel("clk")), 
+               "Wire Clock Pass: Initial module definition should not have clocks wired.");
     }
+
+    // Run the pass
     passManager->run();
+
+    // Check that the clocks are now wired
     for (auto instance : definition->getInstances()) {
-        ASSERT(definition->hasConnection(topClock, instance.second->sel("clk")), "Wire Clock Pass Test Failed, not all clocks wired up.");
+        ASSERT(definition->hasConnection(topClock, instance.second->sel("clk")), 
+               "Wire Clock Pass Test Failed, not all clocks wired up.");
     }
 
     deleteContext(context);


### PR DESCRIPTION
Minor patches to my simple wire clock example.
Test actually checks the presence of the new connections (as well as the lack of them initially).
Changes cast operations to use the `cast<>()` pattern. (Should this actually be a dynamic cast?)
Also, am I allowed to assume the top-level type of a moduleDef/Instance will always be a record? 