### PR TITLE
Add lifting clock ports pass

### DIFF
--- a/include/coreir-passes/transform/liftclockports.h
+++ b/include/coreir-passes/transform/liftclockports.h
@@ -1,0 +1,19 @@
+#ifndef LIFTCLOCKPORTPASS_HPP_
+#define LIFTCLOCKPORTPASS_HPP_
+
+#include "coreir.h"
+
+namespace CoreIR {
+namespace Passes {
+
+class LiftClockPorts : public InstanceGraphPass {
+  private :
+    Type* clockType; 
+  public :
+    LiftClockPorts(std::string name, Type* clockType) : InstanceGraphPass(name, "Add a clock port to an instantiable if any of its instances contain an unwired clocked port. Also wires up the new clock port to the instances."), clockType(clockType) {}
+    bool runOnInstanceGraphNode(InstanceGraphNode& node);
+};
+
+}
+}
+#endif

--- a/src/passes/transform/liftclockports.cpp
+++ b/src/passes/transform/liftclockports.cpp
@@ -1,0 +1,40 @@
+#include "coreir.h"
+#include "coreir-passes/transform/liftclockports.h"
+
+using namespace CoreIR;
+
+bool Passes::LiftClockPorts::runOnInstanceGraphNode(InstanceGraphNode& node) {
+    Instantiable* instantiable = node.getInstantiable();
+    bool clockAdded = false;
+    if (isa<Module>(instantiable)) {
+        Module* module = cast<Module>(instantiable);
+        ModuleDef* definition = module->getDef();
+        RecordType* type = cast<RecordType>(definition->getType());  // FIXME: Can I assume this is always a RecordType
+        bool containsClock = false;
+        for (auto field : type->getRecord()) {
+            if (field.second == this->clockType) {
+                containsClock = true;
+                break;
+            }
+        }
+        if (!containsClock) {
+            bool addClock = false;
+            for (auto instance : definition->getInstances()) {
+                RecordType* instanceType = cast<RecordType>(instance.second->getType());
+                for (auto field : instanceType->getRecord()) {
+                    if (field.second == this->clockType) {
+                        addClock = true;
+                        break;
+                    }
+                }
+                if (addClock) break;
+            }
+            if (addClock) {
+                node.appendField("clk", this->clockType);
+                clockAdded = true;
+            }
+        }
+    }
+
+    return clockAdded;
+}

--- a/tests/unit/circuits/shift_register_unwired_clock.json
+++ b/tests/unit/circuits/shift_register_unwired_clock.json
@@ -78,10 +78,6 @@
           "type": [
             "Record",
             {
-              "CLK": [
-                "Named",
-                "coreir.clkIn"
-              ],
               "I": [
                 "Array",
                 4,


### PR DESCRIPTION
Appends a field `clk` of type `clockType` to a module and all it's instances iff:
* Doesn't have a field with a port of `clockType`
* Contains an instance with a port of `clockType`

A good extension would be to support specifying the name of the new clock field.