### PR TITLE
Allow user to specify prefix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,10 @@ ifdef COREDEBUG
 CXXFLAGS += -O0 -g3 -D_GLIBCXX_DEBUG
 endif
 
+export CXX
+export CFLAGS
+export CXXFLAGS
+
 all: build coreir
 
 .PHONY: test

--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,11 @@
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S), Linux)
 TARGET = so
-prefix=/usr
+prefix?=/usr
 endif
 ifeq ($(UNAME_S), Darwin)
 TARGET = dylib
-prefix=/usr/local
+prefix?=/usr/local
 endif
 
 all: build coreir

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,26 @@ TARGET = dylib
 prefix?=/usr/local
 endif
 
+
+COREIRCONFIG ?= g++
+CXX ?= g++
+
+
+ifeq ($(COREIRCONFIG),g++)
+CXX = g++
+endif
+
+ifeq ($(COREIRCONFIG),g++-4.9)
+CXX = g++-4.9
+endif
+
+CFLAGS = -Wall -fPIC
+CXXFLAGS = -std=c++11  -Wall  -fPIC -Werror
+
+ifdef COREDEBUG
+CXXFLAGS += -O0 -g3 -D_GLIBCXX_DEBUG
+endif
+
 all: build coreir
 
 .PHONY: test

--- a/epasses/Makefile
+++ b/epasses/Makefile
@@ -1,20 +1,3 @@
-COREIRCONFIG ?= g++
-CXX ?= g++
-
-ifeq ($(COREIRCONFIG),g++)
-CXX = g++
-endif
-
-ifeq ($(COREIRCONFIG),g++-4.9)
-CXX = g++-4.9
-endif
-
-CXXFLAGS = -std=c++11  -Wall  -fPIC
-
-ifdef COREDEBUG
-CXXFLAGS += -O0 -g3 -D_GLIBCXX_DEBUG 
-endif
-
 HOME = ..
 LPATH = -L$(HOME)/lib
 INCS = -I$(HOME)/include -I.

--- a/src/binary/Makefile
+++ b/src/binary/Makefile
@@ -1,21 +1,4 @@
 .SUFFIXES:
-COREIRCONFIG ?= g++
-CXX ?= g++
-
-ifeq ($(COREIRCONFIG),g++)
-CXX = g++
-endif
-
-ifeq ($(COREIRCONFIG),g++-4.9)
-CXX = g++-4.9
-endif
-
-CXXFLAGS = -std=c++11  -Wall  -fPIC -Werror
-
-ifdef COREDEBUG
-CXXFLAGS += -O0 -g3 -D_GLIBCXX_DEBUG 
-endif
-
 
 HOME = ../..
 INCS = -I$(HOME)/include -I.

--- a/src/coreir-c/Makefile
+++ b/src/coreir-c/Makefile
@@ -1,20 +1,3 @@
-COREIRCONFIG ?= g++
-CXX ?= g++
-
-ifeq ($(COREIRCONFIG),g++)
-CXX = g++
-endif
-
-ifeq ($(COREIRCONFIG),g++-4.9)
-CXX = g++-4.9
-endif
-
-CXXFLAGS = -std=c++11  -Wall  -fPIC
-
-ifdef COREDEBUG
-CXXFLAGS += -O0 -g3 -D_GLIBCXX_DEBUG 
-endif
-
 HOME = ../..
 LPATH = -L$(HOME)/lib
 INCS = -I$(HOME)/include -I.

--- a/src/ir/Makefile
+++ b/src/ir/Makefile
@@ -1,20 +1,3 @@
-COREIRCONFIG ?= g++
-CXX ?= g++
-
-ifeq ($(COREIRCONFIG),g++)
-CXX = g++
-endif
-
-ifeq ($(COREIRCONFIG),g++-4.9)
-CXX = g++-4.9
-endif
-
-CXXFLAGS = -std=c++11  -Wall  -fPIC 
-
-ifdef COREDEBUG
-CXXFLAGS += -O0 -g3 -D_GLIBCXX_DEBUG
-endif
-
 HOME = ../..
 INCS = -I$(HOME)/include -I.
 SRCFILES = $(wildcard [^_]*.cpp)

--- a/src/libs/Makefile
+++ b/src/libs/Makefile
@@ -1,20 +1,3 @@
-COREIRCONFIG ?= g++
-CXX ?= g++
-
-ifeq ($(COREIRCONFIG),g++)
-CXX = g++
-endif
-
-ifeq ($(COREIRCONFIG),g++-4.9)
-CXX = g++-4.9
-endif
-
-CXXFLAGS = -std=c++11  -Wall  -fPIC
-
-ifdef COREDEBUG
-CXXFLAGS += -O0 -g3 -D_GLIBCXX_DEBUG 
-endif
-
 HOME = ../..
 LPATH = -L$(HOME)/lib
 INCS = -I$(HOME)/include -I.

--- a/src/passes/analysis/Makefile
+++ b/src/passes/analysis/Makefile
@@ -1,20 +1,3 @@
-COREIRCONFIG ?= g++
-CXX ?= g++
-
-ifeq ($(COREIRCONFIG),g++)
-CXX = g++
-endif
-
-ifeq ($(COREIRCONFIG),g++-4.9)
-CXX = g++-4.9
-endif
-
-CXXFLAGS = -std=c++11 -Wall -fPIC
-
-ifdef COREDEBUG
-CXXFLAGS += -O0 -g3 -D_GLIBCXX_DEBUG 
-endif
-
 HOME = ../../..
 LPATH = -L$(HOME)/lib
 INCS = -I$(HOME)/include -I.

