### PR TITLE
Args

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ test: build
 	$(MAKE) -C tests
 	cd tests; ./run
 
-installtest: install
+installtest:
 	$(MAKE) -C tests/install
 	cd tests/install; ./run
 	coreir -i examples/counters.json -p flatten

--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,8 @@ CXX = g++-4.9
 endif
 
 CFLAGS = -Wall -fPIC
-CXXFLAGS = -std=c++11 -Wall -fPIC -Werror -ferror-limit=5
-#CXXFLAGS = -std=c++11 -Wall -fPIC -Werror -Wno-error=sign-compare
+#CXXFLAGS = -std=c++11 -Wall -fPIC -Werror -ferror-limit=5
+CXXFLAGS = -std=c++11 -Wall -fPIC -Werror
 
 ifdef COREDEBUG
 CXXFLAGS += -O0 -g3 -D_GLIBCXX_DEBUG

--- a/doc/JsonSpec.md
+++ b/doc/JsonSpec.md
@@ -37,6 +37,8 @@ Module = {
   "type":Type,
   "modparams"?:Parameter,
   "defaultmodargs"?:Values,
+  "genref"?:NamedRef, //Used for generated modules
+  "genargs"?:Values, //'' '' 
   "instances"?:{<instname>:Instance,...},
   "connections"?: Connection[]
 }
@@ -45,6 +47,7 @@ Generator = {
   "typegen":NamedRef
   "genparams":Parameters,
   "defaultgenargs"?:Consts,
+
 }
 
 Instance = {

--- a/examples/counters.json
+++ b/examples/counters.json
@@ -7,42 +7,16 @@
           }],
           "instances": {
             "count0": {"modref": "global.counter"},
-            "count1": {"modref": "global.counter"},
-            "slice0": {
-              "genref": "coreir.slice",
-              "genargs": {"width":["Int", 16], "lo":["Int", 0],"hi":["Int", 8]}
-            },
-            "slice1": {
-              "genref": "coreir.slice",
-              "genargs": {"width":["Int", 16], "lo":["Int", 8],"hi":["Int", 16]}
-            },
-            "cat": {
-              "genref": "coreir.concat",
-              "genargs": {"width0":["Int", 8], "width1":["Int", 8]}
-            },
-            "neg": {
-              "genref": "coreir.neg",
-              "genargs": {"width":["Int", 16]}
-            },
-            "term": {
-              "genref": "coreir.term",
-              "genargs": {"width":["Int", 16]}
-            }
+            "count1": {"modref": "global.counter"}
           },
           "connections": [
-            ["count0.out.4","count1.en"],
-            ["count1.out.8","count0.en"],
-            ["count0.out","slice0.in"],
-            ["count1.out","slice1.in"],
-            ["slice0.out","cat.in0"],
-            ["slice1.out","cat.in1"],
-            ["cat.out","neg.in"],
-            ["neg.out","term.in"]
+            ["count0.out.4","count1.clr"],
+            ["count1.out.8","count0.clr"]
           ]
         },
         "counter": {
           "type": ["Record",{
-            "en": "BitIn",
+            "clr": "BitIn",
             "out": ["Array",16,"Bit"]
           }],
           "instances": {
@@ -53,7 +27,8 @@
             },
             "r": {
               "genref": "mantle.reg",
-              "genargs": {"width":["Int", 16],"has_en":["Bool",true]}
+              "genargs": {"width":["Int", 16],"has_clr":["Bool",true]},
+              "modargs": {"init":[["BitVector",16],55]}
             },
             "a": {
               "genref": "coreir.add",
@@ -65,7 +40,7 @@
             ["r.out","a.in1"],
             ["a.out","r.in"],
             ["r.out","self.out"],
-            ["self.en","r.en"]
+            ["self.clr","r.clr"]
           ]
         }
       }

