### PR TITLE
Match bitvector operator= with constructor code

### DIFF
--- a/include/coreir/ir/dynamic_bit_vector.h
+++ b/include/coreir/ir/dynamic_bit_vector.h
@@ -76,11 +76,11 @@ namespace bsim {
     	return *this;
       }
 
-      N = other.bitLength();
       bits.resize(other.bits.size());
 
-      for (int i = 0; i < N; i++) {
-    	set(i, other.get(i));
+      N = other.bitLength();
+      for (int i = 0; i < NUM_BYTES(N); i++) {
+        bits[i] = other.bits[i];
       }
 
 


### PR DESCRIPTION
Cargo culted logic from constructor to operator=, needed to make mantle pass, not entirely sure what the difference between these two was, but it seems like they should use the same logic.