### PR TITLE
Added mem to coreir

### DIFF
--- a/src/ir/common.cpp
+++ b/src/ir/common.cpp
@@ -14,6 +14,9 @@ namespace CoreIR {
 bool isNumber(string s) {
   return s.find_first_not_of("0123456789")==string::npos;
 }
+bool isPower2(uint n) {
+  return n & (n-1);
+}
 
 bool ConnectionComp::SPComp(const SelectPath& l, const SelectPath& r) {
   if (l.size() != r.size()) {

--- a/src/ir/common.cpp
+++ b/src/ir/common.cpp
@@ -15,7 +15,7 @@ bool isNumber(string s) {
   return s.find_first_not_of("0123456789")==string::npos;
 }
 bool isPower2(uint n) {
-  return n & (n-1);
+  return (n & (n-1))==0;
 }
 
 bool ConnectionComp::SPComp(const SelectPath& l, const SelectPath& r) {

--- a/src/ir/common.hpp
+++ b/src/ir/common.hpp
@@ -102,6 +102,7 @@ inline void hash_combine(size_t& seed, const T& v) {
 
 //These are defined in helpers
 bool isNumber(string s);
+bool isPower2(uint n);
 string Param2Str(Param);
 string Params2Str(Params);
 string Args2Str(Args);

--- a/src/ir/coreirprims.cpp
+++ b/src/ir/coreirprims.cpp
@@ -145,7 +145,7 @@ void coreirprims_state(Context* c, Namespace* coreirprims) {
     bool rst = args.at("rst")->get<ArgBool>();
     assert(!(clr && rst));
     Type* ptype = c->Bit()->Arr(width);
-    if (width==1) ptype = c->Bit();
+    if (width==0) ptype = c->Bit();
 
     RecordParams r({
         {"in" , ptype->getFlipped()},
@@ -177,7 +177,7 @@ void coreirprims_state(Context* c, Namespace* coreirprims) {
 
   //Set nameGen function
   auto regNameGen = [](Args args) {
-    string name = "reg_P";
+    string name = "reg_P"; //TODO Should we do negedge?
     bool rst = args["rst"]->get<ArgBool>();
     bool clr = args["clr"]->get<ArgBool>();
     bool en = args["en"]->get<ArgBool>();
@@ -187,6 +187,32 @@ void coreirprims_state(Context* c, Namespace* coreirprims) {
     return name;
   };
   reg->setNameGen(regNameGen);
+
+
+  Params memGenParams({{"width",AINT},{"depth",AINT}});
+  auto memFun = [](Context* c, Args args) { 
+    uint width = args.at("width")->get<ArgInt>();
+    uint depth = args.at("depth")->get<ArgInt>();
+    ASSERT(isPower2(width),"width needs to be a power of 2: " + to_string(width));
+    ASSERT(isPower2(depth),"depth needs to be a power of 2: " + to_string(depth));
+    uint awidth = uint(std::log2(depth));
+    return c->Record({
+      {"wclk",c->Named("coreir.clkIn")},
+      {"wen",c->BitIn()},
+      {"wdata",c->BitIn()->Arr(width)},
+      {"waddr",c->BitIn()->Arr(awidth)},
+      {"rclk",c->Named("coreir.clkIn")},
+      {"ren",c->BitIn()},
+      {"rdata",c->Bit()->Arr(width)},
+      {"raddr",c->BitIn()->Arr(awidth)}
+    });
+  };
+  TypeGen* memTypeGen = coreirprims->newTypeGen("memType",memGenParams,memFun);
+  auto mem = coreirprims->newGeneratorDecl("mem",memTypeGen,memGenParams);
+  jverilog["parameters"] = {"width","init"};
+  jverilog["prefix"] = "coreir_";
+  mem->getMetaData()["verilog"] = jverilog;
+
 
 }
 
@@ -214,7 +240,7 @@ Namespace* CoreIRLoadLibrary_coreirprims(Context* c) {
     [](Context* c, Args args) {
       uint width = args.at("width")->get<ArgInt>();
       Type* ptype = c->Bit()->Arr(width);
-      if (width==1) ptype = c->Bit();
+      if (width==0) ptype = c->Bit();
       return c->Record({
         {"in",c->Flip(ptype)},
         {"out",ptype}
@@ -227,7 +253,7 @@ Namespace* CoreIRLoadLibrary_coreirprims(Context* c) {
     [](Context* c, Args args) {
       uint width = args.at("width")->get<ArgInt>();
       Type* ptype = c->Bit()->Arr(width);
-      if (width==1) ptype = c->Bit();
+      if (width==0) ptype = c->Bit();
       return c->Record({
         {"in0",c->Flip(ptype)},
         {"in1",c->Flip(ptype)},
@@ -242,7 +268,7 @@ Namespace* CoreIRLoadLibrary_coreirprims(Context* c) {
     [](Context* c, Args args) {
       uint width = args.at("width")->get<ArgInt>();
       Type* ptype = c->Bit()->Arr(width);
-      if (width==1) ptype = c->Bit();
+      if (width==0) ptype = c->Bit();
       return c->Record({
         {"in0",c->Flip(ptype)},
         {"in1",c->Flip(ptype)},
@@ -256,7 +282,7 @@ Namespace* CoreIRLoadLibrary_coreirprims(Context* c) {
     [](Context* c, Args args) {
       uint width = args.at("width")->get<ArgInt>();
       Type* ptype = c->Bit()->Arr(width);
-      if (width==1) ptype = c->Bit();
+      if (width==0) ptype = c->Bit();
       return c->Record({
         {"in",c->Flip(ptype)},
         {"out",c->Bit()}
@@ -283,7 +309,7 @@ Namespace* CoreIRLoadLibrary_coreirprims(Context* c) {
     [](Context* c, Args args) {
       uint width = args.at("width")->get<ArgInt>();
       Type* ptype = c->Bit()->Arr(width);
-      if (width==1) ptype = c->Bit();
+      if (width==0) ptype = c->Bit();
       return c->Record({
         {"in0",c->Flip(ptype)},
         {"in1",c->Flip(ptype)},
@@ -357,7 +383,7 @@ Namespace* CoreIRLoadLibrary_coreirprims(Context* c) {
     [](Context* c, Args args) {
       uint width = args.at("width")->get<ArgInt>();
       Type* ptype = c->Bit()->Arr(width);
-      if (width==1) ptype = c->Bit();
+      if (width==0) ptype = c->Bit();
 
       return c->Record({
         {"out",ptype}
@@ -376,7 +402,7 @@ Namespace* CoreIRLoadLibrary_coreirprims(Context* c) {
     [](Context* c, Args args) {
       uint width = args.at("width")->get<ArgInt>();
       Type* ptype = c->Bit()->Arr(width);
-      if (width==1) ptype = c->Bit();
+      if (width==0) ptype = c->Bit();
       return c->Record({
         {"in",ptype->getFlipped()}
       });

--- a/src/ir/namespace.cpp
+++ b/src/ir/namespace.cpp
@@ -138,8 +138,8 @@ TypeGen* Namespace::getTypeGen(string name) {
 
 Generator* Namespace::newGeneratorDecl(string name,TypeGen* typegen, Params genparams, Params configparams) {
   //Make sure module does not already exist as a module or generator
-  assert(moduleList.count(name)==0);
-  assert(generatorList.count(name)==0);
+  ASSERT(moduleList.count(name)==0,"Already added " + name);
+  ASSERT(generatorList.count(name)==0,"Already added " + name);
   
   Generator* g = new Generator(this,name,typegen,genparams,configparams);
   generatorList.emplace(name,g);

--- a/tools/gen_verilog_prims.py
+++ b/tools/gen_verilog_prims.py
@@ -234,6 +234,43 @@ if __name__ == "__main__":
       v.add_body(body)
       f.write(v.to_string())
       
+    #Now do the memory
+    v = vmodule("coreir_mem")
+    v.add_param("width",16)
+    v.add_param("depth",1024)
+    v.add_input("rclk",1)
+    v.add_input("ren",1)
+    v.add_output("rdata","width")
+    v.add_input("raddr","$clog2(depth)")
+    v.add_input("wclk",1)
+    v.add_input("wen",1)
+    v.add_input("wdata","width")
+    v.add_input("waddr","$clog2(depth)")
+    v.add_body("""
+reg [width-1:0] data[depth-1:0];
+reg [width-1:0] outreg;
 
+always @(posedge wclk) begin
+  if (wen) begin
+    data[waddr] <= wdata;
+  end
+end
 
+always @(posedge rclk) begin
+  if (ren) begin
+    outreg <= data[raddr];
+  end
+end
+
+assign rdata = outreg;
+//Initialize to X
+integer i;
+initial begin
+  outreg = {width{1'bx}};
+  for (i=0; i<depth; i+=1) begin
+    data[i] = {width{1'bx}};
+  end
+end
+""");
+    f.write(v.to_string())
 


### PR DESCRIPTION
It is parameterized by width and depth, so total size of memory is width*depth bits. 
I also have the address ports be exactly log2 of the depth.
You get back the read data the cycle *after* you make read enable a 1. "Synchronous read".
if read address and write address are the same, you get the *old* data and not the new data on the read port. (This could be parametrizable in the future if we wanted)

I did some minor testing for the generated verilog, but better testing should be done.

@phanrahan might want to take a look as well.