--- a/include/coreir/ir/context.h
+++ b/include/coreir/ir/context.h
@@ -65,7 +65,7 @@ class Context {
     Module* getModule(std::string ref);
     Generator* getGenerator(std::string ref);
     Instantiable* getInstantiable(std::string ref);
-    std::map<std::string,Namespace*> getNamespaces() {return namespaces;}
+    std::map<std::string,Namespace*> getNamespaces();
     void addPass(Pass* p);
     bool runPasses(std::vector<std::string> order,std::vector<std::string> namespaces= std::vector<std::string>({"global"}));
 

--- a/include/coreir/ir/instancegraph.h
+++ b/include/coreir/ir/instancegraph.h
@@ -14,7 +14,7 @@ class InstanceGraph {
   public :
     InstanceGraph() {}
     ~InstanceGraph() {this->releaseMemory();}
-    void construct(Namespace* ns);
+    void construct(Context* c);
     std::list<InstanceGraphNode*> getSortedNodes() { return sortedNodes;}
     void releaseMemory();
     void sortVisit(InstanceGraphNode* node);

--- a/include/coreir/ir/instantiable.h
+++ b/include/coreir/ir/instantiable.h
@@ -99,7 +99,7 @@ class Args {
   public :
     ~Args();
     Arg* getArg(std::string field) {
-      ASSERT(args.count(field)==0,"Missing arg: " + field);
+      ASSERT(args.count(field),"Missing arg: " + field);
       return args[field];
     }
 };

--- a/include/coreir/ir/instantiable.h
+++ b/include/coreir/ir/instantiable.h
@@ -111,10 +111,10 @@ class Module : public Instantiable, public Args {
   const Params modparams;
   Values defaultModArgs;
 
-
   Generator* g = nullptr;
   Values genargs;
 
+  std::string longname;
   //std::map<std::string,Arg*> moduleargs;
 
   //the directedModule View
@@ -124,10 +124,8 @@ class Module : public Instantiable, public Args {
   std::vector<ModuleDef*> mdefList;
 
   public :
-    Module(Namespace* ns,std::string name, Type* type,Params modparams) : Instantiable(IK_Module,ns,name), Args(modparams), type(type), modparams(modparams) {}
-    Module(Namespace* ns,std::string name, Type* type,Params modparams, Generator* g, Values genargs) : Instantiable(IK_Module,ns,name), Args(modparams), type(type), modparams(modparams), g(g), genargs(genargs) {
-      ASSERT(genargs.size(),"Missing genargs!");
-    }
+    Module(Namespace* ns,std::string name, Type* type,Params modparams) : Instantiable(IK_Module,ns,name), Args(modparams), type(type), modparams(modparams), longname(name) {}
+    Module(Namespace* ns,std::string name, Type* type,Params modparams, Generator* g, Values genargs);
     ~Module();
     static bool classof(const Instantiable* i) {return i->getKind()==IK_Module;}
     bool hasDef() const { return !!def; }
@@ -145,14 +143,14 @@ class Module : public Instantiable, public Args {
     std::string toString() const override;
     Type* getType() { return type;}
     
-    bool generated() { return !!g;}
+    bool generated() const { return !!g;}
     Generator* getGenerator() { return g;}
     Values getGenArgs() { 
       ASSERT(generated(),"This is not a generated module!");
       return genargs;
     }
     bool runGenerator();
-
+    std::string getLongName() const {return longname;}
 
     void print(void) override;
 

--- a/include/coreir/ir/namespace.h
+++ b/include/coreir/ir/namespace.h
@@ -31,7 +31,7 @@ class Namespace {
     ~Namespace();
     const std::string& getName() { return name;}
     Context* getContext() { return c;}
-    std::map<std::string,Module*> getModules() { return moduleList;}
+    std::map<std::string,Module*> getModules();
     std::map<std::string,Generator*> getGenerators() { return generatorList;}
 
     NamedType* newNamedType(std::string name, std::string nameFlip, Type* raw);
@@ -48,7 +48,6 @@ class Namespace {
 
     Generator* newGeneratorDecl(std::string name,TypeGen* typegen, Params genparams);
     Module* newModuleDecl(std::string name, Type* t,Params moduleparams=Params());
-    void addModule(Module* m);
 
     Generator* getGenerator(std::string gname);
     Module* getModule(std::string mname);

--- a/include/coreir/ir/namespace.h
+++ b/include/coreir/ir/namespace.h
@@ -49,6 +49,11 @@ class Namespace {
     Generator* newGeneratorDecl(std::string name,TypeGen* typegen, Params genparams);
     Module* newModuleDecl(std::string name, Type* t,Params moduleparams=Params());
 
+    //Use with caution!!
+    //This will also delete all modules in generator
+    void eraseGenerator(std::string name);
+    void eraseModule(std::string name);
+
     Generator* getGenerator(std::string gname);
     Module* getModule(std::string mname);
     Instantiable* getInstantiable(std::string name);

--- a/include/coreir/ir/passes.h
+++ b/include/coreir/ir/passes.h
@@ -8,7 +8,7 @@ namespace CoreIR {
 class Pass {
   
   public:
-    enum PassKind {PK_Namespace, PK_Module, PK_Instance, PK_InstanceVisitor, PK_InstanceGraph};
+    enum PassKind {PK_Context, PK_Namespace, PK_Module, PK_Instance, PK_InstanceVisitor, PK_InstanceGraph};
   private:
     PassKind kind;
     //Used as the unique identifier for the pass
@@ -45,6 +45,17 @@ class Pass {
 
 typedef Pass* register_pass_t();
 typedef void delete_pass_t(Pass*);
+
+//You can do whatever you want here
+class ContextPass : public Pass {
+  public:
+    explicit ContextPass(std::string name, std::string description, bool isAnalysis=false) : Pass(PK_Context,name,description,isAnalysis) {}
+    static bool classof(const Pass* p) {return p->getKind()==PK_Context;}
+    virtual bool runOnContext(Context* c) = 0;
+    virtual void releaseMemory() override {}
+    virtual void setAnalysisInfo() override {}
+    virtual void print() override {}
+};
 
 //You can do whatever you want here
 class NamespacePass : public Pass {

--- a/include/coreir/ir/passmanager.h
+++ b/include/coreir/ir/passmanager.h
@@ -48,6 +48,7 @@ class PassManager {
     friend class Pass;
     bool runPass(Pass* p);
 
+    bool runContextPass(Pass* p);
     bool runNamespacePass(Pass* p);
     bool runModulePass(Pass* p);
     bool runInstancePass(Pass* p);

--- a/include/coreir/ir/wireable.h
+++ b/include/coreir/ir/wireable.h
@@ -88,18 +88,12 @@ class Interface : public Wireable {
 
 class Instance : public Wireable {
   const std::string instname;
-  Module* moduleRef = nullptr;
-  
+  Module* moduleRef;
   Values modargs;
-  
   bool isgen;
-  bool wasgen = false;
-  Generator* generatorRef = nullptr;
-  Values genargs;
   
   public :
-    Instance(ModuleDef* container, std::string instname, Module* moduleRef, Values modargs=Values());
-    Instance(ModuleDef* container, std::string instname, Generator* generatorRef, Values genargs, Values modargs=Values());
+    Instance(ModuleDef* container, std::string instname, Module* moduleRef, Values modargs);
     static bool classof(const Wireable* w) {return w->getKind()==WK_Instance;}
     std::string toString() const;
     json toJson();
@@ -108,26 +102,14 @@ class Instance : public Wireable {
     const Values& getModArgs() const {return modargs;}
     bool hasModArgs() {return !modargs.empty();}
     
-    //isGen means it is currently an instance of a generator
-    //(Generator has NOT been run)
-    bool isGen() const { return isgen;}
-
-    //wasGen means it Was a generator AND the generator was run.
-    //It still has genargs, but it also is referencing a module now.
-    bool wasGen() const { return wasgen;}
-    Generator* getGeneratorRef() { return generatorRef;}
-    Instantiable* getInstantiableRef();
-    Values getGenArgs() {return genargs;}
+    bool isGen() const;
+    Generator* getGeneratorRef();
+    Values getGenArgs();
     
-    //Returns if it actually ran the generator
-    //Runs the generator and changes instance label to Module
-    //Does NOT add the module to list of namespace modules
-    //Module is owned by the generator. 
-    //Call namespace.addModule(m) to move from generator to namespace
-    bool runGenerator();
-
+    Instantiable* getInstantiableRef();
+    
     void replace(Module* moduleRef, Values modargs=Values());
-    void replace(Generator* generatorRef, Values genargs, Values modargs=Values());
+    //void replace(Generator* generatorRef, Values genargs, Values modargs=Values());
   
   friend class InstanceGraphNode;
 };

--- a/include/coreir/passes/analysis/createinstancegraph.h
+++ b/include/coreir/passes/analysis/createinstancegraph.h
@@ -6,15 +6,15 @@
 namespace CoreIR {
 namespace Passes {
 
-class CreateInstanceGraph : public NamespacePass {
+class CreateInstanceGraph : public ContextPass {
   InstanceGraph* ig = nullptr;
   public :
     static std::string ID;
-    CreateInstanceGraph() : NamespacePass(ID,"Creates the InstanceGraph",true) {
+    CreateInstanceGraph() : ContextPass(ID,"Creates the InstanceGraph",true) {
       ig = new InstanceGraph;
     }
     ~CreateInstanceGraph() { delete ig;}
-    bool runOnNamespace(Namespace* ns) override;
+    bool runOnContext(Context* c) override;
     void releaseMemory() override;
     InstanceGraph* getInstanceGraph() { return ig;}
 };

--- a/include/coreir/passes/analysis/vmodule.h
+++ b/include/coreir/passes/analysis/vmodule.h
@@ -79,6 +79,7 @@ class VModule {
       Type2Ports(t,ports);
     }
     VModule(Module* m) : VModule(m->getName(),m->getType()) {
+      if (m->generated()) this->modname = m->getLongName();
       this->addParams(params,m->getModParams());
       this->addDefaults(paramDefaults,m->getDefaultModArgs());
       this->checkJson(m->getMetaData());
@@ -106,6 +107,7 @@ class VModule {
         }
       }
     }
+    std::string getName() { return modname;}
     bool hasDef() {return stmts.size() > 0 && (interface.size()>0 || ports.size()>0);}
     void addStmt(std::string stmt) { stmts.push_back(stmt); }
     std::string toCommentString() {

--- a/include/coreir/passes/analysis/vmodule.h
+++ b/include/coreir/passes/analysis/vmodule.h
@@ -135,7 +135,10 @@ class VModule {
       }
     }
     std::string toConstString(Value* v) {
-      if (auto iv = dyn_cast<ConstInt>(v)) {
+      if (auto av = dyn_cast<Arg>(v)) {
+        return av->getField();
+      }
+      else if (auto iv = dyn_cast<ConstInt>(v)) {
         return iv->toString();
       }
       else if (auto bv = dyn_cast<ConstBool>(v)) {

--- a/include/coreir/passes/common.h
+++ b/include/coreir/passes/common.h
@@ -21,6 +21,7 @@
 #include "transform/removeunconnected.h"
 #include "transform/liftclockports.h"
 #include "transform/wireclocks.h"
+#include "transform/cullgraph.h"
 
 
 //TODO Macrofy this
@@ -50,6 +51,7 @@ namespace CoreIR {
     pm.addPass(new Passes::RemoveUnconnected());
     pm.addPass(new Passes::LiftClockPorts("liftclockports-coreir",c->Named("coreir.clkIn")));
     pm.addPass(new Passes::WireClocks("wireclocks-coreir",c->Named("coreir.clkIn")));
+    pm.addPass(new Passes::CullGraph());
   }
 }
 

--- a/include/coreir/passes/transform/cullgraph.h
+++ b/include/coreir/passes/transform/cullgraph.h
@@ -1,0 +1,22 @@
+#ifndef COREIR_CULLGRAPH_HPP_
+#define COREIR_CULLGRAPH_HPP_
+
+#include "coreir.h"
+// This will recusrively run all the generators and replace module definitions
+// For every instance, if it is a generator, it 
+
+namespace CoreIR {
+namespace Passes {
+
+
+class CullGraph : public ContextPass {
+  public :
+    static std::string ID;
+    CullGraph() : ContextPass(ID,"Runs all generators") {}
+    bool runOnContext(Context* c);
+};
+
+}
+}
+
+#endif

--- a/include/coreir/passes/transform/rungenerators.h
+++ b/include/coreir/passes/transform/rungenerators.h
@@ -9,11 +9,11 @@ namespace CoreIR {
 namespace Passes {
 
 
-class RunGenerators : public NamespacePass {
+class RunGenerators : public ContextPass {
   public :
     static std::string ID;
-    RunGenerators() : NamespacePass(ID,"Runs all generators") {}
-    bool runOnNamespace(Namespace* ns);
+    RunGenerators() : ContextPass(ID,"Runs all generators") {}
+    bool runOnContext(Context* ns);
 };
 
 }

--- a/src/binary/coreir.cpp
+++ b/src/binary/coreir.cpp
@@ -173,16 +173,16 @@ int main(int argc, char *argv[]) {
     c->setTop(topRef);
   }
 
+  vector<string> namespaces = splitString<vector<string>>(options["n"].as<string>(),',');
+  
   //Load and run passes
   bool modified = false;
   if (options.count("p")) {
     string plist = options["p"].as<string>();
     vector<string> porder = splitString<vector<string>>(plist,',');
-    modified = c->runPasses(porder);
+    modified = c->runPasses(porder,namespaces);
   }
   
-  vector<string> namespaces = splitString<vector<string>>(options["n"].as<string>(),',');
-
   //Output to correct format
   if (outExt=="json") {
     c->runPasses({"coreirjson"},namespaces);
@@ -191,7 +191,7 @@ int main(int argc, char *argv[]) {
   }
   else if (outExt=="fir") {
     CoreIRLoadFirrtl_coreir(c);
-    c->runPasses({"rungenerators","liftclockports-coreir","wireclocks-coreir","firrtl"});
+    c->runPasses({"rungenerators","liftclockports-coreir","wireclocks-coreir","firrtl"},namespaces);
     //Get the analysis pass
     auto fpass = static_cast<Passes::Firrtl*>(c->getPassManager()->getAnalysisPass("firrtl"));
     
@@ -201,7 +201,7 @@ int main(int argc, char *argv[]) {
   else if (outExt=="v") {
     CoreIRLoadVerilog_coreir(c);
     CoreIRLoadVerilog_corebit(c);
-    modified |= c->runPasses({"rungenerators","liftclockports-coreir","wireclocks-coreir","removebulkconnections","flattentypes","verilog"});
+    modified |= c->runPasses({"rungenerators","liftclockports-coreir","wireclocks-coreir","removebulkconnections","flattentypes","verilog"},namespaces);
     auto vpass = static_cast<Passes::Verilog*>(c->getPassManager()->getAnalysisPass("verilog"));
     
     vpass->writeToStream(*sout);

--- a/src/binary/coreir.cpp
+++ b/src/binary/coreir.cpp
@@ -201,7 +201,7 @@ int main(int argc, char *argv[]) {
   else if (outExt=="v") {
     CoreIRLoadVerilog_coreir(c);
     CoreIRLoadVerilog_corebit(c);
-    modified |= c->runPasses({"rungenerators","liftclockports-coreir","wireclocks-coreir","removebulkconnections","flattentypes","verilog"},namespaces);
+    modified |= c->runPasses({"rungenerators","cullgraph","liftclockports-coreir","wireclocks-coreir","removebulkconnections","flattentypes","verilog"},namespaces);
     auto vpass = static_cast<Passes::Verilog*>(c->getPassManager()->getAnalysisPass("verilog"));
     
     vpass->writeToStream(*sout);

--- a/src/definitions/corebitVerilog.hpp
+++ b/src/definitions/corebitVerilog.hpp
@@ -59,7 +59,7 @@ void CoreIRLoadVerilog_corebit(Context* c) {
       string op = it1.first;
       string vbody = it1.second;
       json vjson;
-      vjson["prefix"] = "bitir_";
+      vjson["prefix"] = "corebit_";
       vjson["definition"] = "  assign out = " + vbody + ";";
       if (it0.first!="other") {
         ASSERT(bitIMap.count(it0.first),"missing" + it0.first);

--- a/src/definitions/corebitVerilog.hpp
+++ b/src/definitions/corebitVerilog.hpp
@@ -78,7 +78,7 @@ void CoreIRLoadVerilog_corebit(Context* c) {
   {
     //Term
     json vjson;
-    vjson["prefix"] = "bitir_";
+    vjson["prefix"] = "corebit_";
     vjson["interface"] = bitIMap["term"];
     vjson["definition"] = "";
     bit->getModule("term")->getMetaData()["verilog"] = vjson;

--- a/src/ir/fileReader.cpp
+++ b/src/ir/fileReader.cpp
@@ -21,8 +21,7 @@ typedef map<string,json> jsonmap;
 
 
 Type* json2Type(Context* c, json jt);
-Values json2Values(Context* c, json j);
-Value* json2Value(Context* c, json j);
+Values json2Values(Context* c, json j, Module* m=nullptr);
 ValueType* json2ValueType(Context* c,json j);
 Params json2Params(Context* c,json j);
 
@@ -118,6 +117,7 @@ bool loadFromFile(Context* c, string filename,Module** top) {
       nsqueue.push_back({ns,jns});
     }
     
+    vector<json> genmodqueue;
     //Saves module declaration and the json representing the module
     vector<std::pair<Module*,json>> modqueue;
     for (auto nsq : nsqueue) {
@@ -135,9 +135,14 @@ bool loadFromFile(Context* c, string filename,Module** top) {
           }
           
           json jmod = jmodmap.second;
-          checkJson(jmod,{"type","modparams","defaultmodargs","instances","connections"});
+          checkJson(jmod,{"type","modparams","defaultmodargs","genref","genargs","instances","connections"});
+          if (jmod.count("genref")) {
+            ASSERT(jmod.count("genargs"),"Need Genargs here");
+            //Skip all generator module defs initially
+            genmodqueue.push_back(jmod);
+            continue;
+          }
           Type* t = json2Type(c,jmod.at("type"));
-          
           Params modparams;
           if (jmod.count("modparams")) {
             modparams = json2Params(c,jmod.at("modparams"));
@@ -164,14 +169,10 @@ bool loadFromFile(Context* c, string filename,Module** top) {
           json jgen = jgenmap.second;
           checkJson(jgen,{"typegen","genparams","defaultgenargs"});
           Params genparams = json2Params(c,jgen.at("genparams"));
-          auto tgenref = getRef(jgen.at("typegen").get<string>());
           TypeGen* typegen = c->getTypeGen(jgen.at("typegen").get<string>());
           assert(genparams == typegen->getParams());
           Params modparams;
           Generator* g = ns->newGeneratorDecl(jgenname,typegen,genparams);
-          //if (jgen.count("defaultmodargs")) {
-          //  g->addDefaultModArgs(json2Values(c,modparams,jgen.at("defaultmodargs")));
-          //}
           if (jgen.count("defaultgenargs")) {
             g->addDefaultGenArgs(json2Values(c,jgen.at("defaultgenargs")));
           }
@@ -180,6 +181,11 @@ bool loadFromFile(Context* c, string filename,Module** top) {
           }
         }
       }
+    }
+    for (auto jgenmod : genmodqueue) {
+      Generator* gen = c->getGenerator(jgenmod.at("genref").get<string>());
+      Values genargs = json2Values(c,jgenmod.at("genargs"));
+      modqueue.push_back({gen->getModule(genargs),jgenmod});
     }
     //Now do all the ModuleDefinitions
     for (auto mq : modqueue) {
@@ -200,7 +206,7 @@ bool loadFromFile(Context* c, string filename,Module** top) {
             Module* modRef = getModSymbol(c,jinst.at("modref").get<string>());
             Values modargs;
             if (jinst.count("modargs")) {
-              modargs = json2Values(c,jinst.at("modargs"));
+              modargs = json2Values(c,jinst.at("modargs"),modRef);
             }
             mdef->addInstance(instname,modRef,modargs);
           }
@@ -306,9 +312,15 @@ Params json2Params(Context* c,json j) {
   return g;
 }
 
-Value* json2Value(Context* c, json j) {
+Value* json2Value(Context* c, json j,Module* m) {
   auto jlist = j.get<vector<json>>();
   ValueType* vtype = json2ValueType(c,jlist[0]);
+  if (jlist.size()==3) {
+    //Arg
+    ASSERT(jlist[1].get<string>()=="Arg","Value with json array of size=3 must be an Arg");
+    ASSERT(m,"NYI using Args here");
+    return m->getArg(jlist[2].get<string>());
+  }
   json jval = jlist[1];
   ASSERT(jlist.size()==2,"NYI");
   switch(vtype->getKind()) {
@@ -321,12 +333,12 @@ Value* json2Value(Context* c, json j) {
   }
 }
 
-Values json2Values(Context* c, json j) {
+Values json2Values(Context* c, json j,Module* m) {
   Values values; 
 
   for (auto jmap : j.get<jsonmap>()) {
     string key = jmap.first;
-    values[jmap.first] = json2Value(c,jmap.second);
+    values[jmap.first] = json2Value(c,jmap.second,m);
   }
   return values;
 }

--- a/src/ir/headers/core.hpp
+++ b/src/ir/headers/core.hpp
@@ -282,6 +282,22 @@ Namespace* CoreIRLoadHeader_core(Context* c) {
   core_convert(c,core);
 
 
+  Params passthroughParams({
+    {"type",CoreIRType::make(c)},
+  });
+  TypeGen* passthroughTG = core->newTypeGen(
+    "passthrough",
+    passthroughParams,
+    [](Context* c, Values args) {
+      Type* t = args.at("type")->get<Type*>();
+      return c->Record({
+        {"in",t->getFlipped()},
+        {"out",t}
+      });
+    }
+  );
+  core->newGeneratorDecl("passthrough",passthroughTG,passthroughParams);
+
 
 
   return core;

--- a/src/ir/headers/core.hpp
+++ b/src/ir/headers/core.hpp
@@ -281,24 +281,6 @@ Namespace* CoreIRLoadHeader_core(Context* c) {
   core_convert(c,core);
 
 
-  //TODO for now keep passthrough here.
-
-  //This defines a passthrough module. It is basically a nop that just passes the signal through
-  Params passthroughParams({
-    {"type",CoreIRType::make(c)},
-  });
-  TypeGen* passthroughTG = core->newTypeGen(
-    "passthrough",
-    passthroughParams,
-    [](Context* c, Values args) {
-      Type* t = args.at("type")->get<Type*>();
-      return c->Record({
-        {"in",t->getFlipped()},
-        {"out",t}
-      });
-    }
-  );
-  core->newGeneratorDecl("passthrough",passthroughTG,passthroughParams);
 
 
   return core;

--- a/src/ir/headers/core.hpp
+++ b/src/ir/headers/core.hpp
@@ -52,6 +52,14 @@ void core_convert(Context* c, Namespace* core) {
 void core_state(Context* c, Namespace* core) {
 
   Params widthparams = Params({{"width",c->Int()}});
+  auto regRstModParamFun = [](Context* c,Values genargs) -> std::pair<Params,Values> {
+    Params modparams;
+    Values defaultargs;
+    int width = genargs.at("width")->get<int>();
+    modparams["init"] = BitVectorType::make(c,width);
+    defaultargs["init"] = Const::make(c,BitVector(width,0));
+    return {modparams,defaultargs};
+  };
 
   //Reg does not have a reset/init
   auto regFun = [](Context* c, Values args) {
@@ -64,7 +72,8 @@ void core_state(Context* c, Namespace* core) {
   };
 
   TypeGen* regTypeGen = core->newTypeGen("regType",widthparams,regFun);
-  core->newGeneratorDecl("reg",regTypeGen,widthparams);
+  auto reg = core->newGeneratorDecl("reg",regTypeGen,widthparams);
+  reg->setModParamsGen(regRstModParamFun);
   
 
 
@@ -78,14 +87,6 @@ void core_state(Context* c, Namespace* core) {
     });
   };
 
-  auto regRstModParamFun = [](Context* c,Values genargs) -> std::pair<Params,Values> {
-    Params modparams;
-    Values defaultargs;
-    int width = genargs.at("width")->get<int>();
-    modparams["init"] = BitVectorType::make(c,width);
-    defaultargs["init"] = Const::make(c,BitVector(width,0));
-    return {modparams,defaultargs};
-  };
 
   TypeGen* regRstTypeGen = core->newTypeGen("regRstType",widthparams,regRstFun);
   auto regRst = core->newGeneratorDecl("regrst",regRstTypeGen,widthparams);

--- a/src/ir/headers/mantle.hpp
+++ b/src/ir/headers/mantle.hpp
@@ -27,11 +27,11 @@ Namespace* CoreIRLoadHeader_mantle(Context* c) {
   auto regModParamFun = [](Context* c,Values genargs) -> std::pair<Params,Values> {
     Params modparams;
     Values defaultargs;
-    if (genargs.at("has_rst")->get<bool>() || genargs.at("has_clr")->get<bool>()) {
+    //if (genargs.at("has_rst")->get<bool>() || genargs.at("has_clr")->get<bool>()) {
       int width = genargs.at("width")->get<int>();
       modparams["init"] = BitVectorType::make(c,width);
       defaultargs["init"] = Const::make(c,BitVector(width,0));
-    }
+    //}
     return {modparams,defaultargs};
   };
 

--- a/src/ir/headers/mantle.hpp
+++ b/src/ir/headers/mantle.hpp
@@ -62,7 +62,7 @@ Namespace* CoreIRLoadHeader_mantle(Context* c) {
       def->connect("reg0.rst","self.rst");
     }
     else {
-      reg = def->addInstance("reg0","coreir.reg",wval);
+      reg = def->addInstance("reg0","coreir.reg",wval,{{"init",def->getModule()->getArg("init")}});
     }
     def->connect("reg0.out","self.out");
     def->connect("reg0.clk","self.clk");
@@ -77,7 +77,7 @@ Namespace* CoreIRLoadHeader_mantle(Context* c) {
     }
     if (clr) {
       auto mux = def->addInstance("clrMux","coreir.mux",wval);
-      auto zero = def->addInstance("c0","coreir.const",wval,{{"value",def->getModule()->getArg("init")}});
+      auto zero = def->addInstance("c0","coreir.const",wval,{{"value",Const::make(c,width,0)}});
       def->connect(mux->sel("out"),toIn);
       def->connect(mux->sel("in1"),zero->sel("out"));
       def->connect(mux->sel("sel"),io->sel("clr"));

--- a/src/ir/headers/mantle.hpp
+++ b/src/ir/headers/mantle.hpp
@@ -27,7 +27,7 @@ Namespace* CoreIRLoadHeader_mantle(Context* c) {
   auto regModParamFun = [](Context* c,Values genargs) -> std::pair<Params,Values> {
     Params modparams;
     Values defaultargs;
-    if (genargs.at("has_rst")->get<bool>() || genargs.at("has_clr")) {
+    if (genargs.at("has_rst")->get<bool>() || genargs.at("has_clr")->get<bool>()) {
       int width = genargs.at("width")->get<int>();
       modparams["init"] = BitVectorType::make(c,width);
       defaultargs["init"] = Const::make(c,BitVector(width,0));
@@ -56,11 +56,9 @@ Namespace* CoreIRLoadHeader_mantle(Context* c) {
     auto io = def->getInterface();
     Values wval({{"width",Const::make(c,width)}});
 
-    //Always instantiate the Register //TODO should this have rst or not
-    //def->connect("reg0.clk","self.clk");
     Wireable* reg;
     if (rst) {
-      reg = def->addInstance("reg0","coreir.regrst",wval);
+      reg = def->addInstance("reg0","coreir.regrst",wval,{{"init",def->getModule()->getArg("init")}});
       def->connect("reg0.rst","self.rst");
     }
     else {
@@ -79,7 +77,7 @@ Namespace* CoreIRLoadHeader_mantle(Context* c) {
     }
     if (clr) {
       auto mux = def->addInstance("clrMux","coreir.mux",wval);
-      auto zero = def->addInstance("c0","coreir.const",wval,{{"value",Const::make(c,BitVector(width,0))}}); //TODO this should reference "init"!!
+      auto zero = def->addInstance("c0","coreir.const",wval,{{"value",def->getModule()->getArg("init")}});
       def->connect(mux->sel("out"),toIn);
       def->connect(mux->sel("in1"),zero->sel("out"));
       def->connect(mux->sel("sel"),io->sel("clr"));

--- a/src/ir/inline.cpp
+++ b/src/ir/inline.cpp
@@ -135,7 +135,7 @@ Instance* addPassthrough(Wireable* w,string instname) {
   Type* wtype = w->getType();
   
   //Add actual passthrough instance
-  Instance* pt = def->addInstance(instname,c->getGenerator("coreir.passthrough"),{{"type",Const::make(c,wtype)}});
+  Instance* pt = def->addInstance(instname,c->getGenerator("_.passthrough"),{{"type",Const::make(c,wtype)}});
   
   unordered_set<Wireable*> completed;
   PTTraverse(def,w,pt->sel("out"),completed);

--- a/src/ir/instancegraph.cpp
+++ b/src/ir/instancegraph.cpp
@@ -22,18 +22,20 @@ void InstanceGraph::sortVisit(InstanceGraphNode* node) {
   sortedNodes.push_front(node);
 }
 
-void InstanceGraph::construct(Namespace* ns) {
+void InstanceGraph::construct(Context* c) {
 
   //Contains all external nodes referenced
   //unordered_map<Instantiable*,InstanceGraphNode*> externalNodeMap;
 
   //Create all Nodes first
-  for (auto imap : ns->getModules()) {
-    nodeMap[imap.second] = new InstanceGraphNode(imap.second,false);
+  for (auto nsmap : c->getNamespaces()) {
+    for (auto imap : nsmap.second->getModules()) {
+      nodeMap[imap.second] = new InstanceGraphNode(imap.second,false);
+    }
   }
-  for (auto imap : ns->getGenerators()) {
-    nodeMap[imap.second] = new InstanceGraphNode(imap.second,false);
-  }
+  //for (auto imap : ns->getGenerators()) {
+  //  nodeMap[imap.second] = new InstanceGraphNode(imap.second,false);
+  //}
 
   //populate all the nodes with pointers to the instances
   unordered_map<Instantiable*,InstanceGraphNode*> nodeMap2;
@@ -46,15 +48,17 @@ void InstanceGraph::construct(Namespace* ns) {
     if (!m->hasDef()) continue;
     ModuleDef* mdef = cast<Module>(nodemap.first)->getDef();
     for (auto instmap : mdef->getInstances()) {
-      Instantiable* icheck = instmap.second->getInstantiableRef();
-      InstanceGraphNode* node;
-      if (nodeMap.count(icheck)==0) {
-        node = new InstanceGraphNode(icheck,true);
-        nodeMap[icheck] = node;
-      }
-      else {
-        node = nodeMap[icheck];
-      }
+      Instantiable* icheck = instmap.second->getModuleRef();
+      ASSERT(nodeMap.count(icheck),"missing: " + icheck->toString());
+      InstanceGraphNode* node = nodeMap[icheck];
+
+      //if (nodeMap.count(icheck)==0) {
+      //  node = new InstanceGraphNode(icheck,true);
+      //  nodeMap[icheck] = node;
+      //}
+      //else {
+      //  node = nodeMap[icheck];
+      //}
 
       node->addInstance(instmap.second,nodemap.second);
     }

--- a/src/ir/instantiable.cpp
+++ b/src/ir/instantiable.cpp
@@ -103,11 +103,10 @@ bool Generator::runAll() {
   }
   return ret;
 }
-
 std::map<std::string,Module*> Generator::getModules() {
   std::map<std::string,Module*> ret; 
   for (auto mpair : genCache) {
-    ret.emplace(mpair.second->getName(),mpair.second);  
+    ret.emplace(mpair.second->getLongName(),mpair.second);  
   }
   return ret;
 }
@@ -138,6 +137,10 @@ string Generator::toString() const {
 
 void Generator::print(void) {
   cout << toString() << endl;
+}
+Module::Module(Namespace* ns,std::string name, Type* type,Params modparams, Generator* g, Values genargs) : Instantiable(IK_Module,ns,name), Args(modparams), type(type), modparams(modparams), g(g), genargs(genargs) {
+  ASSERT(g && genargs.size(),"Missing genargs!");
+  this->longname = name + getContext()->getUnique(); //TODO do a better name
 }
 
 DirectedModule* Module::newDirectedModule() {
@@ -183,7 +186,7 @@ void Module::setDef(ModuleDef* def, bool validate) {
 }
 
 string Module::toString() const {
-  return "Module: " + name + "\n  Type: " + type->toString() + "\n  Def? " + (hasDef() ? "Yes" : "No");
+  return "Module: " + name + (generated() ? Values2Str(genargs) : "") + "\n  Type: " + type->toString() + "\n  Def? " + (hasDef() ? "Yes" : "No");
 }
 
 bool Module::runGenerator() {

--- a/src/ir/instantiable.cpp
+++ b/src/ir/instantiable.cpp
@@ -60,7 +60,7 @@ Generator::~Generator() {
 
 //This is the tough one
 Module* Generator::getModule(Values genargs) {
-  
+  mergeValues(genargs,defaultGenArgs);
   if (genCache.count(genargs)) {
     return genCache[genargs];
   }
@@ -72,16 +72,16 @@ Module* Generator::getModule(Values genargs) {
     modname = nameGen(genargs);
   }
   else {
-    modname = this->name + getContext()->getUnique(); //TODO
+    modname = this->name;// + getContext()->getUnique(); //TODO create better name
   }
   Module* m;
   if (modParamsGen) {
-    std::pair<Params,Values> pc = modParamsGen(getContext(),genargs);
-    m = new Module(ns,modname,type,pc.first);
+    auto pc = modParamsGen(getContext(),genargs);
+    m = new Module(ns,modname,type,pc.first,this,genargs);
     m->addDefaultModArgs(pc.second);
   }
   else {
-     m = new Module(ns,modname,type);
+     m = new Module(ns,modname,type,Params(),this,genargs);
   }
   m->setLinkageKind(Instantiable::LK_Generated);
   genCache[genargs] = m;
@@ -89,13 +89,29 @@ Module* Generator::getModule(Values genargs) {
   //TODO I am not sure what the default behavior should be
   //for not having a def
   //Run the generator if it has the def
-  if (this->hasDef()) {
-    ModuleDef* mdef = m->newModuleDef();
-    def->createModuleDef(mdef,genargs); 
-    m->setDef(mdef);
-  }
+  //if (this->hasDef()) {
+  //  ModuleDef* mdef = m->newModuleDef();
+  //  def->createModuleDef(mdef,genargs); 
+  //  m->setDef(mdef);
+  //}
   return m;
 }
+bool Generator::runAll() {
+  bool ret = false;
+  for (auto mpair : genCache) {
+    ret |= mpair.second->runGenerator();
+  }
+  return ret;
+}
+
+std::map<std::string,Module*> Generator::getModules() {
+  std::map<std::string,Module*> ret; 
+  for (auto mpair : genCache) {
+    ret.emplace(mpair.second->getName(),mpair.second);  
+  }
+  return ret;
+}
+
 
 void Generator::setGeneratorDefFromFun(ModuleDefGenFun fun) {
   ASSERT(!def,"Do you really want to overwrite the def? No.");
@@ -117,6 +133,8 @@ string Generator::toString() const {
   ret = ret + "\n    Def? " + (hasDef() ? "Yes" : "No");
   return ret;
 }
+
+
 
 void Generator::print(void) {
   cout << toString() << endl;
@@ -166,6 +184,17 @@ void Module::setDef(ModuleDef* def, bool validate) {
 
 string Module::toString() const {
   return "Module: " + name + "\n  Type: " + type->toString() + "\n  Def? " + (hasDef() ? "Yes" : "No");
+}
+
+bool Module::runGenerator() {
+  ASSERT(g,"Cannot Run Generator of module that is not gen!");
+  if (!g->hasDef()) return false;
+  if (this->hasDef()) return false;
+  
+  ModuleDef* mdef = this->newModuleDef();
+  g->getDef()->createModuleDef(mdef,genargs); 
+  this->setDef(mdef);
+  return true;
 }
 
 void Module::print(void) {

--- a/src/ir/moduledef.cpp
+++ b/src/ir/moduledef.cpp
@@ -137,10 +137,11 @@ Instance* ModuleDef::getInstancesIterNext(Instance* instance) {
 }
 
 
+ //   Instance(ModuleDef* container, std::string instname, Module* moduleRef, Values modargs);
 Instance* ModuleDef::addInstance(string instname,Generator* gen, Values genargs,Values modargs) {
   ASSERT(instances.count(instname)==0,instname + " already an instance");
 
-  Instance* inst = new Instance(this,instname,gen,genargs,modargs);
+  Instance* inst = new Instance(this,instname,gen->getModule(genargs),modargs);
   instances[instname] = inst;
 
   appendInstanceToIter(inst);

--- a/src/ir/namespace.cpp
+++ b/src/ir/namespace.cpp
@@ -35,9 +35,6 @@ std::map<std::string,Module*> Namespace::getModules() {
   return ret;
 }
 
-
-
-
 NamedType* Namespace::newNamedType(string name, string nameFlip, Type* raw) {
   //Make sure the name and its flip are different
   assert(name != nameFlip);

--- a/src/ir/namespace.cpp
+++ b/src/ir/namespace.cpp
@@ -23,6 +23,21 @@ Namespace::~Namespace() {
   for (auto tg : typeGenList) delete tg.second;
 }
 
+//This will return all modules including all the generated ones
+//TODO 
+std::map<std::string,Module*> Namespace::getModules() { 
+  std::map<std::string,Module*> ret = moduleList;
+  for (auto g : generatorList) {
+    for (auto m : g.second->getModules()) {
+      ret.emplace(m);
+    }
+  }
+  return ret;
+}
+
+
+
+
 NamedType* Namespace::newNamedType(string name, string nameFlip, Type* raw) {
   //Make sure the name and its flip are different
   assert(name != nameFlip);
@@ -146,16 +161,6 @@ Module* Namespace::newModuleDecl(string name, Type* t, Params configparams) {
   Module* m = new Module(this,name,t, configparams);
   moduleList[name] = m;
   return m;
-}
-
-void Namespace::addModule(Module* m) {
-  ASSERT(m->getLinkageKind()==Instantiable::LK_Generated,"Cannot add Namespace module to another namespace!");
-  string name = m->getName();
-  assert(moduleList.count(name)==0);
-  assert(generatorList.count(name)==0);
-  m->setNamespace(this);
-  m->setLinkageKind(Instantiable::LK_Namespace);
-  moduleList[name] = m;
 }
 
 Generator* Namespace::getGenerator(string gname) {

--- a/src/ir/namespace.cpp
+++ b/src/ir/namespace.cpp
@@ -160,6 +160,22 @@ Module* Namespace::newModuleDecl(string name, Type* t, Params configparams) {
   return m;
 }
 
+void Namespace::eraseGenerator(std::string name) {
+  ASSERT(generatorList.count(name),"Cannot delete generator because it does not exist! " + getName() + "." + name);
+  delete generatorList[name];
+  generatorList.erase(name);
+}
+
+void Namespace::eraseModule(std::string name) {
+  ASSERT(moduleList.count(name),"Cannot delete module because it does not exist!" + getName() + "." + name);
+  delete moduleList[name];
+  moduleList.erase(name);
+}
+
+
+
+
+
 Generator* Namespace::getGenerator(string gname) {
   auto it = generatorList.find(gname);
   if (it != generatorList.end()) return it->second;

--- a/src/ir/passmanager.cpp
+++ b/src/ir/passmanager.cpp
@@ -48,6 +48,9 @@ bool PassManager::runNamespacePass(Pass* pass) {
   }
   return modified;
 }
+bool PassManager::runContextPass(Pass* pass) {
+  return cast<ContextPass>(pass)->runOnContext(c);
+}
 
 //Only runs on modules with definitions
 bool PassManager::runModulePass(Pass* pass) {
@@ -115,6 +118,9 @@ bool PassManager::runPass(Pass* p) {
   }
   bool modified = false;
   switch(p->getKind()) {
+    case Pass::PK_Context:
+      modified = runContextPass(p);
+      break;
     case Pass::PK_Namespace:
       modified = runNamespacePass(p);
       break;

--- a/src/ir/passmanager.cpp
+++ b/src/ir/passmanager.cpp
@@ -158,6 +158,11 @@ bool PassManager::run(PassOrder order,vector<string> nsnames) {
     ASSERT(c->hasNamespace(nsname),"Missing namespace: " + nsname);
     this->nss.push_back(c->getNamespace(nsname));
   }
+  //For now just do all namespaces
+  //for (auto ns : c->getNamespaces()) {
+  //  nss.push_back(ns.second);
+  //}
+
   bool ret = false;
   //Execute each in order (and the respective dependencies) independently
   for (auto oname : order) {

--- a/src/ir/wireable.cpp
+++ b/src/ir/wireable.cpp
@@ -158,6 +158,11 @@ Wireable* Wireable::getTopParent() {
   return top;
 }
 
+string Interface::toString() const{
+  return "self";
+}
+
+
 
 Instance::Instance(ModuleDef* container, string instname, Module* moduleRef, Values modargs) : Wireable(WK_Instance,container,nullptr), instname(instname), moduleRef(moduleRef), isgen(false) {
   ASSERT(moduleRef,"Module is null, in inst: " + this->getInstname());
@@ -171,50 +176,19 @@ Instance::Instance(ModuleDef* container, string instname, Module* moduleRef, Val
   this->type = moduleRef->getType();
 }
 
-Instance::Instance(ModuleDef* container, string instname, Generator* generatorRef, Values genargs, Values modargs) : Wireable(WK_Instance,container,nullptr), instname(instname), isgen(true), generatorRef(generatorRef) {
-  ASSERT(generatorRef,"Generator is null, in inst: " + this->getInstname());
-  mergeValues(genargs,generatorRef->getDefaultGenArgs());
-  checkValuesAreParams(genargs,generatorRef->getGenParams());
-  this->genargs = genargs;
-  this->type = generatorRef->getTypeGen()->getType(genargs);
-  ASSERT(isa<RecordType>(this->type),"Generated type needs to be a record but is: " + this->type->toString());
-  auto mpair = generatorRef->getModParams(genargs);
-  mergeValues(modargs,mpair.second);
-  checkValuesAreParams(modargs,mpair.first);
-  this->modargs = modargs;
-}
-
-string Interface::toString() const{
-  return "self";
-}
 
 string Instance::toString() const {
   return instname;
 }
 
 Instantiable* Instance::getInstantiableRef() {
-  if (isgen) return generatorRef;
-  else return moduleRef;
+  if (isGen()) return getGeneratorRef();
+  else return getModuleRef();
 }
+bool Instance::isGen() const { return moduleRef->generated();}
+Generator* Instance::getGeneratorRef() { return moduleRef->getGenerator();} //TODO depreciate
+Values Instance::getGenArgs() {return moduleRef->getGenArgs();}
 
-bool Instance::runGenerator() {
-  ASSERT(generatorRef,"Not a Generator Instanc! in " + this->getInstname());
-  //If we have already run the generator, do not run again
-  if (moduleRef) return false;
-
-  //TODO should this be the default behavior?
-  //If there is no generatorDef, then just do nothing
-  if (!generatorRef->hasDef()) return false;
-
-  //Actually run the generator
-  this->moduleRef = generatorRef->getModule(genargs);
-  assert(moduleRef->hasDef());
-
-  //Change this instance to a Module
-  isgen = false;
-  wasgen = true;
-  return true;
-}
 
 void Instance::replace(Module* moduleRef, Values modargs) {
   ASSERT(!this->isGen(),"NYI, Cannot replace a generator instance with a module isntance")
@@ -227,21 +201,21 @@ void Instance::replace(Module* moduleRef, Values modargs) {
 
 //TODO this is probably super unsafe and will leak memory
 //TODO I do not think this deals with default args
-void Instance::replace(Generator* generatorRef, Values genargs, Values modargs) {
-  ASSERT(generatorRef,"Generator is null! in inst: " + this->getInstname());
-  ASSERT(this->isGen(),"NYI, Cannot replace a generator instance with a module isntance");
-
-  this->generatorRef = generatorRef;
-  checkValuesAreParams(genargs,generatorRef->getGenParams());
-  this->genargs = genargs;
-  Type* newType = generatorRef->getTypeGen()->getType(genargs);
-  ASSERT(this->getType() == newType,"NYI, Cannot replace with a different type");
-  
-  auto mpair = generatorRef->getModParams(genargs);
-  mergeValues(modargs,mpair.second);
-  checkValuesAreParams(modargs,mpair.first);
-  this->modargs = modargs;
-}
+//void Instance::replace(Generator* generatorRef, Values genargs, Values modargs) {
+//  ASSERT(generatorRef,"Generator is null! in inst: " + this->getInstname());
+//  ASSERT(this->isGen(),"NYI, Cannot replace a generator instance with a module isntance");
+//
+//  this->generatorRef = generatorRef;
+//  checkValuesAreParams(genargs,generatorRef->getGenParams());
+//  this->genargs = genargs;
+//  Type* newType = generatorRef->getTypeGen()->getType(genargs);
+//  ASSERT(this->getType() == newType,"NYI, Cannot replace with a different type");
+//  
+//  auto mpair = generatorRef->getModParams(genargs);
+//  mergeValues(modargs,mpair.second);
+//  checkValuesAreParams(modargs,mpair.first);
+//  this->modargs = modargs;
+//}
 
 
 string Select::toString() const {

--- a/src/libs/commonlib.cpp
+++ b/src/libs/commonlib.cpp
@@ -137,7 +137,7 @@ Namespace* CoreIRLoadLibrary_commonlib(Context* c) {
       Namespace* stdlib = c->getNamespace("coreir");
       Namespace* commonlib = c->getNamespace("commonlib");
       Generator* mux2 = stdlib->getGenerator("mux");
-      Generator* passthrough = stdlib->getGenerator("passthrough");
+      Generator* passthrough = c->getGenerator("_.passthrough");
       Generator* muxN = commonlib->getGenerator("muxn");
 
       Const* aWidth = Const::make(c,width);
@@ -200,7 +200,7 @@ Namespace* CoreIRLoadLibrary_commonlib(Context* c) {
     Const* aOperator = Const::make(c,op2);
 
     if (N == 1) {
-      def->addInstance("passthrough","coreir.passthrough",{{"type",Const::make(c,c->BitIn()->Arr(width))}});
+      def->addInstance("passthrough","_.passthrough",{{"type",Const::make(c,c->BitIn()->Arr(width))}});
     }
     else if (N == 2) {
       def->addInstance("join",op2,{{"width",aWidth}});

--- a/src/libs/commonlib.cpp
+++ b/src/libs/commonlib.cpp
@@ -137,7 +137,7 @@ Namespace* CoreIRLoadLibrary_commonlib(Context* c) {
       Namespace* stdlib = c->getNamespace("coreir");
       Namespace* commonlib = c->getNamespace("commonlib");
       Generator* mux2 = stdlib->getGenerator("mux");
-      Generator* passthrough = c->getGenerator("_.passthrough");
+      Generator* passthrough = c->getGenerator("coreir.passthrough");
       Generator* muxN = commonlib->getGenerator("muxn");
 
       Const* aWidth = Const::make(c,width);
@@ -200,7 +200,7 @@ Namespace* CoreIRLoadLibrary_commonlib(Context* c) {
     Const* aOperator = Const::make(c,op2);
 
     if (N == 1) {
-      def->addInstance("passthrough","_.passthrough",{{"type",Const::make(c,c->BitIn()->Arr(width))}});
+      def->addInstance("passthrough","coreir.passthrough",{{"type",Const::make(c,c->BitIn()->Arr(width))}});
     }
     else if (N == 2) {
       def->addInstance("join",op2,{{"width",aWidth}});

--- a/src/passes/analysis/coreirjson.cpp
+++ b/src/passes/analysis/coreirjson.cpp
@@ -3,6 +3,7 @@
 #include <set>
 #include <map>
 
+//TODO Write out Generator mod defs
 using namespace CoreIR;
 using namespace std;
 namespace {
@@ -26,6 +27,7 @@ class Dict {
   public:
     Dict(uint i) : ts(tab(i)) {}
     Dict() {}
+    bool isEmpty() { return fields.size()==0;}
     void add(string field,string val) { 
       fields.push_back(quote(field)+":"+val);
       sorted[field] = quote(field)+":"+val;
@@ -81,13 +83,12 @@ string Params2Json(Params gp) {
 string Type2Json(Type* t);
 string Value2Json(Value* v) {
   Array ret;
+  ret.add(ValueType2Json(v->getValueType()));
   if (auto a = dyn_cast<Arg>(v)) {
     ret.add(quote("Arg"));
-    ret.add(ValueType2Json(v->getValueType()));
     ret.add(quote(a->getField()));
   }
   else if (auto con = dyn_cast<Const>(v)) {
-    ret.add(ValueType2Json(v->getValueType()));
     if (auto cb = dyn_cast<ConstBool>(con)) {
       ret.add(cb->get() ? "true" : "false");
     }
@@ -95,7 +96,7 @@ string Value2Json(Value* v) {
       ret.add(to_string(ci->get()));
     }
     else if (auto cbv = dyn_cast<ConstBitVector>(con)) {
-      ret.add(to_string(cbv->get().to_type<int>()));
+      ret.add(to_string(cbv->get().to_type<uint64_t>()));
     }
     else if (auto cs = dyn_cast<ConstString>(con)) {
       ret.add(quote(cs->get()));
@@ -199,6 +200,10 @@ string Connections2Json(Connections& cons) {
 
 string Module2Json(Module* m) {
   Dict j(6);
+  if (m->hasDef() && m->generated()) {
+    j.add("genref",quote(m->getGenerator()->getRefName()));
+    j.add("genargs",Values2Json(m->getGenArgs()));
+  }
   j.add("type",TopType2Json(m->getType()));
   if (!m->getModParams().empty()) {
     j.add("modparams",Params2Json(m->getModParams()));
@@ -242,8 +247,13 @@ bool Passes::CoreIRJson::runOnNamespace(Namespace* ns) {
   Dict jns(2);
   if (!ns->getModules().empty()) {
     Dict jmod(4);
-    for (auto m : ns->getModules()) jmod.add(m.first,Module2Json(m.second));
-    jns.add("modules",jmod.toMultiString());
+    for (auto m : ns->getModules()) {
+      if (m.second->generated() && !m.second->hasDef()) continue;
+      jmod.add(m.first,Module2Json(m.second));
+    }
+    if (!jmod.isEmpty()) {
+      jns.add("modules",jmod.toMultiString());
+    }
   }
   if (!ns->getGenerators().empty()) {
     Dict jgen(4);

--- a/src/passes/analysis/coreirjson.cpp
+++ b/src/passes/analysis/coreirjson.cpp
@@ -248,8 +248,10 @@ bool Passes::CoreIRJson::runOnNamespace(Namespace* ns) {
   if (!ns->getModules().empty()) {
     Dict jmod(4);
     for (auto m : ns->getModules()) {
+      string mname = m.first;
+      if (m.second->generated()) mname = m.second->getGenerator()->getName();
       if (m.second->generated() && !m.second->hasDef()) continue;
-      jmod.add(m.first,Module2Json(m.second));
+      jmod.add(mname,Module2Json(m.second));
     }
     if (!jmod.isEmpty()) {
       jns.add("modules",jmod.toMultiString());

--- a/src/passes/analysis/createinstancegraph.cpp
+++ b/src/passes/analysis/createinstancegraph.cpp
@@ -5,8 +5,8 @@ using namespace CoreIR;
 using namespace std;
 
 std::string Passes::CreateInstanceGraph::ID = "createinstancegraph";
-bool Passes::CreateInstanceGraph::runOnNamespace(Namespace* ns) {
-  ig->construct(ns);
+bool Passes::CreateInstanceGraph::runOnContext(Context* c) {
+  ig->construct(c);
   return false;
 }
 void Passes::CreateInstanceGraph::releaseMemory() {

--- a/src/passes/analysis/verifyflattenedtypes.cpp
+++ b/src/passes/analysis/verifyflattenedtypes.cpp
@@ -26,7 +26,7 @@ bool Passes::VerifyFlattenedTypes::runOnInstanceGraphNode(InstanceGraphNode& nod
     for (auto inst : node.getInstanceList()) {
       for (auto rmap : (cast<RecordType>(inst->getType()))->getRecord()) {
         ASSERT(isBitOrArrOfBits(rmap.second),
-          "{"+inst->getContainer()->getModule()->getRefName()+"}."+inst->getInstname() + "." + rmap.first + " is not flattened!\n  Type is: " + rmap.second->toString()); 
+          "{"+inst->getContainer()->getModule()->getRefName()+"}."+inst->getInstname() + "." + rmap.first + " IS not flattened!\n  Type is: " + rmap.second->toString()); 
       }
     }
   }

--- a/src/passes/analysis/verilog.cpp
+++ b/src/passes/analysis/verilog.cpp
@@ -57,7 +57,7 @@ bool Passes::Verilog::runOnInstanceGraphNode(InstanceGraphNode& node) {
     for (auto rmap : cast<RecordType>(imap.second->getType())->getRecord()) {
       vmod->addStmt(VWireDec(VWire(iname+"_"+rmap.first,rmap.second)));
     }
-    ASSERT(modMap.count(iref),"DEBUG ME: Missing iref");
+    ASSERT(modMap.count(iref),"DEBUG ME: Missing iref " + iref->getRefName());
     vmod->addStmt(modMap[iref]->toInstanceString(inst));
   }
 

--- a/src/passes/analysis/verilog.cpp
+++ b/src/passes/analysis/verilog.cpp
@@ -30,7 +30,7 @@ bool Passes::Verilog::runOnInstanceGraphNode(InstanceGraphNode& node) {
   if (m->generated() && !m->hasDef()) {
     Generator* g = m->getGenerator();
     VModule* vmod;
-    if (modMap.count(g)) {
+    if (modMap.count(g)) { //Slightly hacky doing a cache here. I could just preload this with a GeneratorPass
       vmod = modMap[g];
     }
     else {
@@ -45,7 +45,7 @@ bool Passes::Verilog::runOnInstanceGraphNode(InstanceGraphNode& node) {
   VModule* vmod = new VModule(m);
   modMap[i] = vmod;
   if (vmod->hasDef()) {
-    ASSERT(!m->hasDef(),"Overriding coreir def with verilog def"); //TODO figure out this better
+    ASSERT(!m->hasDef(),"NYI linking error"); //TODO figure out this better
     return false;
   }
   if (!m->hasDef()) {
@@ -60,7 +60,7 @@ bool Passes::Verilog::runOnInstanceGraphNode(InstanceGraphNode& node) {
     string iname = imap.first;
     Instance* inst = imap.second;
     Module* mref = imap.second->getModuleRef();
-    ASSERT(modMap.count(mref),"DEBUG FUCK");
+    ASSERT(modMap.count(mref),"DEBUG ME");
     VModule* vref = modMap[mref];
     vmod->addStmt("  //Wire declarations for instance '" + iname + "' (Module "+ vref->getName() + ")");
     for (auto rmap : cast<RecordType>(imap.second->getType())->getRecord()) {

--- a/src/passes/analysis/verilog.cpp
+++ b/src/passes/analysis/verilog.cpp
@@ -26,15 +26,16 @@ bool Passes::Verilog::runOnInstanceGraphNode(InstanceGraphNode& node) {
   
   //Create a new Vmodule for this node
   Instantiable* i = node.getInstantiable();
-  if (auto g = dyn_cast<Generator>(i)) {
+  Module* m = cast<Module>(i);
+  if (m->generated() && !m->hasDef()) {
+    Generator* g = m->getGenerator();
     auto vmod = new VModule(g);
-    this->modMap[i] = vmod;
+    this->modMap[g] = vmod;
     if (!vmod->hasDef()) {
-      this->external.insert(i);
+      this->external.insert(g);
     }
     return false;
   }
-  Module* m = cast<Module>(i);
   VModule* vmod = new VModule(m);
   modMap[i] = vmod;
   if (vmod->hasDef()) {
@@ -52,7 +53,8 @@ bool Passes::Verilog::runOnInstanceGraphNode(InstanceGraphNode& node) {
   for (auto imap : def->getInstances()) {
     string iname = imap.first;
     Instance* inst = imap.second;
-    Instantiable* iref = imap.second->getInstantiableRef();
+    Module* mref = imap.second->getModuleRef();
+    if (mref->
     vmod->addStmt("  //Wire declarations for instance '" + imap.first + "' (Module "+ iref->getName() + ")");
     for (auto rmap : cast<RecordType>(imap.second->getType())->getRecord()) {
       vmod->addStmt(VWireDec(VWire(iname+"_"+rmap.first,rmap.second)));

--- a/src/passes/analysis/vmodule.cpp
+++ b/src/passes/analysis/vmodule.cpp
@@ -19,7 +19,7 @@ string VModule::toString() {
   
   vector<string> paramstrs;
   for (auto p : params) {
-    string s = "parameter " + p + "=" + (paramDefaults.count(p)>0 ? paramDefaults[p] : "16"); 
+    string s = "parameter " + p + "=" + (paramDefaults.count(p)>0 ? paramDefaults[p] : "1"); 
     paramstrs.push_back(s);
   }
   string pstring = paramstrs.size()>0 ? " #(" + join(paramstrs.begin(),paramstrs.end(),string(", "))+") " : " ";

--- a/src/passes/transform/cullgraph.cpp
+++ b/src/passes/transform/cullgraph.cpp
@@ -1,0 +1,48 @@
+#include "coreir.h"
+#include "coreir/passes/transform/cullgraph.h"
+
+using namespace std;
+using namespace CoreIR;
+
+namespace {
+void recurse(Module* m, set<Instantiable*>& used) {
+  used.insert(m);
+  if (m->generated()) used.insert(m->getGenerator());
+  if (!m->hasDef()) return;
+  for (auto ipair : m->getDef()->getInstances()) {
+    recurse(ipair.second->getModuleRef(),used);
+  }
+}
+}
+
+string Passes::CullGraph::ID = "cullgraph";
+bool Passes::CullGraph::runOnContext(Context* c) {
+  if (!c->hasTop()) return false;
+  //Find a list of all used Modules and Generators
+  set<Instantiable*> used;
+  recurse(c->getTop(),used);
+  
+  set<Instantiable*> toErase;
+  for (auto npair : c->getNamespaces()) {
+    for (auto gpair : npair.second->getGenerators()) {
+      if (used.count(gpair.second)==0) {
+        toErase.insert(gpair.second);
+      }
+    }
+    for (auto mpair : npair.second->getModules()) {
+      if (used.count(mpair.second)==0) {
+        toErase.insert(mpair.second);
+      }
+    }
+  }
+  for (auto i : toErase) {
+    if (auto m = dyn_cast<Module>(i)) {
+      m->getNamespace()->eraseModule(m->getName());
+    }
+    else if (auto g = dyn_cast<Generator>(i)) {
+      g->getNamespace()->eraseGenerator(g->getName());
+    }
+  }
+  return toErase.size()>0;
+  
+}

--- a/src/passes/transform/rungenerators.cpp
+++ b/src/passes/transform/rungenerators.cpp
@@ -39,13 +39,14 @@ using namespace CoreIR;
 //This will be buggy if a generator refers to another generator in another namespace
 string Passes::RunGenerators::ID = "rungenerators";
 bool Passes::RunGenerators::runOnNamespace(Namespace* ns) {
-  
+  cout << "running on ns: " << ns->getName() << endl;
   bool changed = true;
   bool modified = false;
   while (changed) {
     changed = false;
     for (auto gpair : ns->getGenerators()) {
       for (auto mpair : gpair.second->getModules()) {
+        cout << "g: " << mpair.second->getRefName() << Values2Str(mpair.second->getGenArgs()) << endl;
         changed |= mpair.second->runGenerator();
       }
     }

--- a/src/passes/transform/rungenerators.cpp
+++ b/src/passes/transform/rungenerators.cpp
@@ -4,39 +4,6 @@
 using namespace std;
 using namespace CoreIR;
 
-
-// This will recusrively run all the generators and replace module definitions
-// For every instance, if it is a generator, it 
-//bool rungeneratorsRec(Module* m, unordered_set<Module*>& ran, unordered_set<Module*>& toRelease) {
-//  assert(m);
-//  //If I already checked module, then just return
-//  if (ran.count(m) > 0) return false;
-//
-//  // Check if there are runnable generators
-//  // Also insert all modules in the runQueue
-//  bool changed = false;
-//  ModuleDef* mdef = m->getDef();
-//  for (auto instmap : mdef->getInstances() ) {
-//    Instance* inst = instmap.second;
-//    
-//    //If it is a generator, just run the generator
-//    if (inst->isGen()) {
-//      if (inst->runGenerator()) {
-//        assert(!inst->isGen());
-//        assert(inst->wasGen());
-//        toRelease.insert(inst->getModuleRef());
-//        //run recursively on the module instance
-//        rungeneratorsRec(inst->getModuleRef(),ran,toRelease);
-//        changed = true;
-//      }
-//    }
-//
-//  }
-//  ran.insert(m);
-//  return changed;
-//}
-
-//This will be buggy if a generator refers to another generator in another namespace
 string Passes::RunGenerators::ID = "rungenerators";
 bool Passes::RunGenerators::runOnContext(Context* c) {
   cout << "In Run Generators" << endl;
@@ -58,23 +25,3 @@ bool Passes::RunGenerators::runOnContext(Context* c) {
   return modified;
   
 }
-  
-  
-  
- 
-  
-//  //Keep list of modules to be added
-//  unordered_set<Module*> ran;
-//  unordered_set<Module*> toRelease;
-//  bool changed = false;
-//  for (auto mmap : ns->getModules()) {
-//    changed |= rungeneratorsRec(mmap.second,ran,toRelease);
-//  }
-//
-//  //Now that all generators have run. Change module linking type for those
-//  //newly created instances to be namespace
-//  for (auto m : toRelease) {
-//    ns->addModule(m);
-//  }
-//
-//  return changed;

--- a/src/passes/transform/rungenerators.cpp
+++ b/src/passes/transform/rungenerators.cpp
@@ -7,51 +7,71 @@ using namespace CoreIR;
 
 // This will recusrively run all the generators and replace module definitions
 // For every instance, if it is a generator, it 
-bool rungeneratorsRec(Module* m, unordered_set<Module*>& ran, unordered_set<Module*>& toRelease) {
-  assert(m);
-  //If I already checked module, then just return
-  if (ran.count(m) > 0) return false;
+//bool rungeneratorsRec(Module* m, unordered_set<Module*>& ran, unordered_set<Module*>& toRelease) {
+//  assert(m);
+//  //If I already checked module, then just return
+//  if (ran.count(m) > 0) return false;
+//
+//  // Check if there are runnable generators
+//  // Also insert all modules in the runQueue
+//  bool changed = false;
+//  ModuleDef* mdef = m->getDef();
+//  for (auto instmap : mdef->getInstances() ) {
+//    Instance* inst = instmap.second;
+//    
+//    //If it is a generator, just run the generator
+//    if (inst->isGen()) {
+//      if (inst->runGenerator()) {
+//        assert(!inst->isGen());
+//        assert(inst->wasGen());
+//        toRelease.insert(inst->getModuleRef());
+//        //run recursively on the module instance
+//        rungeneratorsRec(inst->getModuleRef(),ran,toRelease);
+//        changed = true;
+//      }
+//    }
+//
+//  }
+//  ran.insert(m);
+//  return changed;
+//}
 
-  // Check if there are runnable generators
-  // Also insert all modules in the runQueue
-  bool changed = false;
-  ModuleDef* mdef = m->getDef();
-  for (auto instmap : mdef->getInstances() ) {
-    Instance* inst = instmap.second;
-    
-    //If it is a generator, just run the generator
-    if (inst->isGen()) {
-      if (inst->runGenerator()) {
-        assert(!inst->isGen());
-        assert(inst->wasGen());
-        toRelease.insert(inst->getModuleRef());
-        //run recursively on the module instance
-        rungeneratorsRec(inst->getModuleRef(),ran,toRelease);
-        changed = true;
-      }
-    }
-
-  }
-  ran.insert(m);
-  return changed;
-}
-
+//This will be buggy if a generator refers to another generator in another namespace
 string Passes::RunGenerators::ID = "rungenerators";
 bool Passes::RunGenerators::runOnNamespace(Namespace* ns) {
-  //Keep list of modules to be added
-  unordered_set<Module*> ran;
-  unordered_set<Module*> toRelease;
-  bool changed = false;
-  for (auto mmap : ns->getModules()) {
-    changed |= rungeneratorsRec(mmap.second,ran,toRelease);
+  
+  bool changed = true;
+  bool modified = false;
+  while (changed) {
+    changed = false;
+    for (auto gpair : ns->getGenerators()) {
+      for (auto mpair : gpair.second->getModules()) {
+        changed |= mpair.second->runGenerator();
+      }
+    }
+    modified |= changed;
   }
 
-  //Now that all generators have run. Change module linking type for those
-  //newly created instances to be namespace
-  for (auto m : toRelease) {
-    ns->addModule(m);
-  }
-
-  return changed;
+  return modified;
+  
 }
-
+  
+  
+  
+ 
+  
+//  //Keep list of modules to be added
+//  unordered_set<Module*> ran;
+//  unordered_set<Module*> toRelease;
+//  bool changed = false;
+//  for (auto mmap : ns->getModules()) {
+//    changed |= rungeneratorsRec(mmap.second,ran,toRelease);
+//  }
+//
+//  //Now that all generators have run. Change module linking type for those
+//  //newly created instances to be namespace
+//  for (auto m : toRelease) {
+//    ns->addModule(m);
+//  }
+//
+//  return changed;

--- a/src/passes/transform/rungenerators.cpp
+++ b/src/passes/transform/rungenerators.cpp
@@ -38,16 +38,18 @@ using namespace CoreIR;
 
 //This will be buggy if a generator refers to another generator in another namespace
 string Passes::RunGenerators::ID = "rungenerators";
-bool Passes::RunGenerators::runOnNamespace(Namespace* ns) {
-  cout << "running on ns: " << ns->getName() << endl;
+bool Passes::RunGenerators::runOnContext(Context* c) {
+  cout << "In Run Generators" << endl;
   bool changed = true;
   bool modified = false;
   while (changed) {
     changed = false;
-    for (auto gpair : ns->getGenerators()) {
-      for (auto mpair : gpair.second->getModules()) {
-        cout << "g: " << mpair.second->getRefName() << Values2Str(mpair.second->getGenArgs()) << endl;
-        changed |= mpair.second->runGenerator();
+    for (auto npair : c->getNamespaces()) {
+      for (auto gpair : npair.second->getGenerators()) {
+        for (auto mpair : gpair.second->getModules()) {
+          cout << "g: " << mpair.second->getRefName() << Values2Str(mpair.second->getGenArgs()) << endl;
+          changed |= mpair.second->runGenerator();
+        }
       }
     }
     modified |= changed;

--- a/tests/unit/addN.cpp
+++ b/tests/unit/addN.cpp
@@ -69,12 +69,11 @@ int main() {
     {"out",c->Bit()->Arr(13)}
   });
 
-  Namespace* coreir = c->getNamespace("coreir");
   Module* add12 = g->newModuleDecl("Add12",add12Type);
   ModuleDef* def = add12->newModuleDef();
     def->addInstance("add8_upper",addN,{{"width",Const::make(c,13)},{"N",Const::make(c,8)}});
     def->addInstance("add4_lower",addN,{{"width",Const::make(c,13)},{"N",Const::make(c,4)}});
-    def->addInstance("add2_join",coreir->getGenerator("add"),{{"width",Const::make(c,13)}});
+    def->addInstance("add2_join","coreir.add",{{"width",Const::make(c,13)}});
     def->connect("self.in8","add8_upper.in");
     def->connect("self.in4","add4_lower.in");
     def->connect("add8_upper.out","add2_join.in0");

--- a/tests/unit/inlinetest.cpp
+++ b/tests/unit/inlinetest.cpp
@@ -58,7 +58,7 @@ int main() {
       def->connect(inst->sel("in")->sel(i),def->getInterface()->sel("in")->sel(i));
     }
     def->connect(inst->sel("out"),def->getInterface()->sel("out"));
-    inst->runGenerator();
+    add4->runAll();
     inlineInstance(inst);
   add->setDef(def);
   add->print();


### PR DESCRIPTION
This is a slightly worrysome amount of changes. I will add more tests before merging this all into dev.

Changes:
Generated Modules are now permenantly in the respected Generator.
Instances can only instance a Module (which may have been generated)
Changed the Json format slightly to support this change. Generated Modules appear under "modules" but have the extra fields of "genref" and "genargs"
Added support for referencing args of the parent container (for setting modargs)
Moved my internal passthrough into a hard to access namespace (does not show up on getNamesapces())
Updated some passes to be a ContextPass (Really should be a "softwaremodule" pass)
Added a culling pass in order to serialize only what is necessary
Updated the verilog to support all these changes

