### PR TITLE
Fix error=return-type, control reaches end of non-void function

### DIFF
--- a/src/ir/fileReader.cpp
+++ b/src/ir/fileReader.cpp
@@ -344,6 +344,7 @@ Type* json2Type(Context* c, json jt) {
     else {
       cout << "ERROR NYI!: " << args[0].get<string>() << endl;
       assert(false);
+      return NULL;
     }
   }
   else throw std::runtime_error("Error parsing Type");

--- a/src/passes/analysis/coreirjson.cpp
+++ b/src/passes/analysis/coreirjson.cpp
@@ -84,6 +84,7 @@ string Arg2Json(shared_ptr<Arg> a) {
   }
   else {
     ASSERT(0,"NYI");
+    return NULL;
   }
 }
 


### PR DESCRIPTION
Fixes
```
error: control reaches end of non-void function [-Werror=return-type]
```

Shouldn't really be an issue because assert will cause execution to terminate, but adding a `return NULL` enables it to compile with g++ 6.2.0 on Ubuntu 16.10 (yakkety)