--- a/src/passes/transform/Makefile
+++ b/src/passes/transform/Makefile
@@ -1,20 +1,3 @@
-COREIRCONFIG ?= g++
-CXX ?= g++
-
-ifeq ($(COREIRCONFIG),g++)
-CXX = g++
-endif
-
-ifeq ($(COREIRCONFIG),g++-4.9)
-CXX = g++-4.9
-endif
-
-CXXFLAGS = -std=c++11  -Wall  -fPIC
-
-ifdef COREDEBUG
-CXXFLAGS += -O0 -g3 -D_GLIBCXX_DEBUG 
-endif
-
 HOME = ../../..
 LPATH = -L$(HOME)/lib
 INCS = -I$(HOME)/include -I.

--- a/tests/cgra/Makefile
+++ b/tests/cgra/Makefile
@@ -1,21 +1,4 @@
 .SUFFIXES:
-COREIRCONFIG ?= g++
-CXX ?= g++
-
-ifeq ($(COREIRCONFIG),g++)
-CXX = g++
-endif
-
-ifeq ($(COREIRCONFIG),g++-4.9)
-CXX = g++-4.9
-endif
-
-CXXFLAGS = -std=c++11  -Wall  -fPIC -Werror
-
-ifdef COREDEBUG
-CXXFLAGS += -O0 -g3 -D_GLIBCXX_DEBUG 
-endif
-
 
 HOME = ../..
 INCS = -I$(HOME)/include -I.

--- a/tests/install/Makefile
+++ b/tests/install/Makefile
@@ -1,20 +1,4 @@
 .SUFFIXES:
-COREIRCONFIG ?= g++
-CXX ?= g++
-
-ifeq ($(COREIRCONFIG),g++)
-CXX = g++
-endif
-
-ifeq ($(COREIRCONFIG),g++-4.9)
-CXX = g++-4.9
-endif
-
-CXXFLAGS = -std=c++11  -Wall  -fPIC -Werror
-
-ifdef COREDEBUG
-CXXFLAGS += -O0 -g3 -D_GLIBCXX_DEBUG 
-endif
 
 LIBS = -lcoreir
 SRCFILES = $(wildcard [^_]*.cpp)

--- a/tests/unit-c/Makefile
+++ b/tests/unit-c/Makefile
@@ -1,21 +1,4 @@
 .SUFFIXES:
-COREIRCONFIG ?= g++
-CXX ?= g++
-
-ifeq ($(COREIRCONFIG),g++)
-CXX = g++
-endif
-
-ifeq ($(COREIRCONFIG),g++-4.9)
-CXX = g++-4.9
-endif
-
-CXXFLAGS = -std=c++11  -Wall  -fPIC -Werror
-CFLAGS = -Wall -fPIC
-
-ifdef COREDEBUG
-CXXFLAGS += -O0 -g3 -D_GLIBCXX_DEBUG 
-endif
 
 HOME = ../..
 INCS = -I$(HOME)/include -I.

--- a/tests/unit/Makefile
+++ b/tests/unit/Makefile
@@ -1,21 +1,4 @@
 .SUFFIXES:
-COREIRCONFIG ?= g++
-CXX ?= g++
-
-ifeq ($(COREIRCONFIG),g++)
-CXX = g++
-endif
-
-ifeq ($(COREIRCONFIG),g++-4.9)
-CXX = g++-4.9
-endif
-
-CXXFLAGS = -std=c++11  -Wall  -fPIC -Werror
-
-ifdef COREDEBUG
-CXXFLAGS += -O0 -g3 -D_GLIBCXX_DEBUG 
-endif
-
 
 HOME = ../..
 INCS = -I$(HOME)/include -I.

--- a/tutorial/hellocounter/Makefile
+++ b/tutorial/hellocounter/Makefile
@@ -1,21 +1,4 @@
 .SUFFIXES:
-COREIRCONFIG ?= g++
-CXX ?= g++
-
-ifeq ($(COREIRCONFIG),g++)
-CXX = g++
-endif
-
-ifeq ($(COREIRCONFIG),g++-4.9)
-CXX = g++-4.9
-endif
-
-CXXFLAGS = -std=c++11  -Wall  -fPIC -Werror
-
-ifdef COREDEBUG
-CXXFLAGS += -O0 -g3 -D_GLIBCXX_DEBUG 
-endif
-
 
 HOME = ../..
 INCS = -I$(HOME)/include -I.

--- a/tutorial/hellopass/Makefile
+++ b/tutorial/hellopass/Makefile
@@ -1,20 +1,3 @@
-COREIRCONFIG ?= g++
-CXX ?= g++
-
-ifeq ($(COREIRCONFIG),g++)
-CXX = g++
-endif
-
-ifeq ($(COREIRCONFIG),g++-4.9)
-CXX = g++-4.9
-endif
-
-CXXFLAGS = -std=c++11  -Wall  -fPIC
-
-ifdef COREDEBUG
-CXXFLAGS += -O0 -g3 -D_GLIBCXX_DEBUG 
-endif
-
 HOME = ../..
 LPATH = -L$(HOME)/lib
 INCS = -I$(HOME)/include -I.


### PR DESCRIPTION
`prefix=foo make install` 
installs coreir to the foo directory

See https://www.gnu.org/software/make/manual/html_node/Setting.html