### PR TITLE
removed reset from dff for now

### DIFF
--- a/src/ir/headers/corebit.hpp
+++ b/src/ir/headers/corebit.hpp
@@ -42,7 +42,6 @@ Namespace* CoreIRLoadHeader_corebit(Context* c) {
   //DFF
   Type* dffType = c->Record({
     {"clk",c->Named("coreir.clkIn")},
-    {"rst",c->Named("coreir.rstIn")},
     {"in",c->BitIn()},
     {"out",c->Bit()}
   });


### PR DESCRIPTION
I am going to remove the reset for now from the single bit FF in effort to get simulation working. Can you verify that this change does not break mantle/magma?
