### PR TITLE
Changed Arg* to be a shared_ptr

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,8 @@ ifeq ($(COREIRCONFIG),g++-4.9)
 CXX = g++-4.9
 endif
 
+CXX=clang++
+
 CFLAGS = -Wall -fPIC
 CXXFLAGS = -std=c++11  -Wall  -fPIC -Werror
 

--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,6 @@ ifeq ($(COREIRCONFIG),g++-4.9)
 CXX = g++-4.9
 endif
 
-CXX=clang++
-
 CFLAGS = -Wall -fPIC
 CXXFLAGS = -std=c++11  -Wall  -fPIC -Werror
 

--- a/include/coreir/ir/args.h
+++ b/include/coreir/ir/args.h
@@ -109,135 +109,37 @@ template<typename T>
 ArgPtr Const_impl(T val);
 
 template<>
-ArgPtr Const_impl<bool>(bool val) {
-  return std::make_shared<ArgBool>(val);
-}
-
+ArgPtr Const_impl<bool>(bool val);
 template<>
-ArgPtr Const_impl<int>(int val) {
-  return std::make_shared<ArgInt>(val);
-}
-
+ArgPtr Const_impl<int>(int val);
 template<>
-ArgPtr Const_impl<std::string>(std::string val) {
-  return std::make_shared<ArgString>(val);
-}
-
+ArgPtr Const_impl<std::string>(std::string val);
 template<>
-ArgPtr Const_impl<Type*>(Type* val) {
-  return std::make_shared<ArgType>(val);
-}
+ArgPtr Const_impl<Type*>(Type* val);
 
 template<typename T>
