### PR TITLE
Fix warnings / errors in GCC 6/7

### DIFF
--- a/include/coreir/ir/fwd_declare.h
+++ b/include/coreir/ir/fwd_declare.h
@@ -18,6 +18,7 @@
   if (!(C)) { \
     std::cout << "ERROR: " << MSG << std::endl << std::endl; \
     assert(C); \
+    while (true) {} /* Hack so GCC knows this doesn't ever return */ \
   }
 
 typedef uint32_t uint;

--- a/src/ir/fileReader.cpp
+++ b/src/ir/fileReader.cpp
@@ -381,6 +381,7 @@ Type* json2Type(Context* c, json jt) {
     else {
       cout << "ERROR NYI!: " << args[0].get<string>() << endl;
       assert(false);
+      return NULL;
     }
   }
   else throw std::runtime_error("Error parsing Type");


### PR DESCRIPTION
GCC 6 and 7 no longer treat assert(false) as a noreturn function, so add some hacks to suppress the errors that now occur with Werror.