-struct always_false : std::false_type {};
-
-template<typename T>
-ArgPtr Const(T val) {
-  static_assert(always_false<T>::value,"Must Specialize");
-}
-
-template<>
-ArgPtr Const<bool>(bool val) {
+typename std::enable_if<std::is_same<T,bool>::value,ArgPtr>::type
+Const(T val) {
   return Const_impl<bool>(val);
 }
 
-//template<typename T,typename std::enable_if<std::is_same<T,bool>::value,int>::type=0>
-//ArgPtr Const(T val) {
-//  return Const_impl<bool>(val);
-//}
-
-template<typename T,typename std::enable_if<!std::is_same<T,bool>::value && std::is_convertible<T,int>::value,int>::type=0>
-ArgPtr Const(T val) {
+template<typename T>
+inline typename std::enable_if<!std::is_same<T,bool>::value && std::is_convertible<T,int>::value,ArgPtr>::type
+Const(T val) {
   return Const_impl<int>(val);
 }
 
-//template<>
-//ArgPtr Const<const char*>(const char* val) {
-//  return Const(std::string(val));
-//}
+template<typename T>
+inline typename std::enable_if<std::is_convertible<T,std::string>::value,ArgPtr>::type
+Const(T val) {
+  return Const_impl<std::string>(val);
+}
 
-
-//ArgPtr Const(bool val);
-//ArgPtr Const(int val);
-//ArgPtr Const(unsigned int val);
-//ArgPtr Const(std::string val);
-//ArgPtr Const(const char* val) ;
-//ArgPtr Const(Type* val);
-  
-//
-//template<typename T, typename ConvertT>
-//ArgPtr Const_impl(T val) {
-//  return std::make_shared<typename Val2Arg<ConvertT>::type>(val);
-//}
-//
-//template<typename T, typename ConvertT>
-//ArgPtr Const(T val);
-//
-//template<> 
-//ArgPtr Const<bool,bool>(bool val) {
-//  return Const_impl<bool,bool>(val);
-//}
-//
-//template<typename T,typename std::enable_if<std::is_convertible<T,int>::value,int>::type=0>
-//ArgPtr Const<T,int>(T val) {
-//  return Const_impl<T,int>(val);
-//}
-//
-//template<typename T,typename std::enable_if<std::is_convertible<T,std::string>::value,int>::type=0>
-//ArgPtr Const<T,std::string>(T val) {
-//  return Const_impl<T,std::string>(val);
-//}
-//
-
-
-//
-//template<typename T>
-//ArgPtr Const(T val) {
-//  return Const_impl<T,T>(val);
-//}
-//
-//template<T>
-//ArgPtr Const(T val) {
-//  return Const_impl
-
-//template<typename T, ConverT, typename std::enable_if<std::is_same<T,bool>::value,int>::type=0>
-//ArgPtr Const(T val);
-//
-//template<>
-//ArgPtr Const<bool>(bool val) {
-//  return std::make_shared<ArgBool>(val);
-//}
-//
-//template<typename T,typename std::enable_if<!std::is_same<T,bool>::value && std::is_convertible<T,int>::value,int>::type=0>
-//ArgPtr Const(T val) {
-//  return std::make_shared<ArgInt>(val);
-//}
-
-//template<typename T,typename std::enable_if<std::is_convertible<T,std::string>::value,int>::type=0>
-//ArgPtr Const(T val) {
-//  return std::make_shared<ArgString>(val);
-//}
-//
-//template<typename T,typename std::enable_if<std::is_convertible<T,Type*>::value,int>::type=0>
-//ArgPtr Const(T val) {
-//  return std::make_shared<ArgType>(val);
-//}
-
-
-
-//std::shared_ptr<Arg> Const(bool b) ;
-//std::shared_ptr<Arg> Const(int i);
-//std::shared_ptr<Arg> Const(std::string s);
-//std::shared_ptr<Arg> Const(Type* t);
-
-//class Instantiable;
-//class ArgInst : Arg {
-//  Instantiable* i;
-//  ArgInst(Instantiable* i) : Arg(AINST), i(i) {}
-//};
-
-
-//bool checkArgs(Args args, Params params);
+template<typename T>
+inline typename std::enable_if<std::is_convertible<T,Type*>::value,ArgPtr>::type
+Const(T val) {
+  return Const_impl<Type*>(val);
+}
 
 }//CoreIR namespace
 

--- a/include/coreir/ir/args.h
+++ b/include/coreir/ir/args.h
@@ -86,24 +86,10 @@ class ArgType : public Arg {
 
 bool operator==(const Args& l, const Args& r);
 
-//Factory functions for args
-//template<typename convertFrom,typename convertTo>
-//ArgPtr Const_impl(std::enable_if<std::is_convertible<convertFrom,convertTo>::value,convertFrom>::type val) {
-//  return make_shared<convertTo>(val);
-//}
-
-//bool
-//int
-//unsigned int
-//string
-//..
+//The following defines the function
+//ArgPtr Const(T val);
 //
-//Const(true)
-//Const(5)
-//Const(-5)
-//Const("literal")
-
-
+//You can use Const to create a new Arg
 
 template<typename T> 
 ArgPtr Const_impl(T val);

--- a/include/coreir/ir/args.h
+++ b/include/coreir/ir/args.h
@@ -86,6 +86,150 @@ class ArgType : public Arg {
 
 bool operator==(const Args& l, const Args& r);
 
+//Factory functions for args
+//template<typename convertFrom,typename convertTo>
+//ArgPtr Const_impl(std::enable_if<std::is_convertible<convertFrom,convertTo>::value,convertFrom>::type val) {
+//  return make_shared<convertTo>(val);
+//}
+
+//bool
+//int
+//unsigned int
+//string
+//..
+//
+//Const(true)
+//Const(5)
+//Const(-5)
+//Const("literal")
+
+
+
+template<typename T> 
+ArgPtr Const_impl(T val);
+
+template<>
+ArgPtr Const_impl<bool>(bool val) {
+  return std::make_shared<ArgBool>(val);
+}
+
+template<>
+ArgPtr Const_impl<int>(int val) {
+  return std::make_shared<ArgInt>(val);
+}
+
+template<>
+ArgPtr Const_impl<std::string>(std::string val) {
+  return std::make_shared<ArgString>(val);
+}
+
+template<>
+ArgPtr Const_impl<Type*>(Type* val) {
+  return std::make_shared<ArgType>(val);
+}
+
+template<typename T>
+struct always_false : std::false_type {};
+
+template<typename T>
+ArgPtr Const(T val) {
+  static_assert(always_false<T>::value,"Must Specialize");
+}
+
+template<>
+ArgPtr Const<bool>(bool val) {
+  return Const_impl<bool>(val);
+}
+
+//template<typename T,typename std::enable_if<std::is_same<T,bool>::value,int>::type=0>
+//ArgPtr Const(T val) {
+//  return Const_impl<bool>(val);
+//}
+
+template<typename T,typename std::enable_if<!std::is_same<T,bool>::value && std::is_convertible<T,int>::value,int>::type=0>
+ArgPtr Const(T val) {
+  return Const_impl<int>(val);
+}
+
+//template<>
+//ArgPtr Const<const char*>(const char* val) {
+//  return Const(std::string(val));
+//}
+
+
+//ArgPtr Const(bool val);
+//ArgPtr Const(int val);
+//ArgPtr Const(unsigned int val);
+//ArgPtr Const(std::string val);
+//ArgPtr Const(const char* val) ;
+//ArgPtr Const(Type* val);
+  
+//
+//template<typename T, typename ConvertT>
+//ArgPtr Const_impl(T val) {
+//  return std::make_shared<typename Val2Arg<ConvertT>::type>(val);
+//}
+//
+//template<typename T, typename ConvertT>
+//ArgPtr Const(T val);
+//
+//template<> 
+//ArgPtr Const<bool,bool>(bool val) {
+//  return Const_impl<bool,bool>(val);
+//}
+//
+//template<typename T,typename std::enable_if<std::is_convertible<T,int>::value,int>::type=0>
+//ArgPtr Const<T,int>(T val) {
+//  return Const_impl<T,int>(val);
+//}
+//
+//template<typename T,typename std::enable_if<std::is_convertible<T,std::string>::value,int>::type=0>
+//ArgPtr Const<T,std::string>(T val) {
+//  return Const_impl<T,std::string>(val);
+//}
+//
+
+
+//
+//template<typename T>
+//ArgPtr Const(T val) {
+//  return Const_impl<T,T>(val);
+//}
+//
+//template<T>
+//ArgPtr Const(T val) {
+//  return Const_impl
+
+//template<typename T, ConverT, typename std::enable_if<std::is_same<T,bool>::value,int>::type=0>
+//ArgPtr Const(T val);
+//
+//template<>
+//ArgPtr Const<bool>(bool val) {
+//  return std::make_shared<ArgBool>(val);
+//}
+//
+//template<typename T,typename std::enable_if<!std::is_same<T,bool>::value && std::is_convertible<T,int>::value,int>::type=0>
+//ArgPtr Const(T val) {
+//  return std::make_shared<ArgInt>(val);
+//}
+
+//template<typename T,typename std::enable_if<std::is_convertible<T,std::string>::value,int>::type=0>
+//ArgPtr Const(T val) {
+//  return std::make_shared<ArgString>(val);
+//}
+//
+//template<typename T,typename std::enable_if<std::is_convertible<T,Type*>::value,int>::type=0>
+//ArgPtr Const(T val) {
+//  return std::make_shared<ArgType>(val);
+//}
+
+
+
+//std::shared_ptr<Arg> Const(bool b) ;
+//std::shared_ptr<Arg> Const(int i);
+//std::shared_ptr<Arg> Const(std::string s);
+//std::shared_ptr<Arg> Const(Type* t);
+
 //class Instantiable;
 //class ArgInst : Arg {
 //  Instantiable* i;

--- a/include/coreir/ir/casting/casting.h
+++ b/include/coreir/ir/casting/casting.h
@@ -23,6 +23,7 @@
 
 #include "type_traits.h"
 #include <cassert>
+#include <vector>
 
 namespace CoreIR {
 
@@ -39,6 +40,14 @@ template<typename From> struct simplify_type {
 
   // An accessor to get the real value...
   static SimpleType &getSimplifiedValue(From &Val) { return Val; }
+};
+
+
+template<typename From> struct simplify_type<std::shared_ptr<From>> {
+  typedef From SimpleType;
+
+  static SimpleType &getSimplifiedValue(std::shared_ptr<From>& Val) {return *Val;}
+
 };
 
 template<typename From> struct simplify_type<const From> {
@@ -157,6 +166,10 @@ template<class To, class From> struct cast_retty_impl<To, From*> {
   typedef To* ret_type;         // Pointer arg case, return Ty*
 };
 
+//template<class To, class From> struct cast_retty_impl<To, std::shared_ptr<From>> {
+//  typedef std::shared_ptr<To> ret_type;         // Pointer arg case, return Ty*
+//};
+
 template<class To, class From> struct cast_retty_impl<To, const From*> {
   typedef const To* ret_type;   // Constant pointer arg case, return const Ty*
 };
@@ -171,7 +184,7 @@ struct cast_retty_wrap {
   // When the simplified type and the from type are not the same, use the type
   // simplifier to reduce the type, then reuse cast_retty_impl to get the
   // resultant type.
-  typedef typename cast_retty<To, SimpleFrom>::ret_type ret_type;
+  typedef typename std::shared_ptr<To> ret_type;
 };
 
 template<class To, class FromTy>
@@ -189,12 +202,22 @@ struct cast_retty {
 // Ensure the non-simple values are converted using the simplify_type template
 // that may be specialized by smart pointers...
 //
+//template<class To, class From, class SimpleFrom> struct cast_convert_val {
+//  // This is not a simple type, use the template to simplify it...
+//  static typename cast_retty<To, From>::ret_type doit(From &Val) {
+//    return cast_convert_val<To, SimpleFrom,
+//      typename simplify_type<SimpleFrom>::SimpleType>::doit(
+//                          simplify_type<From>::getSimplifiedValue(Val));
+//  }
+//};
+
 template<class To, class From, class SimpleFrom> struct cast_convert_val {
   // This is not a simple type, use the template to simplify it...
   static typename cast_retty<To, From>::ret_type doit(From &Val) {
-    return cast_convert_val<To, SimpleFrom,
-      typename simplify_type<SimpleFrom>::SimpleType>::doit(
-                          simplify_type<From>::getSimplifiedValue(Val));
+    return std::dynamic_pointer_cast<To>(Val);
+//    return cast_convert_val<To, SimpleFrom,
+//      typename simplify_type<SimpleFrom>::SimpleType>::doit(
+//                          simplify_type<From>::getSimplifiedValue(Val));
   }
 };
 

--- a/include/coreir/ir/casting/casting.h
+++ b/include/coreir/ir/casting/casting.h
@@ -166,10 +166,6 @@ template<class To, class From> struct cast_retty_impl<To, From*> {
   typedef To* ret_type;         // Pointer arg case, return Ty*
 };
 
-//template<class To, class From> struct cast_retty_impl<To, std::shared_ptr<From>> {
-//  typedef std::shared_ptr<To> ret_type;         // Pointer arg case, return Ty*
-//};
-
 template<class To, class From> struct cast_retty_impl<To, const From*> {
   typedef const To* ret_type;   // Constant pointer arg case, return const Ty*
 };
@@ -202,22 +198,12 @@ struct cast_retty {
 // Ensure the non-simple values are converted using the simplify_type template
 // that may be specialized by smart pointers...
 //
-//template<class To, class From, class SimpleFrom> struct cast_convert_val {
-//  // This is not a simple type, use the template to simplify it...
-//  static typename cast_retty<To, From>::ret_type doit(From &Val) {
-//    return cast_convert_val<To, SimpleFrom,
-//      typename simplify_type<SimpleFrom>::SimpleType>::doit(
-//                          simplify_type<From>::getSimplifiedValue(Val));
-//  }
-//};
 
+//Assume that any non-simplified type is a smart pointer
 template<class To, class From, class SimpleFrom> struct cast_convert_val {
   // This is not a simple type, use the template to simplify it...
   static typename cast_retty<To, From>::ret_type doit(From &Val) {
     return std::dynamic_pointer_cast<To>(Val);
-//    return cast_convert_val<To, SimpleFrom,
-//      typename simplify_type<SimpleFrom>::SimpleType>::doit(
-//                          simplify_type<From>::getSimplifiedValue(Val));
   }
 };
 

--- a/include/coreir/ir/casting/casting.h
+++ b/include/coreir/ir/casting/casting.h
@@ -23,7 +23,7 @@
 
 #include "type_traits.h"
 #include <cassert>
-#include <vector>
+#include <memory>
 
 namespace CoreIR {
 

--- a/include/coreir/ir/context.h
+++ b/include/coreir/ir/context.h
@@ -21,7 +21,7 @@ class Context {
   //Memory management
   TypeCache* cache;
   
-  std::vector<Arg*> argList;
+  std::unordered_map<void*,ArgPtr> argList;
   std::vector<Args*> argsList;
   std::vector<Arg**> argPtrArrays;
   std::vector<RecordParams*> recordParamsList;
@@ -83,21 +83,20 @@ class Context {
     RecordParams* newRecordParams();
     Params* newParams();
     Args* newArgs();
-    
-    //Factory functions for args
-    Arg* argBool(bool b);
-    Arg* argInt(int i);
-    Arg* argString(std::string s);
-    Arg* argType(Type* t);
 
     //Unique
     std::string getUnique() {
       return "_U" + std::to_string(unique++);
     }
 
+     
+    // C API memory management
+
+    //Saves 
+    void* saveArg(ArgPtr arg);
+    ArgPtr getSavedArg(void*);
     
-
-
+    
     Arg** newArgPtrArray(int size);
     Connection* newConnectionArray(int size);
     Connection** newConnectionPtrArray(int size);

--- a/include/coreir/ir/fwd_declare.h
+++ b/include/coreir/ir/fwd_declare.h
@@ -7,6 +7,7 @@
 #include <map>
 #include <unordered_map>
 #include <unordered_set>
+#include <memory>
 #include <cassert>
 #include <sstream>
 #include <iostream>

--- a/include/coreir/ir/fwd_declare.h
+++ b/include/coreir/ir/fwd_declare.h
@@ -68,7 +68,8 @@ class PassManager;
 typedef enum {AINT=0,ASTRING=1,ATYPE=2,ABOOL=3} Param;
 
 typedef std::map<std::string,Param> Params;
-typedef std::map<std::string,Arg*> Args;
+typedef std::shared_ptr<Arg> ArgPtr;
+typedef std::map<std::string,ArgPtr> Args;
 bool operator==(const Args& l, const Args& r);
 
 //TODO this is a hack solution that should be fixed

--- a/include/coreir/ir/wireable.h
+++ b/include/coreir/ir/wireable.h
@@ -104,9 +104,8 @@ class Instance : public Wireable {
     std::string toString() const;
     json toJson();
     Module* getModuleRef() {return moduleRef;}
-    const std::string& getInstname() { return instname; }
-    Arg* getConfigArg(std::string s);
-    Args getConfigArgs() const {return configargs;}
+    const std::string& getInstname() const { return instname; }
+    const Args& getConfigArgs() const {return configargs;}
     bool hasConfigArgs() {return !configargs.empty();}
     
     //isGen means it is currently an instance of a generator
@@ -118,7 +117,7 @@ class Instance : public Wireable {
     bool wasGen() const { return wasgen;}
     Generator* getGeneratorRef() { return generatorRef;}
     Instantiable* getInstantiableRef();
-    Args getGenArgs() {return genargs;}
+    const Args& getGenArgs() const {return genargs;}
     
     //Returns if it actually ran the generator
     //Runs the generator and changes instance label to Module

--- a/src/coreir-c/args-c.cpp
+++ b/src/coreir-c/args-c.cpp
@@ -26,29 +26,32 @@ extern "C" {
     const string& s = arg->get<string>();
     return s.c_str();
   }
-  
-  //Create Arg for int
-  COREArg* COREArgInt(COREContext* c,int i) {
-    Arg* ga = rcast<Context*>(c)->argInt(i);
-    return rcast<COREArg*>(ga);
-  }
-  
-  //Create Arg for String
-  COREArg* COREArgString(COREContext* c,char* str) {
-    Arg* ga = rcast<Context*>(c)->argString(string(str));
-    return rcast<COREArg*>(ga);
-  }
-
-  //Create Arg for Bool
-  COREArg* COREArgBool(COREContext* c, bool val) {
-    Arg* ga = rcast<Context*>(c)->argBool(val);
-    return rcast<COREArg*>(ga);
-  }
 
   bool COREArgBoolGet(COREArg* a) {
     Arg* arg = rcast<Arg*>(a);
     //Get will assert if wrong arg kind
     return arg->get<bool>();
+  }
+  
+  //Create Arg for int
+  COREArg* COREArgInt(COREContext* c,int i) {
+    ArgPtr ga = Const(i);
+    void* raw = rcast<Context*>(c)->saveArg(ga);
+    return rcast<COREArg*>(raw);
+  }
+  
+  //Create Arg for String
+  COREArg* COREArgString(COREContext* c,char* str) {
+    ArgPtr ga = Const(string(str));
+    void* raw = rcast<Context*>(c)->saveArg(ga);
+    return rcast<COREArg*>(raw);
+  }
+
+  //Create Arg for Bool
+  COREArg* COREArgBool(COREContext* c, bool val) {
+    ArgPtr ga = Const(val);
+    void* raw = rcast<Context*>(c)->saveArg(ga);
+    return rcast<COREArg*>(raw);
   }
 
 }

--- a/src/ir/args.cpp
+++ b/src/ir/args.cpp
@@ -6,6 +6,30 @@ using namespace std;
 
 namespace CoreIR {
 
+//ArgPtr Const(bool val) {
+//  return std::make_shared<ArgBool>(val);
+//}
+//
+//ArgPtr Const(unsigned int val) {
+//  return Const((int)val);
+//}
+//
+//ArgPtr Const(int val) {
+//  return std::make_shared<ArgInt>(val);
+//}
+//
+//ArgPtr Const(std::string val) {
+//  return std::make_shared<ArgString>(val);
+//}
+//
+//ArgPtr Const(const char* val) {
+//  return Const(std::string(val));
+//}
+//
+//ArgPtr Const(Type* val) {
+//  return std::make_shared<ArgType>(val);
+//}
+
 bool Arg::operator==(const Arg& r) const {
   return r.getKind() == this->kind;
 }
@@ -50,6 +74,15 @@ bool operator==(const Args& l, const Args& r) {
 //  }
 //  return true;
 //}
+//template<typename T>
+//ArgPtr Const(T val) {
+//  return make_shared<typename Val2Arg<T>::type>(val);
+//}
+//
+//template ArgPtr Const<bool>(bool);
+//template ArgPtr Const<int>(int);
+//template ArgPtr Const<std::string>(std::string);
+//template ArgPtr Const<Type*>(Type*);
 
 }//CoreIR namespace
 
@@ -62,7 +95,7 @@ size_t std::hash<Args>::operator() (const Args& args) const {
   for (auto it : args) {
     size_t hash = 0;
     hash_combine(hash,it.first);
-    Arg* arg = it.second;
+    auto arg = it.second;
     switch(arg->getKind()) {
       case ASTRING : {
         string arg_s = arg->get<string>();

--- a/src/ir/args.cpp
+++ b/src/ir/args.cpp
@@ -31,46 +31,6 @@ ArgPtr Const_impl<Type*>(Type* val) {
   return Const_impl2<Type*>(val);   
 }
 
-//template<>
-//ArgPtr Const_impl<int>(int val) {
-//  return std::make_shared<ArgInt>(val);
-//}
-//
-//template<>
-//ArgPtr Const_impl<std::string>(std::string val) {
-//  return std::make_shared<ArgString>(val);
-//}
-//
-//template<>
-//ArgPtr Const_impl<Type*>(Type* val) {
-//  return std::make_shared<ArgType>(val);
-//}
-
-
-//ArgPtr Const(bool val) {
-//  return std::make_shared<ArgBool>(val);
-//}
-//
-//ArgPtr Const(unsigned int val) {
-//  return Const((int)val);
-//}
-//
-//ArgPtr Const(int val) {
-//  return std::make_shared<ArgInt>(val);
-//}
-//
-//ArgPtr Const(std::string val) {
-//  return std::make_shared<ArgString>(val);
-//}
-//
-//ArgPtr Const(const char* val) {
-//  return Const(std::string(val));
-//}
-//
-//ArgPtr Const(Type* val) {
-//  return std::make_shared<ArgType>(val);
-//}
-
 bool Arg::operator==(const Arg& r) const {
   return r.getKind() == this->kind;
 }
@@ -105,25 +65,6 @@ bool operator==(const Args& l, const Args& r) {
   }
   return true;
 }
-
-//bool checkArgs(Args args, Params params) {
-//  if (args.size() != params.size()) return false;
-//  for (auto parammap : params) {
-//    auto arg = args.find(parammap.first);
-//    if (arg == args.end()) return false;
-//    if (arg->second->getKind() != parammap.second) return false;
-//  }
-//  return true;
-//}
-//template<typename T>
-//ArgPtr Const(T val) {
-//  return make_shared<typename Val2Arg<T>::type>(val);
-//}
-//
-//template ArgPtr Const<bool>(bool);
-//template ArgPtr Const<int>(int);
-//template ArgPtr Const<std::string>(std::string);
-//template ArgPtr Const<Type*>(Type*);
 
 }//CoreIR namespace
 

--- a/src/ir/args.cpp
+++ b/src/ir/args.cpp
@@ -6,6 +6,47 @@ using namespace std;
 
 namespace CoreIR {
 
+template<typename T>
+ArgPtr Const_impl2(T val) {
+  return std::make_shared<typename Val2Arg<T>::type>(val);
+}
+
+template<>
+ArgPtr Const_impl<bool>(bool val) {
+  return Const_impl2<bool>(val);   
+}
+
+template<>
+ArgPtr Const_impl<int>(int val) {
+  return Const_impl2<int>(val);   
+}
+
+template<>
+ArgPtr Const_impl<std::string>(std::string val) {
+  return Const_impl2<std::string>(val);   
+}
+
+template<>
+ArgPtr Const_impl<Type*>(Type* val) {
+  return Const_impl2<Type*>(val);   
+}
+
+//template<>
+//ArgPtr Const_impl<int>(int val) {
+//  return std::make_shared<ArgInt>(val);
+//}
+//
+//template<>
+//ArgPtr Const_impl<std::string>(std::string val) {
+//  return std::make_shared<ArgString>(val);
+//}
+//
+//template<>
+//ArgPtr Const_impl<Type*>(Type* val) {
+//  return std::make_shared<ArgType>(val);
+//}
+
+
 //ArgPtr Const(bool val) {
 //  return std::make_shared<ArgBool>(val);
 //}

--- a/src/ir/common.cpp
+++ b/src/ir/common.cpp
@@ -84,7 +84,7 @@ void checkArgsAreParams(Args args, Params params) {
   for (auto const &param : params) {
     auto const &arg = args.find(param.first);
     ASSERT(arg != args.end(), "Arg Not found: " + param.first );
-    ASSERT(arg->second->getKind() == param.second,"Param type mismatch for: " + param.first);
+    ASSERT(arg->second->getKind() == param.second,"Param type mismatch for: " + param.first + " (" + Param2Str(arg->second->getKind())+ " vs " + Param2Str(param.second)+")");
   }
 }
 

--- a/src/ir/context.cpp
+++ b/src/ir/context.cpp
@@ -34,7 +34,6 @@ Context::~Context() {
   for (auto it : stringBuffers) free(it);
   for (auto it : directedConnectionPtrArrays) free(it);
   for (auto it : directedInstancePtrArrays) free(it);
-  for (auto it : argList) delete it;
   for (auto it : argPtrArrays) free(it);
 
   delete cache;
@@ -270,25 +269,15 @@ DirectedInstance** Context::newDirectedInstancePtrArray(int size) {
     return arr;
 }
 
-Arg* Context::argBool(bool b) { 
-  Arg* ga = new ArgBool(b); 
-  argList.push_back(ga);
-  return ga;
+void* Context::saveArg(shared_ptr<Arg> arg) { 
+  void* key = arg.get();
+  argList[key] = arg;
+  return key;
 }
-Arg* Context::argInt(int i) { 
-  Arg* ga = new ArgInt(i); 
-  argList.push_back(ga);
-  return ga;
-}
-Arg* Context::argString(string s) { 
-  Arg* ga = new ArgString(s); 
-  argList.push_back(ga);
-  return ga;
-}
-Arg* Context::argType(Type* t) { 
-  Arg* ga = new ArgType(t); 
-  argList.push_back(ga);
-  return ga;
+
+ArgPtr Context::getSavedArg(void* arg) {
+  ASSERT(argList.count(arg),"Missing Arg!");
+  return argList[arg];
 }
 
 Context* newContext() {

--- a/src/ir/coreirprims.hpp
+++ b/src/ir/coreirprims.hpp
@@ -157,8 +157,8 @@ void coreirprims_state(Context* c, Namespace* coreirprims) {
   TypeGen* regTypeGen = coreirprims->newTypeGen("regType",regGenParams,regFun);
 
   auto reg = coreirprims->newGeneratorDecl("reg",regTypeGen,regGenParams,regConfigParams);
-  reg->addDefaultGenArgs({{"en",c->argBool(false)},{"clr",c->argBool(false)},{"rst",c->argBool(false)}});
-  reg->addDefaultConfigArgs({{"init",c->argInt(0)}});
+  reg->addDefaultGenArgs({{"en",Const(false)},{"clr",Const(false)},{"rst",Const(false)}});
+  reg->addDefaultConfigArgs({{"init",Const(0)}});
   
   json jverilog;
   jverilog["parameters"] = {"width","init"};
@@ -203,8 +203,8 @@ void coreirprims_state(Context* c, Namespace* coreirprims) {
   });
   TypeGen* bitRegTypeGen = coreirprims->newTypeGen("bitRegType",bitRegGenParams,bitRegFun);
   auto bitreg = coreirprims->newGeneratorDecl("bitreg",bitRegTypeGen,bitRegGenParams,regConfigParams);
-  bitreg->addDefaultGenArgs({{"en",c->argBool(false)},{"clr",c->argBool(false)},{"rst",c->argBool(false)}});
-  bitreg->addDefaultConfigArgs({{"init",c->argInt(0)}});
+  bitreg->addDefaultGenArgs({{"en",Const(false)},{"clr",Const(false)},{"rst",Const(false)}});
+  bitreg->addDefaultConfigArgs({{"init",Const(0)}});
   
   jverilog["parameters"] = {"init"};
   jverilog["prefix"] = "coreir_";

--- a/src/ir/fileReader.cpp
+++ b/src/ir/fileReader.cpp
@@ -9,6 +9,7 @@
 #include "coreir/ir/instantiable.h"
 #include "coreir/ir/moduledef.h"
 #include "coreir/ir/wireable.h"
+#include "coreir/ir/args.h"
 
 using namespace std;
 
@@ -292,12 +293,12 @@ Args json2Args(Context* c, Params genparams, json j) {
       throw std::runtime_error(key + " does not exist in params!");
     }
     Param kind = genparams.at(key);
-    Arg* g;
+    shared_ptr<Arg> g;
     switch(kind) {
-      case ABOOL : g = c->argBool(j.at(key).get<bool>()); break;
-      case AINT : g = c->argInt(j.at(key).get<int>()); break;
-      case ASTRING : g = c->argString(j.at(key).get<string>()); break;
-      case ATYPE : g = c->argType(json2Type(c,j.at(key))); break;
+      case ABOOL : g = Const(j.at(key).get<bool>()); break;
+      case AINT : g = Const(j.at(key).get<int>()); break;
+      case ASTRING : g = Const(j.at(key).get<string>()); break;
+      case ATYPE : g = Const(json2Type(c,j.at(key))); break;
       default :  throw std::runtime_error(Param2Str(kind) + "is not a valid arg param!");
     }
     gargs[key] = g;

--- a/src/ir/inline.cpp
+++ b/src/ir/inline.cpp
@@ -4,6 +4,7 @@
 #include "coreir/ir/wireable.h"
 #include "coreir/ir/moduledef.h"
 #include "coreir/ir/types.h"
+#include "coreir/ir/args.h"
 
 using namespace std;
 namespace CoreIR {
@@ -134,7 +135,7 @@ Instance* addPassthrough(Wireable* w,string instname) {
   Type* wtype = w->getType();
   
   //Add actual passthrough instance
-  Instance* pt = def->addInstance(instname,c->getGenerator("coreir.passthrough"),{{"type",c->argType(wtype)}});
+  Instance* pt = def->addInstance(instname,c->getGenerator("coreir.passthrough"),{{"type",Const(wtype)}});
   
   unordered_set<Wireable*> completed;
   PTTraverse(def,w,pt->sel("out"),completed);

--- a/src/ir/instantiable.cpp
+++ b/src/ir/instantiable.cpp
@@ -43,6 +43,7 @@ Generator::Generator(Namespace* ns,string name,TypeGen* typegen, Params genparam
     auto const &gen_param = genparams.find(type_param.first);
     ASSERT(gen_param != genparams.end(),"Param not found: " + type_param.first);
     ASSERT(gen_param->second == type_param.second,"Param type mismatch for " + type_param.first);
+    ASSERT(gen_param->second == type_param.second,"Param type mismatch for: " + gen_param->first + " (" + Param2Str(gen_param->second)+ " vs " + Param2Str(type_param.second)+")");
   }
 }
 

--- a/src/ir/wireable.cpp
+++ b/src/ir/wireable.cpp
@@ -198,12 +198,6 @@ string Instance::toString() const {
   return instname;
 }
 
-//TODO this could throw an error. Bad!
-Arg* Instance::getConfigArg(string s) { 
-  ASSERT(configargs.count(s)>0, "ConfigArgs does not contain field: " + s);
-  return configargs.at(s);
-}
-
 Instantiable* Instance::getInstantiableRef() { 
   if (isgen) return generatorRef;
   else return moduleRef;

--- a/src/libs/cgralib.cpp
+++ b/src/libs/cgralib.cpp
@@ -49,17 +49,17 @@ Namespace* CoreIRLoadLibrary_cgralib(Context* c) {
     });
   });
   Generator* PE = cgralib->newGeneratorDecl("PE",cgralib->getTypeGen("PEType"),PEGenParams,PEConfigParams);
-  PE->addDefaultGenArgs({{"width",c->argInt(16)},{"numdataports",c->argInt(2)},{"numbitports",c->argInt(3)}});
+  PE->addDefaultGenArgs({{"width",Const(16)},{"numdataports",Const(2)},{"numbitports",Const(3)}});
   PE->addDefaultConfigArgs({
-      {"LUT_init",c->argInt(0)},
-      {"data0_mode",c->argString("BYPASS")},
-      {"data0_init",c->argInt(0)},
-      {"data1_mode",c->argString("BYPASS")},
-      {"data1_init",c->argInt(0)},
-      {"bit0_mode",c->argString("BYPASS")},
-      {"bit0_init",c->argInt(0)},
-      {"bit1_mode",c->argString("BYPASS")},
-      {"bit2_mode",c->argString("BYPASS")}
+      {"LUT_init",Const(0)},
+      {"data0_mode",Const("BYPASS")},
+      {"data0_init",Const(0)},
+      {"data1_mode",Const("BYPASS")},
+      {"data1_init",Const(0)},
+      {"bit0_mode",Const("BYPASS")},
+      {"bit0_init",Const(0)},
+      {"bit1_mode",Const("BYPASS")},
+      {"bit2_mode",Const("BYPASS")}
   });
 
   //DataPE declaration
@@ -83,12 +83,12 @@ Namespace* CoreIRLoadLibrary_cgralib(Context* c) {
     });
   });
   Generator* DataPE = cgralib->newGeneratorDecl("DataPE",cgralib->getTypeGen("DataPEType"),DataPEGenParams,DataPEConfigParams);
-  DataPE->addDefaultGenArgs({{"width",c->argInt(16)},{"numdataports",c->argInt(2)}});
+  DataPE->addDefaultGenArgs({{"width",Const(16)},{"numdataports",Const(2)}});
   DataPE->addDefaultConfigArgs({
-      {"data0_mode",c->argString("BYPASS")},
-      {"data0_init",c->argInt(0)},
-      {"data1_mode",c->argString("BYPASS")},
-      {"data1_init",c->argInt(0)}
+      {"data0_mode",Const("BYPASS")},
+      {"data0_init",Const(0)},
+      {"data1_mode",Const("BYPASS")},
+      {"data1_init",Const(0)}
   });
   
   //BitPE declaration
@@ -111,12 +111,12 @@ Namespace* CoreIRLoadLibrary_cgralib(Context* c) {
     });
   });
   Generator* BitPE = cgralib->newGeneratorDecl("BitPE",cgralib->getTypeGen("BitPEType"),BitPEGenParams,BitPEConfigParams);
-  BitPE->addDefaultGenArgs({{"numbitports",c->argInt(3)}});
+  BitPE->addDefaultGenArgs({{"numbitports",Const(3)}});
   BitPE->addDefaultConfigArgs({
-    {"bit0_mode",c->argString("BYPASS")},
-    {"bit0_init",c->argInt(0)},
-    {"bit1_mode",c->argString("BYPASS")},
-    {"bit2_mode",c->argString("BYPASS")}
+    {"bit0_mode",Const("BYPASS")},
+    {"bit0_init",Const(0)},
+    {"bit1_mode",Const("BYPASS")},
+    {"bit2_mode",Const("BYPASS")}
   });
 
   //IO Declaration
@@ -144,10 +144,10 @@ Namespace* CoreIRLoadLibrary_cgralib(Context* c) {
     });
   });
   Generator* Mem = cgralib->newGeneratorDecl("Mem",cgralib->getTypeGen("MemType"),MemGenParams,MemConfigParams);
-  Mem->addDefaultGenArgs({{"width",c->argInt(16)},{"depth",c->argInt(1024)}});
+  Mem->addDefaultGenArgs({{"width",Const(16)},{"depth",Const(1024)}});
   Mem->addDefaultConfigArgs({
-    {"fifo_depth",c->argInt(1024)},
-    {"almost_full_cnt",c->argInt(0)}
+    {"fifo_depth",Const(1024)},
+    {"almost_full_cnt",Const(0)}
   });
 
 

--- a/src/libs/commonlib.cpp
+++ b/src/libs/commonlib.cpp
@@ -92,7 +92,7 @@ Namespace* CoreIRLoadLibrary_commonlib(Context* c) {
     Module* logicalNot = coreirprims->getModule("bitnot");
     
     // create necessary hardware
-    Arg* aWidth = c->argInt(width);
+    ArgPtr aWidth = Const(width);
     def->addInstance("equal",equal,{{"width",aWidth}});
     def->addInstance("not",logicalNot);
 
@@ -120,10 +120,10 @@ Namespace* CoreIRLoadLibrary_commonlib(Context* c) {
       Generator* passthrough = stdlib->getGenerator("passthrough");
       Generator* muxN = commonlib->getGenerator("muxn");
     
-      Arg* aWidth = c->argInt(width);
+      ArgPtr aWidth = Const(width);
     
       if (N == 1) {
-        def->addInstance("passthrough",passthrough,{{"type",c->argType(c->BitIn()->Arr(width))}});
+        def->addInstance("passthrough",passthrough,{{"type",Const(c->BitIn()->Arr(width))}});
       }
       else if (N == 2) {
         def->addInstance("join",mux2,{{"width",aWidth}});
@@ -144,8 +144,8 @@ Namespace* CoreIRLoadLibrary_commonlib(Context* c) {
         def->connect({"self","in","sel",to_string(Nbits-1)},{"join","sel"});
 
         cout << "N=" << N << " which has bitwidth " << Nbits << ", breaking into " << Nlargehalf << " and " << Nsmallhalf <<endl;
-        Arg* aNlarge = c->argInt(Nlargehalf);
-        Arg* aNsmall = c->argInt(Nsmallhalf);
+        ArgPtr aNlarge = Const(Nlargehalf);
+        ArgPtr aNsmall = Const(Nsmallhalf);
 
         def->addInstance("muxN_0",muxN,{{"width",aWidth},{"N",aNlarge}});
         def->addInstance("muxN_1",muxN,{{"width",aWidth},{"N",aNsmall}});
@@ -176,11 +176,11 @@ Namespace* CoreIRLoadLibrary_commonlib(Context* c) {
     Namespace* commonlib = c->getNamespace("commonlib");
     Generator* opN = commonlib->getGenerator("opn");
     
-    Arg* aWidth = c->argInt(width);
-    Arg* aOperator = c->argString(op2);
+    ArgPtr aWidth = Const(width);
+    ArgPtr aOperator = Const(op2);
     
     if (N == 1) {
-      def->addInstance("passthrough","coreir.passthrough",{{"type",c->argType(c->BitIn()->Arr(width))}});
+      def->addInstance("passthrough","coreir.passthrough",{{"type",Const(c->BitIn()->Arr(width))}});
     }
     else if (N == 2) {
       def->addInstance("join",op2,{{"width",aWidth}});
@@ -199,8 +199,8 @@ Namespace* CoreIRLoadLibrary_commonlib(Context* c) {
       uint Nsmallhalf = N - Nlargehalf;
 
       cout << "N=" << N << " which has bitwidth " << Nbits << ", breaking into " << Nlargehalf << " and " << Nsmallhalf <<endl;
-      Arg* aNlarge = c->argInt(Nlargehalf);
-      Arg* aNsmall = c->argInt(Nsmallhalf);
+      ArgPtr aNlarge = Const(Nlargehalf);
+      ArgPtr aNsmall = Const(Nsmallhalf);
 
       def->addInstance("opN_0",opN,{{"width",aWidth},{"N",aNlarge},{"operator",aOperator}});
       def->addInstance("opN_1",opN,{{"width",aWidth},{"N",aNsmall},{"operator",aOperator}});
@@ -227,7 +227,7 @@ Namespace* CoreIRLoadLibrary_commonlib(Context* c) {
     });
   });
   Generator* lutN = commonlib->newGeneratorDecl("lutN",commonlib->getTypeGen("lutNType"),lutNParams,{{"init",AINT}});
-  lutN->addDefaultConfigArgs({{"init",c->argInt(0)}});
+  lutN->addDefaultConfigArgs({{"init",Const(0)}});
   
 
   Params MemGenParams = {{"width",AINT},{"depth",AINT}};
@@ -242,7 +242,7 @@ Namespace* CoreIRLoadLibrary_commonlib(Context* c) {
     });
   });
   Generator* lbMem = commonlib->newGeneratorDecl("LinebufferMem",commonlib->getTypeGen("LinebufferMemType"),MemGenParams);
-  lbMem->addDefaultGenArgs({{"width",c->argInt(16)},{"depth",c->argInt(1024)}});
+  lbMem->addDefaultGenArgs({{"width",Const(16)},{"depth",Const(1024)}});
   
   //Fifo Memory. Use this for memory in Fifo mode
   commonlib->newTypeGen("FifoMemType",MemGenParams,[](Context* c, Args args) {
@@ -257,7 +257,7 @@ Namespace* CoreIRLoadLibrary_commonlib(Context* c) {
     });
   });
   Generator* fifoMem = commonlib->newGeneratorDecl("FifoMem",commonlib->getTypeGen("FifoMemType"),MemGenParams,{{"almost_full_cnt",AINT}});
-  fifoMem->addDefaultGenArgs({{"width",c->argInt(16)},{"depth",c->argInt(1024)}});
+  fifoMem->addDefaultGenArgs({{"width",Const(16)},{"depth",Const(1024)}});
 
   //TODO RAM
 
@@ -298,8 +298,9 @@ Namespace* CoreIRLoadLibrary_commonlib(Context* c) {
     assert(image_width > stencil_width);
     assert(bitwidth > 0);
 
-    Arg* aBitwidth = c->argInt(bitwidth);
-    Arg* aImageWidth = c->argInt(image_width);
+    ArgPtr aBitwidth = Const(bitwidth);
+    assert(isa<ArgInt>(aBitwidth));
+    ArgPtr aImageWidth = Const(image_width);
     Namespace* coreirprims = c->getNamespace("coreir");
 
     // create the inital register chain
@@ -325,7 +326,7 @@ Namespace* CoreIRLoadLibrary_commonlib(Context* c) {
       def->addInstance(mem_name,"commonlib.LinebufferMem",{{"width",aBitwidth},{"depth",aImageWidth}});
       def->addInstance(mem_name+"_valid_term", coreirprims->getModule("bitterm"));
       def->connect({mem_name,"valid"},{mem_name+"_valid_term", "in"});
-      def->addInstance(mem_name+"_wen", coreirprims->getModule("bitconst"), {{"value",c->argInt(1)}});
+      def->addInstance(mem_name+"_wen", coreirprims->getModule("bitconst"), {{"value",Const(1)}});
       def->connect({mem_name,"wen"},{mem_name+"_wen", "out"});
 
       // connect the input
@@ -421,14 +422,14 @@ Namespace* CoreIRLoadLibrary_commonlib(Context* c) {
     Generator* const_gen = coreirprims->getGenerator("const");
     
     // create hardware
-    Arg* aBitwidth = c->argInt(width);
-    Arg* aReset = c->argInt(min);
-    def->addInstance("count", reg_gen, {{"width",aBitwidth},{"clr",c->argBool(true)},{"en",c->argBool(true)}},
+    ArgPtr aBitwidth = Const(width);
+    ArgPtr aReset = Const(min);
+    def->addInstance("count", reg_gen, {{"width",aBitwidth},{"clr",Const(true)},{"en",Const(true)}},
                      {{"init",aReset}});
 
-    //def->addInstance("min", const_gen, {{"width",aBitwidth}}, {{"value",c->argInt(min)}});
-    def->addInstance("max", const_gen, {{"width",aBitwidth}}, {{"value",c->argInt(max)}});
-    def->addInstance("inc", const_gen, {{"width",aBitwidth}}, {{"value",c->argInt(inc)}});
+    //def->addInstance("min", const_gen, {{"width",aBitwidth}}, {{"value",Const(min)}});
+    def->addInstance("max", const_gen, {{"width",aBitwidth}}, {{"value",Const(max)}});
+    def->addInstance("inc", const_gen, {{"width",aBitwidth}}, {{"value",Const(inc)}});
     def->addInstance("ult", ult_gen, {{"width",aBitwidth}});
     def->addInstance("add", add_gen, {{"width",aBitwidth}});
     def->addInstance("and", and_mod);

--- a/src/passes/analysis/coreirjson.cpp
+++ b/src/passes/analysis/coreirjson.cpp
@@ -69,7 +69,7 @@ string Params2Json(Params gp) {
 }
 
 string Type2Json(Type* t);
-string Arg2Json(Arg* a) {
+string Arg2Json(shared_ptr<Arg> a) {
   if (auto ab = dyn_cast<ArgBool>(a)) {
     return ab->get() ? "true" : "false";
   }

--- a/src/passes/analysis/firrtl.cpp
+++ b/src/passes/analysis/firrtl.cpp
@@ -122,7 +122,7 @@ bool Passes::Firrtl::runOnInstanceGraphNode(InstanceGraphNode& node) {
   if (isStdlib) {
     //This ugliness is getting an example of a type for coreir generator
     //The 5 does not matter because I am throwing away widths anyways
-    Type* t = cast<Generator>(i)->getTypeGen()->createType(i->getContext(),{{"width",i->getContext()->argInt(5)}});
+    Type* t = cast<Generator>(i)->getTypeGen()->createType(i->getContext(),{{"width",Const(5)}});
     fm = new FModule(name,t,true);
     coreir2firrtl(i,*fm);
   }

--- a/tests/cgra/_linebuffer.cpp
+++ b/tests/cgra/_linebuffer.cpp
@@ -25,10 +25,10 @@ int main() {
   Module* lb33 = c->getGlobal()->newModuleDecl("lb33", lb33Type);
   ModuleDef* def = lb33->newModuleDef();
     def->addInstance("lb33_inst", linebuffer, {
-      {"bitwidth",c->argInt(16)},
-	    {"stencil_width",c->argInt(3)},
-      {"stencil_height",c->argInt(3)},
-			{"image_width",c->argInt(512)}
+      {"bitwidth",Const(16)},
+	    {"stencil_width",Const(3)},
+      {"stencil_height",Const(3)},
+			{"image_width",Const(512)}
     });
     def->connect("self.in", "lb33_inst.in");
     def->connect("self.out", "lb33_inst.out");
@@ -42,9 +42,9 @@ int main() {
 =======
   Module* lb32 = c->getGlobal()->newModuleDecl("lb32", lb32Type);
   ModuleDef* def = lb32->newModuleDef();
-    def->addInstance("lb32_inst", linebuffer, {{"bitwidth",c->argInt(16)},
-	  {"stencil_width",c->argInt(2)},{"stencil_height",c->argInt(3)},
-					   {"image_width",c->argInt(512)}});
+    def->addInstance("lb32_inst", linebuffer, {{"bitwidth",Const(16)},
+	  {"stencil_width",Const(2)},{"stencil_height",Const(3)},
+					   {"image_width",Const(512)}});
     def->connect("self.in", "lb32_inst.in");
     def->connect("self.out", "lb32_inst.out");
   lb32->setDef(def);

--- a/tests/cgra/memexample.cpp
+++ b/tests/cgra/memexample.cpp
@@ -10,19 +10,19 @@ int main() {
   Namespace* cgralib = CoreIRLoadLibrary_cgralib(c);
  
   //Createing a pretty expansive example for caleb
-  Args w16 = {{"width",c->argInt(16)}};
+  Args w16 = {{"width",Const(16)}};
   
   Generator* PE = cgralib->getGenerator("PE");
   Generator* IO = cgralib->getGenerator("IO");
   Generator* Mem = cgralib->getGenerator("Mem");
   Module* Top = c->getGlobal()->newModuleDecl("Top",c->Record());
   ModuleDef* def = Top->newModuleDef();
-    def->addInstance("io0",IO,w16,{{"mode",c->argString("i")}});
-    def->addInstance("p0",PE,{{"width",c->argInt(16)}},{{"op",c->argString("add")}});
+    def->addInstance("io0",IO,w16,{{"mode",Const("i")}});
+    def->addInstance("p0",PE,{{"width",Const(16)}},{{"op",Const("add")}});
   Params MemGenParams = {{"width",AINT},{"depth",AINT}};
-    def->addInstance("m0",Mem,{{"width",c->argInt(16)},{"depth",c->argInt(512)}},{{"mode",c->argString("o")}});
-    def->addInstance("p1",PE,{{"width",c->argInt(16)}},{{"op",c->argString("mult")}});
-    def->addInstance("io1",IO,w16,{{"mode",c->argString("o")}});
+    def->addInstance("m0",Mem,{{"width",Const(16)},{"depth",Const(512)}},{{"mode",Const("o")}});
+    def->addInstance("p1",PE,{{"width",Const(16)}},{{"op",Const("mult")}});
+    def->addInstance("io1",IO,w16,{{"mode",Const("o")}});
     
     def->connect("io0.out","p0.data.in.0");
     def->connect("io0.out","m0.wdata");

--- a/tests/cgra/muxn.cpp
+++ b/tests/cgra/muxn.cpp
@@ -27,7 +27,7 @@ int main() {
   Module* muxN = c->getGlobal()->newModuleDecl("mux_n", muxNType);
   ModuleDef* def = muxN->newModuleDef();
     def->addInstance("muxN_inst", muxn, 
-                     {{"width",c->argInt(16)},{"N",c->argInt(N)}});
+                     {{"width",Const(16)},{"N",Const(N)}});
     def->connect("self.in", "muxN_inst.in");
     def->connect("self.out", "muxN_inst.out");
   muxN->setDef(def);

--- a/tests/cgra/opn.cpp
+++ b/tests/cgra/opn.cpp
@@ -21,7 +21,7 @@ int main() {
   Module* add15 = c->getGlobal()->newModuleDecl("add15", add15Type);
   ModuleDef* def = add15->newModuleDef();
     def->addInstance("add15", opN, 
-                     {{"width",c->argInt(16)},{"N",c->argInt(15)},{"operator",c->argString("coreir.add")}}
+                     {{"width",Const(16)},{"N",Const(15)},{"operator",Const("coreir.add")}}
                      );
     def->connect("self.in", "add15.in");
     def->connect("self.out", "add15.out");

--- a/tests/cgra/regexample.cpp
+++ b/tests/cgra/regexample.cpp
@@ -10,19 +10,19 @@ int main() {
   CoreIRLoadLibrary_cgralib(c);
  
   //Createing a pretty expansive example for caleb
-  Args w16 = {{"width",c->argInt(16)}};
+  Args w16 = {{"width",Const(16)}};
   
   Module* Top = c->getGlobal()->newModuleDecl("Top",c->Record());
   ModuleDef* def = Top->newModuleDef();
-    def->addInstance("io0","cgralib.IO",w16,{{"mode",c->argString("i")}});
+    def->addInstance("io0","cgralib.IO",w16,{{"mode",Const("i")}});
     def->addInstance("r0","coreir.reg",w16);
-    def->addInstance("c0","coreir.const",w16,{{"value",c->argInt(795)}});
-    def->addInstance("p0","cgralib.PE",{{"width",c->argInt(16)}},{{"op",c->argString("add")}});
+    def->addInstance("c0","coreir.const",w16,{{"value",Const(795)}});
+    def->addInstance("p0","cgralib.PE",{{"width",Const(16)}},{{"op",Const("add")}});
     def->addInstance("r1","coreir.reg",w16);
     def->addInstance("r2","coreir.reg",w16);
     def->addInstance("r3","coreir.reg",w16);
     def->addInstance("r4","coreir.reg",w16);
-    def->addInstance("io1","cgralib.IO",w16,{{"mode",c->argString("o")}});
+    def->addInstance("io1","cgralib.IO",w16,{{"mode",Const("o")}});
     
     def->connect("io0.out","r0.in");
     def->connect("c0.out","p0.data.in.0");

--- a/tests/install/saveAndLoad.cpp
+++ b/tests/install/saveAndLoad.cpp
@@ -39,7 +39,7 @@ int main() {
     Generator* add2 = coreir->getGenerator("add");
     Generator* addN = c->getGlobal()->getGenerator("addN");
     
-    Arg* aWidth = c->argInt(width);
+    ArgPtr aWidth = Const(width);
     
     def->addInstance("join",add2,{{"width",aWidth}});
     def->connect("join.out","self.out");
@@ -50,7 +50,7 @@ int main() {
     }
     else {
       //Connect half instances
-      Arg* aN2 = c->argInt(N/2);
+      ArgPtr aN2 = Const(N/2);
       def->addInstance("addN_0",addN,{{"width",aWidth},{"N",aN2}});
       def->addInstance("addN_1",addN,{{"width",aWidth},{"N",aN2}});
       for (uint i=0; i<N/2; ++i) {
@@ -72,9 +72,9 @@ int main() {
   Namespace* coreir = c->getNamespace("coreir");
   Module* add12 = g->newModuleDecl("Add12",add12Type);
   ModuleDef* def = add12->newModuleDef();
-    def->addInstance("add8_upper",addN,{{"width",c->argInt(13)},{"N",c->argInt(8)}});
-    def->addInstance("add4_lower",addN,{{"width",c->argInt(13)},{"N",c->argInt(4)}});
-    def->addInstance("add2_join",coreir->getGenerator("add"),{{"width",c->argInt(13)}});
+    def->addInstance("add8_upper",addN,{{"width",Const(13)},{"N",Const(8)}});
+    def->addInstance("add4_lower",addN,{{"width",Const(13)},{"N",Const(4)}});
+    def->addInstance("add2_join",coreir->getGenerator("add"),{{"width",Const(13)}});
     def->connect("self.in8","add8_upper.in");
     def->connect("self.in4","add4_lower.in");
     def->connect("add8_upper.out","add2_join.in0");

--- a/tests/unit/add4.cpp
+++ b/tests/unit/add4.cpp
@@ -22,9 +22,9 @@ int main() {
   Module* add4_n = g->newModuleDecl("Add4",add4Type);
   ModuleDef* def = add4_n->newModuleDef();
     Wireable* self = def->sel("self");
-    Wireable* add_00 = def->addInstance("add00",add2,{{"width",c->argInt(n)}});
-    Wireable* add_01 = def->addInstance("add01",add2,{{"width",c->argInt(n)}});
-    Wireable* add_1 = def->addInstance("add1",add2,{{"width",c->argInt(n)}});
+    Wireable* add_00 = def->addInstance("add00",add2,{{"width",Const(n)}});
+    Wireable* add_01 = def->addInstance("add01",add2,{{"width",Const(n)}});
+    Wireable* add_1 = def->addInstance("add1",add2,{{"width",Const(n)}});
     
     def->connect(self->sel("in")->sel(0),add_00->sel("in0"));
     def->connect(self->sel("in")->sel(1),add_00->sel("in1"));

--- a/tests/unit/addN.cpp
+++ b/tests/unit/addN.cpp
@@ -39,7 +39,7 @@ int main() {
     Generator* add2 = coreir->getGenerator("add");
     Generator* addN = c->getGlobal()->getGenerator("addN");
     
-    Arg* aWidth = c->argInt(width);
+    ArgPtr aWidth = Const(width);
     
     def->addInstance("join",add2,{{"width",aWidth}});
     def->connect("join.out","self.out");
@@ -50,7 +50,7 @@ int main() {
     }
     else {
       //Connect half instances
-      Arg* aN2 = c->argInt(N/2);
+      ArgPtr aN2 = Const(N/2);
       def->addInstance("addN_0",addN,{{"width",aWidth},{"N",aN2}});
       def->addInstance("addN_1",addN,{{"width",aWidth},{"N",aN2}});
       for (uint i=0; i<N/2; ++i) {
@@ -72,9 +72,9 @@ int main() {
   Namespace* coreir = c->getNamespace("coreir");
   Module* add12 = g->newModuleDecl("Add12",add12Type);
   ModuleDef* def = add12->newModuleDef();
-    def->addInstance("add8_upper",addN,{{"width",c->argInt(13)},{"N",c->argInt(8)}});
-    def->addInstance("add4_lower",addN,{{"width",c->argInt(13)},{"N",c->argInt(4)}});
-    def->addInstance("add2_join",coreir->getGenerator("add"),{{"width",c->argInt(13)}});
+    def->addInstance("add8_upper",addN,{{"width",Const(13)},{"N",Const(8)}});
+    def->addInstance("add4_lower",addN,{{"width",Const(13)},{"N",Const(4)}});
+    def->addInstance("add2_join",coreir->getGenerator("add"),{{"width",Const(13)}});
     def->connect("self.in8","add8_upper.in");
     def->connect("self.in4","add4_lower.in");
     def->connect("add8_upper.out","add2_join.in0");

--- a/tests/unit/argtest.cpp
+++ b/tests/unit/argtest.cpp
@@ -8,10 +8,10 @@ int main() {
   Context* c = newContext();
 
   // TODO should test a bunch of other permutations
-  Args g1 = {{"a",c->argInt(5)},{"b",c->argString("ross")}};
-  Args g2 = {{"a",c->argInt(5)},{"b",c->argString("ross")}};
-  Args g3 = {{"c",c->argInt(5)},{"b",c->argString("ross")}};
-  Args g4 = {{"a",c->argInt(5)},{"b",c->argString("ross")},{"c",c->argType(c->BitIn())}};
+  Args g1 = {{"a",Const(5)},{"b",Const("ross")}};
+  Args g2 = {{"a",Const(5)},{"b",Const("ross")}};
+  Args g3 = {{"c",Const(5)},{"b",Const("ross")}};
+  Args g4 = {{"a",Const(5)},{"b",Const("ross")},{"c",Const(c->BitIn())}};
   assert(g1 == g2);
   checkArgsAreParams(g1,{{"a",AINT},{"b",ASTRING}});
   assert(g1 != g3);

--- a/tests/unit/casting.cpp
+++ b/tests/unit/casting.cpp
@@ -29,10 +29,10 @@ int main() {
 
   //Test casting of ArgBool
   {
-    Arg* a = c->argBool(false);
+    ArgPtr a = Const(false);
     assert(isa<ArgBool>(a));
     assert(a->get<bool>()==false);
-    ArgBool* ac = cast<ArgBool>(a);
+    shared_ptr<ArgBool> ac = cast<ArgBool>(a);
     assert(dyn_cast<Arg>(ac));
     assert(dyn_cast<ArgBool>(a));
     assert(!dyn_cast<ArgString>(a));
@@ -40,10 +40,10 @@ int main() {
   
   //Test casting of ArgInt
   {
-    Arg* a = c->argInt(5);
+    ArgPtr a = Const(5);
     assert(isa<ArgInt>(a));
     assert(a->get<int>()==5);
-    ArgInt* ac = cast<ArgInt>(a);
+    shared_ptr<ArgInt> ac = cast<ArgInt>(a);
     assert(dyn_cast<Arg>(ac));
     assert(dyn_cast<ArgInt>(a));
     assert(!dyn_cast<ArgString>(a));
@@ -51,10 +51,10 @@ int main() {
   
   //Test casting of ArgString
   {
-    Arg* a = c->argString("Ross");
+    ArgPtr a = Const("Ross");
     assert(isa<ArgString>(a));
     assert(a->get<string>()=="Ross");
-    ArgString* ac = cast<ArgString>(a);
+    shared_ptr<ArgString> ac = cast<ArgString>(a);
     assert(dyn_cast<Arg>(ac));
     assert(dyn_cast<ArgString>(a));
     assert(!dyn_cast<ArgType>(a));
@@ -62,10 +62,10 @@ int main() {
   
   //Test casting of ArgType
   {
-    Arg* a = c->argType(c->BitIn());
+    ArgPtr a = Const(c->BitIn());
     assert(isa<ArgType>(a));
     assert(a->get<Type*>()==c->BitIn());
-    ArgType* ac = cast<ArgType>(a);
+    shared_ptr<ArgType> ac = cast<ArgType>(a);
     assert(dyn_cast<Arg>(ac));
     assert(dyn_cast<ArgType>(a));
     assert(!dyn_cast<ArgInt>(a));

--- a/tests/unit/connect.cpp
+++ b/tests/unit/connect.cpp
@@ -12,7 +12,7 @@ int main() {
   
   Namespace* coreir = c->getNamespace("coreir");
   
-  Module* const16 = coreir->getGenerator("const")->getModule({{"width",c->argInt(16)}});
+  Module* const16 = coreir->getGenerator("const")->getModule({{"width",Const(16)}});
  
   // Define Module Type
   Type* mType = c->Record({
@@ -22,7 +22,7 @@ int main() {
   Module* mod = g->newModuleDecl("mod",mType);
   ModuleDef* def = mod->newModuleDef();
     Wireable* self = def->sel("self");
-    Wireable* i0 = def->addInstance("i0",const16,{{"value",c->argInt(23)}});
+    Wireable* i0 = def->addInstance("i0",const16,{{"value",Const(23)}});
     def->connect(i0->sel("out"),self->sel("out"));
     def->connect(i0->sel("out"),self->sel("out"));
     def->connect(self->sel("out"),i0->sel("out"));

--- a/tests/unit/dadd4.cpp
+++ b/tests/unit/dadd4.cpp
@@ -26,9 +26,9 @@ int main() {
   Module* add4_n = g->newModuleDecl("Add4",add4Type);
   ModuleDef* def = add4_n->newModuleDef();
     Wireable* self = def->sel("self");
-    Wireable* add_00 = def->addInstance("add00",add2,{{"width",c->argInt(n)}});
-    Wireable* add_01 = def->addInstance("add01",add2,{{"width",c->argInt(n)}});
-    Wireable* add_1 = def->addInstance("add1",add2,{{"width",c->argInt(n)}});
+    Wireable* add_00 = def->addInstance("add00",add2,{{"width",Const(n)}});
+    Wireable* add_01 = def->addInstance("add01",add2,{{"width",Const(n)}});
+    Wireable* add_1 = def->addInstance("add1",add2,{{"width",Const(n)}});
     
     def->connect(self->sel("in")->sel(0),add_00->sel("in0"));
     def->connect(self->sel("in")->sel(1),add_00->sel("in1"));

--- a/tests/unit/defaulttest.cpp
+++ b/tests/unit/defaulttest.cpp
@@ -42,13 +42,13 @@ int main() {
 
   Generator* d = g->newGeneratorDecl("defaults",g->getTypeGen("default_type"),{{"ga",AINT},{"gb",AINT}},{{"ca",AINT},{"cb",AINT}});
   //Set defaults for ga and ca
-  d->addDefaultGenArgs({{"ga",c->argInt(5)}});
-  d->addDefaultConfigArgs({{"ca",c->argInt(10)}});
+  d->addDefaultGenArgs({{"ga",Const(5)}});
+  d->addDefaultConfigArgs({{"ca",Const(10)}});
 
   Module* tester = g->newModuleDecl("Tester",c->Record());
   ModuleDef* def = tester->newModuleDef();
-    def->addInstance("i0",d,{{"ga",c->argInt(6)},{"gb",c->argInt(7)}},{{"ca",c->argInt(11)},{"cb",c->argInt(12)}});
-    def->addInstance("i1",d,{{"gb",c->argInt(7)}},{{"cb",c->argInt(12)}});
+    def->addInstance("i0",d,{{"ga",Const(6)},{"gb",Const(7)}},{{"ca",Const(11)},{"cb",Const(12)}});
+    def->addInstance("i1",d,{{"gb",Const(7)}},{{"cb",Const(12)}});
   tester->setDef(def);
   tester->print();
  

--- a/tests/unit/inlinetest.cpp
+++ b/tests/unit/inlinetest.cpp
@@ -34,9 +34,9 @@ int main() {
     Namespace* coreir = c->getNamespace("coreir");
     auto add2 = coreir->getGenerator("add");
     Wireable* self = def->sel("self");
-    Wireable* add_00 = def->addInstance("add00",add2,{{"width",c->argInt(n)}});
-    Wireable* add_01 = def->addInstance("add01",add2,{{"width",c->argInt(n)}});
-    Wireable* add_1 = def->addInstance("add1",add2,{{"width",c->argInt(n)}});
+    Wireable* add_00 = def->addInstance("add00",add2,{{"width",Const(n)}});
+    Wireable* add_01 = def->addInstance("add01",add2,{{"width",Const(n)}});
+    Wireable* add_1 = def->addInstance("add1",add2,{{"width",Const(n)}});
     
     def->connect(self->sel("in")->sel(0),add_00->sel("in0"));
     def->connect(self->sel("in")->sel(1),add_00->sel("in1"));
@@ -49,11 +49,11 @@ int main() {
     def->connect(add_1->sel("out"),self->sel("out"));
   });
  
-  Type* t = g->getTypeGen("add4_type")->getType({{"width",c->argInt(13)}});
+  Type* t = g->getTypeGen("add4_type")->getType({{"width",Const(13)}});
   
   Module* add = g->newModuleDecl("Add",t);
   ModuleDef* def = add->newModuleDef();
-    Instance* inst = def->addInstance("i0",add4,{{"width",c->argInt(13)}});
+    Instance* inst = def->addInstance("i0",add4,{{"width",Const(13)}});
     for (uint i=0; i<4; ++i) {
       def->connect(inst->sel("in")->sel(i),def->getInterface()->sel("in")->sel(i));
     }

--- a/tests/unit/mnrpass.cpp
+++ b/tests/unit/mnrpass.cpp
@@ -14,14 +14,14 @@ int main() {
   
   Namespace* sl = c->getNamespace("coreir");
 
-  Args wargs({{"width",c->argInt(19)}});
+  Args wargs({{"width",Const(19)}});
   
   // Define random module with subs
   Module* ms = prj->newModuleDecl("SNRTestSub",c->Record());
   ModuleDef* def = ms->newModuleDef();
-    def->addInstance("c0",sl->getGenerator("const"),wargs,{{"value",c->argInt(5)}});
-    def->addInstance("c1",sl->getGenerator("const"),wargs,{{"value",c->argInt(5)}});
-    def->addInstance("c2",sl->getGenerator("const"),wargs,{{"value",c->argInt(2)}});
+    def->addInstance("c0",sl->getGenerator("const"),wargs,{{"value",Const(5)}});
+    def->addInstance("c1",sl->getGenerator("const"),wargs,{{"value",Const(5)}});
+    def->addInstance("c2",sl->getGenerator("const"),wargs,{{"value",Const(2)}});
     def->addInstance("s0",sl->getGenerator("sub"),wargs);
     def->addInstance("s1",sl->getGenerator("sub"),wargs);
     def->addInstance("m0",sl->getGenerator("mul"),wargs);
@@ -37,9 +37,9 @@ int main() {
   // Define same random module with adds instead of subs and operands switched
   Module* ma = g->newModuleDecl("SNRTestAdd",c->Record());
   def = ma->newModuleDef();
-    def->addInstance("c0",sl->getGenerator("const"),wargs,{{"value",c->argInt(0)}});
-    def->addInstance("c1",sl->getGenerator("const"),wargs,{{"value",c->argInt(1)}});
-    def->addInstance("c2",sl->getGenerator("const"),wargs,{{"value",c->argInt(2)}});
+    def->addInstance("c0",sl->getGenerator("const"),wargs,{{"value",Const(0)}});
+    def->addInstance("c1",sl->getGenerator("const"),wargs,{{"value",Const(1)}});
+    def->addInstance("c2",sl->getGenerator("const"),wargs,{{"value",Const(2)}});
     def->addInstance("a0",sl->getGenerator("add"),wargs);
     def->addInstance("a1",sl->getGenerator("add"),wargs);
     def->addInstance("m0",sl->getGenerator("mul"),wargs);
@@ -81,7 +81,7 @@ int main() {
   Module* patternC = patns->newModuleDecl("cpat",cType);
   pdef = patternC->newModuleDef();
     pdef->addInstance("a0",sl->getGenerator("add"),wargs);
-    pdef->addInstance("c0",sl->getGenerator("const"),wargs,{{"value",c->argInt(31)}});
+    pdef->addInstance("c0",sl->getGenerator("const"),wargs,{{"value",Const(31)}});
     pdef->connect("self.in","a0.in1");
     pdef->connect("c0.out","a0.in0");
     pdef->connect("self.out","a0.out");

--- a/tests/unit/saveAndLoad.cpp
+++ b/tests/unit/saveAndLoad.cpp
@@ -39,7 +39,7 @@ int main() {
     Generator* add2 = coreir->getGenerator("add");
     Generator* addN = c->getGlobal()->getGenerator("addN");
     
-    Arg* aWidth = c->argInt(width);
+    ArgPtr aWidth = Const(width);
     
     def->addInstance("join",add2,{{"width",aWidth}});
     def->connect("join.out","self.out");
@@ -50,7 +50,7 @@ int main() {
     }
     else {
       //Connect half instances
-      Arg* aN2 = c->argInt(N/2);
+      ArgPtr aN2 = Const(N/2);
       def->addInstance("addN_0",addN,{{"width",aWidth},{"N",aN2}});
       def->addInstance("addN_1",addN,{{"width",aWidth},{"N",aN2}});
       for (uint i=0; i<N/2; ++i) {
@@ -72,9 +72,9 @@ int main() {
   Namespace* coreir = c->getNamespace("coreir");
   Module* add12 = g->newModuleDecl("Add12",add12Type);
   ModuleDef* def = add12->newModuleDef();
-    def->addInstance("add8_upper",addN,{{"width",c->argInt(13)},{"N",c->argInt(8)}});
-    def->addInstance("add4_lower",addN,{{"width",c->argInt(13)},{"N",c->argInt(4)}});
-    def->addInstance("add2_join",coreir->getGenerator("add"),{{"width",c->argInt(13)}});
+    def->addInstance("add8_upper",addN,{{"width",Const(13)},{"N",Const(8)}});
+    def->addInstance("add4_lower",addN,{{"width",Const(13)},{"N",Const(4)}});
+    def->addInstance("add2_join",coreir->getGenerator("add"),{{"width",Const(13)}});
     def->connect("self.in8","add8_upper.in");
     def->connect("self.in4","add4_lower.in");
     def->connect("add8_upper.out","add2_join.in0");

--- a/tests/unit/simple.cpp
+++ b/tests/unit/simple.cpp
@@ -6,22 +6,17 @@ using namespace CoreIR;
 int main() {
   Context* c = newContext();
 
-  Namespace* coreir = c->getNamespace("coreir");
- 
   //Type of module 
   Type* addmultType = c->Record({
     {"in",c->Array(16,c->BitIn())},
     {"out",c->Array(16,c->Bit())}
   });
-  Args w16({{"width",c->argInt(16)}});
-  Generator* Add = coreir->getGenerator("add");
-  Generator* Mul = coreir->getGenerator("mul");
-  Generator* Const = coreir->getGenerator("const");
+  Args w16({{"width",Const(16)}});
   Module* addmult = c->getGlobal()->newModuleDecl("addmult",addmultType);
   ModuleDef* def = addmult->newModuleDef();
-    def->addInstance("ai",Add,w16);
-    def->addInstance("mi",Mul,w16);
-    def->addInstance("ci",Const,w16,{{"value",c->argInt(140)}});
+    def->addInstance("ai","coreir.add",w16);
+    def->addInstance("mi","coreir.mul",w16);
+    def->addInstance("ci","coreir.const",w16,{{"value",Const(140)}});
     
     def->connect("self.in","ai.in0");
     def->connect("ci.out","ai.in1");

--- a/tests/unit/typetest.cpp
+++ b/tests/unit/typetest.cpp
@@ -24,9 +24,9 @@ int main() {
   };
 
   g->newNominalTypeGen("int", "intIn",{{"w",AINT}},intTypeFun);
-  Args ga1 = {{"w",c->argInt(16)}};
-  Args ga2 = {{"w",c->argInt(16)}};
-  Args ga3 = {{"w",c->argInt(17)}};
+  Args ga1 = {{"w",Const(16)}};
+  Args ga2 = {{"w",Const(16)}};
+  Args ga3 = {{"w",Const(17)}};
   
   ASSERT(ga1 == ga2,"Equality is bad");
   ASSERT(ga1 != ga3,"not equalit is bad");


### PR DESCRIPTION
This allows me to not have to manage any memory for Args (with the exception of the c api)
This is the first part of a goal of mine to change Arg->Expr which will contain things other than just constants. This will likely eventually involve me creating my own intrusive pointer class (similar to Halide)

You can now call Const(5) in place of c->argInt(5)

Everything else should work the same including casting (That took a bit of work). 

A lot of the changes in the files are just changing Context.arg*() into Const()
