### PR TITLE
Interpreter flip flop support

### DIFF
--- a/src/simulator/interpret.cpp
+++ b/src/simulator/interpret.cpp
@@ -1089,11 +1089,13 @@ namespace CoreIR {
   }
 
   void SimulatorState::updateDFFOutput(const vdisc vd) {
-    assert(false);
+    //assert(false);
+    updateRegisterOutput(vd);
   }
 
   void SimulatorState::updateDFFValue(const vdisc vd) {
-    assert(false);
+    //assert(false);
+    updateRegisterValue(vd);
   }
   
   void SimulatorState::updateRegisterOutput(const vdisc vd) {

--- a/src/simulator/interpret.cpp
+++ b/src/simulator/interpret.cpp
@@ -396,8 +396,13 @@ namespace CoreIR {
     setLinebufferMemDefaults();
     setRegisterDefaults();
     setDFFDefaults();
+    setInputDefaults();
 
 
+  }
+
+  void SimulatorState::setInputDefaults() {
+    
   }
 
   void SimulatorState::setValue(const std::vector<std::string>& name,

--- a/src/simulator/interpret.cpp
+++ b/src/simulator/interpret.cpp
@@ -1225,15 +1225,21 @@ namespace CoreIR {
     vector<vdisc> unset;
     for (auto& vd : opGraph.getVerts()) {
 
-      if (opGraph.getInputConnections(vd).size() == 0) {
+      WireNode w = opGraph.getNode(vd);
+      //if (opGraph.getInputConnections(vd).size() == 0) {
+      if (isGraphInput(w)) {
 
-        for (auto& sel : getOutputSelects(opGraph.getNode(vd).getWire())) {
-          if (!isSet(toSelect(sel.second))) {
-            unset.push_back(vd);
-            break;            
-          }
+        Select* inSel = toSelect(w.getWire());
+        //assert(isSw.getWire()
 
+        //for (auto& sel : getOutputSelects(opGraph.getNode(vd).getWire())) {
+        //for (auto& sel : getOutputSelects(w.getWire())) {
+        if (!isSet(inSel)) { //toSelect(sel.second))) {
+          cout << "Select " << inSel->toString() << " is not set" << " in " << w.getWire()->toString() << endl;
+          unset.push_back(vd);
         }
+
+          //}
       }
 
     }

--- a/src/simulator/interpret.cpp
+++ b/src/simulator/interpret.cpp
@@ -8,7 +8,7 @@ namespace CoreIR {
 
   string getQualifiedOpName(CoreIR::Instance& inst) {
     string opName = inst.getModuleRef()->getNamespace()->getName() + "." +
-      getOpName(*inst);
+      getOpName(inst);
 
     return opName;
   }
@@ -949,7 +949,7 @@ namespace CoreIR {
             return BitVec(1, 0);
           }
         });
-    } else if (opName == "coreir.lutN") {
+    } else if (opName == "commonlib.lutN") {
       updateLUTNNode(vd);
     } else {
       cout << "Unsupported node: " << wd.getWire()->toString() << " has operation name: " << opName << endl;

--- a/src/simulator/interpret.cpp
+++ b/src/simulator/interpret.cpp
@@ -1220,6 +1220,27 @@ namespace CoreIR {
 
   }
 
+  std::vector<vdisc> SimulatorState::unsetInputs() {
+    NGraph& opGraph = getCircuitGraph();
+    vector<vdisc> unset;
+    for (auto& vd : opGraph.getVerts()) {
+
+      if (opGraph.getInputConnections(vd).size() == 0) {
+
+        for (auto& sel : getOutputSelects(opGraph.getNode(vd).getWire())) {
+          if (!isSet(toSelect(sel.second))) {
+            unset.push_back(vd);
+            break;            
+          }
+
+        }
+      }
+
+    }
+
+    return unset;
+  }
+
   void SimulatorState::execute() {
     assert(atLastState());
 
@@ -1231,6 +1252,15 @@ namespace CoreIR {
 
     circStates.push_back(next);
     stateIndex++;
+
+    vector<vdisc> unsetIns = unsetInputs();
+    if (unsetIns.size() > 0) {
+      cout << "Cannot execute because " << unsetIns.size() << " input(s) are not set:" << endl;
+      for (auto& vd : unsetIns) {
+        cout << "\t" << getCircuitGraph().getNode(vd).getWire()->toString() << endl;
+      }
+      return;
+    }
 
     //end = clock();
 

--- a/src/simulator/interpret.cpp
+++ b/src/simulator/interpret.cpp
@@ -6,6 +6,13 @@ using namespace std;
 
 namespace CoreIR {
 
+  string getQualifiedOpName(CoreIR::Instance& inst) {
+    string opName = inst.getModuleRef()->getNamespace()->getName() + "." +
+      getOpName(*inst);
+
+    return opName;
+  }
+
   void SimMemory::setAddr(const BitVec& bv, const BitVec& val) {
     assert(bv.bitLength() == log2(depth));
     assert(val.bitLength() == ((int) width));
@@ -806,58 +813,60 @@ namespace CoreIR {
 
     assert(isInstance(wd.getWire()));
 
-    string opName = getOpName(*toInstance(wd.getWire()));
-    if ((opName == "and") || (opName == "bitand")) {
+    //string opName = getOpName(*toInstance(wd.getWire()));
+    string opName = getQualifiedOpName(*toInstance(wd.getWire()));
+
+    if ((opName == "coreir.and") || (opName == "corebit.and")) {
       updateAndNode(vd);
-    } else if (opName == "eq") {
+    } else if (opName == "coreir.eq") {
       updateEqNode(vd);
-    } else if (opName == "neq") {
+    } else if (opName == "coreir.neq") {
       updateNeqNode(vd);
-    } else if ((opName == "or") || (opName == "bitor")) {
+    } else if ((opName == "coreir.or") || (opName == "corebit.or")) {
       updateOrNode(vd);
-    } else if ((opName == "xor") || (opName == "bitxor")) {
+    } else if ((opName == "coreir.xor") || (opName == "corebit.xor")) {
       updateBitVecBinop(vd, [](const BitVec& l, const BitVec& r) {
           return l ^ r;
       });
-    } else if (opName == "not") {
+    } else if (opName == "coreir.not") {
       updateBitVecUnop(vd, [](const BitVec& r) {
           return ~r;
       });
-    } else if (opName == "andr") {
+    } else if (opName == "coreir.andr") {
       updateAndrNode(vd);
-    } else if (opName == "add") {
+    } else if (opName == "coreir.add") {
       updateAddNode(vd);
-    } else if (opName == "sub") {
+    } else if (opName == "coreir.sub") {
       updateBitVecBinop(vd, [](const BitVec& l, const BitVec& r) {
         return sub_general_width_bv(l, r);
       });
-    } else if (opName == "mul") {
+    } else if (opName == "coreir.mul") {
       updateBitVecBinop(vd, [](const BitVec& l, const BitVec& r) {
         return mul_general_width_bv(l, r);
       });
-    } else if ((opName == "const") || (opName == "bitconst")) {
-    } else if (opName == "bitterm") {
-    } else if ((opName == "reg") || (opName == "dff")) {
-    } else if ((opName == "mem") || (opName == "LinebufferMem")) {
-    } else if (opName == "mux") {
+    } else if ((opName == "coreir.const") || (opName == "corebit.const")) {
+    } else if (opName == "corebit.term") {
+    } else if ((opName == "coreir.reg") || (opName == "corebit.dff")) {
+    } else if ((opName == "coreir.mem") || (opName == "commonlib.LinebufferMem")) {
+    } else if (opName == "coreir.mux") {
       updateMuxNode(vd);
-    } else if (opName == "slice") {
+    } else if (opName == "coreir.slice") {
       updateSliceNode(vd);
-    } else if (opName == "concat") {
+    } else if (opName == "coreir.concat") {
       updateConcatNode(vd);
-    } else if (opName == "lshr") {
+    } else if (opName == "coreir.lshr") {
       updateBitVecBinop(vd, [](const BitVec& l, const BitVec& r) {
           return lshr(l, r);
         });
-    } else if (opName == "ashr") {
+    } else if (opName == "coreir.ashr") {
       updateBitVecBinop(vd, [](const BitVec& l, const BitVec& r) {
           return ashr(l, r);
         });
-    } else if (opName == "shl") {
+    } else if (opName == "coreir.shl") {
        updateBitVecBinop(vd, [](const BitVec& l, const BitVec& r) {
            return shl(l, r);
          });
-    } else if (opName == "ult") {
+    } else if (opName == "coreir.ult") {
       updateBitVecBinop(vd, [](const BitVec& l, const BitVec& r) {
           if (l < r) {
             return BitVec(1, 1);
@@ -865,7 +874,7 @@ namespace CoreIR {
             return BitVec(1, 0);
           }
         });
-    } else if (opName == "ule") {
+    } else if (opName == "coreir.ule") {
       updateBitVecBinop(vd, [](const BitVec& l, const BitVec& r) {
           if ((l < r) || (l == r)) {
             return BitVec(1, 1);
@@ -873,7 +882,7 @@ namespace CoreIR {
             return BitVec(1, 0);
           }
         });
-    } else if (opName == "ugt") {
+    } else if (opName == "coreir.ugt") {
       updateBitVecBinop(vd, [](const BitVec& l, const BitVec& r) {
           if (l > r) {
             return BitVec(1, 1);
@@ -882,7 +891,7 @@ namespace CoreIR {
           }
         });
       
-    } else if (opName == "uge") {
+    } else if (opName == "coreir.uge") {
       updateBitVecBinop(vd, [](const BitVec& l, const BitVec& r) {
           if ((l > r) || (l == r)) {
             return BitVec(1, 1);
@@ -890,7 +899,7 @@ namespace CoreIR {
             return BitVec(1, 0);
           }
         });
-    } else if (opName == "smax") {
+    } else if (opName == "coreir.smax") {
       updateBitVecBinop(vd, [](const BitVec& l, const BitVec& r) {
           if (signed_gt(l, r) || (l == r)) {
             return l;
@@ -898,7 +907,7 @@ namespace CoreIR {
             return r;
           }
         });
-    } else if (opName == "smin") {
+    } else if (opName == "coreir.smin") {
       updateBitVecBinop(vd, [](const BitVec& l, const BitVec& r) {
           if (signed_gt(l, r) || (l == r)) {
             return r;
@@ -906,7 +915,7 @@ namespace CoreIR {
             return l;
           }
         });
-    } else if (opName == "sgt") {
+    } else if (opName == "coreir.sgt") {
       updateBitVecBinop(vd, [](const BitVec& l, const BitVec& r) {
           if (signed_gt(l, r)) {
             return BitVec(1, 1);
@@ -914,7 +923,7 @@ namespace CoreIR {
             return BitVec(1, 0);
           }
         });
-    } else if (opName == "sge") {
+    } else if (opName == "coreir.sge") {
       updateBitVecBinop(vd, [](const BitVec& l, const BitVec& r) {
           if (signed_gte(l, r)) {
             return BitVec(1, 1);
@@ -922,7 +931,7 @@ namespace CoreIR {
             return BitVec(1, 0);
           }
         });
-    } else if (opName == "slt") {
+    } else if (opName == "coreir.slt") {
 
       updateBitVecBinop(vd, [](const BitVec& l, const BitVec& r) {
           if (!signed_gte(l, r)) {
@@ -931,7 +940,7 @@ namespace CoreIR {
             return BitVec(1, 0);
           }
         });
-    } else if (opName == "sle") {
+    } else if (opName == "coreir.sle") {
 
       updateBitVecBinop(vd, [](const BitVec& l, const BitVec& r) {
           if (!signed_gt(l, r)) {
@@ -940,7 +949,7 @@ namespace CoreIR {
             return BitVec(1, 0);
           }
         });
-    } else if (opName == "lutN") {
+    } else if (opName == "coreir.lutN") {
       updateLUTNNode(vd);
     } else {
       cout << "Unsupported node: " << wd.getWire()->toString() << " has operation name: " << opName << endl;
@@ -1067,7 +1076,6 @@ namespace CoreIR {
         Values args = inst->getModArgs();
 
         bool val = args["init"]->get<bool>();
-        //uint width = (args["width"])->get<int>();
 
         setRegister(inst->toString(), BitVec(1, val ? 1 : 0));
         setValue(inst->sel("out"), getRegister(inst->toString()));
@@ -1076,9 +1084,11 @@ namespace CoreIR {
   }
 
   void SimulatorState::updateDFFOutput(const vdisc vd) {
+    assert(false);
   }
 
   void SimulatorState::updateDFFValue(const vdisc vd) {
+    assert(false);
   }
   
   void SimulatorState::updateRegisterOutput(const vdisc vd) {

--- a/src/simulator/interpret.cpp
+++ b/src/simulator/interpret.cpp
@@ -1226,20 +1226,16 @@ namespace CoreIR {
     for (auto& vd : opGraph.getVerts()) {
 
       WireNode w = opGraph.getNode(vd);
-      //if (opGraph.getInputConnections(vd).size() == 0) {
+
       if (isGraphInput(w)) {
 
         Select* inSel = toSelect(w.getWire());
-        //assert(isSw.getWire()
 
-        //for (auto& sel : getOutputSelects(opGraph.getNode(vd).getWire())) {
-        //for (auto& sel : getOutputSelects(w.getWire())) {
         if (!isSet(inSel)) { //toSelect(sel.second))) {
           cout << "Select " << inSel->toString() << " is not set" << " in " << w.getWire()->toString() << endl;
           unset.push_back(vd);
         }
 
-          //}
       }
 
     }

--- a/src/simulator/interpret.hpp
+++ b/src/simulator/interpret.hpp
@@ -195,6 +195,10 @@ namespace CoreIR {
 
     void deleteWatchPoint(const std::string& name);
 
+    void setDFFDefaults();
+    void updateDFFOutput(const vdisc vd);
+    void updateDFFValue(const vdisc vd);
+
     void updateMemoryOutput(const vdisc vd);
     void setConstantDefaults();
     void setRegisterDefaults();

--- a/src/simulator/interpret.hpp
+++ b/src/simulator/interpret.hpp
@@ -167,6 +167,7 @@ namespace CoreIR {
     int numCircStates() const;
 
     void setInputDefaults();
+    std::vector<vdisc> unsetInputs();
 
     std::vector<CircuitState> getCircStates() const;
 

--- a/src/simulator/interpret.hpp
+++ b/src/simulator/interpret.hpp
@@ -166,6 +166,8 @@ namespace CoreIR {
 
     int numCircStates() const;
 
+    void setInputDefaults();
+
     std::vector<CircuitState> getCircStates() const;
 
     NGraph& getCircuitGraph() { return gr; }

--- a/tests/simulator/interpreter.cpp
+++ b/tests/simulator/interpreter.cpp
@@ -861,7 +861,6 @@ namespace CoreIR {
       Type* dffType = c->Record({
           {"IN", c->BitIn()},
             {"CLK", c->Named("coreir.clkIn")},
-              {"RST", c->Named("coreir.rstIn")},
                 {"OUT", c->Bit()}
         });
 
@@ -873,31 +872,34 @@ namespace CoreIR {
         		 dff,
         		 {{"init", Const::make(c, true)}});
 
-      // Wireable* self = def->sel("self");
-      // def->connect("self.IN", "dff0.in");
-      // def->connect("self.CLK", "dff0.clk");
-      // def->connect("self.RST", "dff0.rst");
-      // def->connect("dff0.out", "self.OUT");
+      Wireable* self = def->sel("self");
+      def->connect("self.IN", "dff0.in");
+      def->connect("self.CLK", "dff0.clk");
+      def->connect("dff0.out", "self.OUT");
 
-      // dffTest->setDef(def);
+      dffTest->setDef(def);
 
-      // c->runPasses({"rungenerators","flattentypes","flatten"});
+      c->runPasses({"rungenerators","flattentypes","flatten"});
 
-      // // cout << "loading" << endl;
-      // // if (!loadFromFile(c,"./topo_sort_error.json")) {
-      // //   cout << "Could not Load from json!!" << endl;
-      // //   c->die();
-      // // }
+      // cout << "loading" << endl;
+      // if (!loadFromFile(c,"./topo_sort_error.json")) {
+      //   cout << "Could not Load from json!!" << endl;
+      //   c->die();
+      // }
 
-      // // Module* m = g->getModule("simple");
+      // Module* m = g->getModule("simple");
 
-      // SimulatorState state(dffTest);
-      // state.setClock("self.CLK", 0, 1);
-      // state.setValue("self.IN", BitVec(1, 0));
+      SimulatorState state(dffTest);
+      state.setClock("self.CLK", 0, 1);
+      state.setValue("self.IN", BitVec(1, 0));
 
-      // state.execute();
+      state.execute();
 
-      // REQUIRE(state.getBitVec("self.COUT") == BitVec(1, 0));
+      REQUIRE(state.getBitVec("self.OUT") == BitVec(1, 1));
+
+      state.execute();
+
+      REQUIRE(state.getBitVec("self.OUT") == BitVec(1, 0));
 
     }
 

--- a/tests/simulator/interpreter.cpp
+++ b/tests/simulator/interpreter.cpp
@@ -825,7 +825,7 @@ namespace CoreIR {
 			 {{"init",
 			       Const::make(c,
 					   BitVector(1 << n, "1010010111010010"))}});
-    
+
       def->connect(self->sel("in"), lut0->sel("in"));
       def->connect(lut0->sel("out"),self->sel("out"));
 
@@ -901,7 +901,6 @@ namespace CoreIR {
 
     }
 
-    // TODO: Uncomment this when the bit operations in coreir are figured out
     SECTION("Selecting bits from a bit vector") {
       Namespace* common = CoreIRLoadLibrary_commonlib(c);
 

--- a/tests/simulator/interpreter.cpp
+++ b/tests/simulator/interpreter.cpp
@@ -940,6 +940,35 @@ namespace CoreIR {
       REQUIRE(state.getBitVec("self.O") == BitVector(8, "11110000"));
     }
 
+    SECTION("Failing clock test") {
+
+      cout << "loading" << endl;
+      if (!loadFromFile(c,"./simple_register_example.json")) {
+    	cout << "Could not Load from json!!" << endl;
+    	c->die();
+      }
+
+      Module* regMod = g->getModule("simple_flattened");
+      SimulatorState state(regMod);
+
+      state.setClock("self.CLK", 0, 1);
+      state.setValue("self.I0", BitVec(2, "11"));
+
+      state.execute();
+      state.execute();
+
+      SimValue* val = state.getValue("self.CLK");
+      assert(val->getType() == SIM_VALUE_CLK);
+
+      ClockValue* clkVal = static_cast<ClockValue*>(val);
+
+      REQUIRE(state.getBitVec("self.O") == BitVec(2, "11"));
+      REQUIRE(clkVal->value() == 1);
+      REQUIRE(clkVal->lastValue() == 0);
+      
+      
+    }
+
     deleteContext(c);
   }
 

--- a/tests/simulator/interpreter.cpp
+++ b/tests/simulator/interpreter.cpp
@@ -951,9 +951,24 @@ namespace CoreIR {
       Module* regMod = g->getModule("simple_flattened");
       SimulatorState state(regMod);
 
+      SECTION("2 unset inputs") {
+        REQUIRE(state.unsetInputs().size() == 2);
+      }
+
+      state.execute();
+
       state.setClock("self.CLK", 0, 1);
+
+      SECTION("1 unset inputs") {
+        REQUIRE(state.unsetInputs().size() == 1);
+      }
+      
       state.setValue("self.I0", BitVec(2, "11"));
 
+      SECTION("0 unset inputs") {
+        REQUIRE(state.unsetInputs().size() == 0);
+      }
+      
       state.execute();
       state.execute();
 

--- a/tests/simulator/interpreter.cpp
+++ b/tests/simulator/interpreter.cpp
@@ -902,45 +902,44 @@ namespace CoreIR {
     }
 
     // TODO: Uncomment this when the bit operations in coreir are figured out
-    // SECTION("Selecting bits from a bit vector") {
-    //   Namespace* common = CoreIRLoadLibrary_commonlib(c);
+    SECTION("Selecting bits from a bit vector") {
+      Namespace* common = CoreIRLoadLibrary_commonlib(c);
 
-    //   cout << "loading" << endl;
-    //   if (!loadFromFile(c,"./sim_ready_sorter.json")) {
-    // 	cout << "Could not Load from json!!" << endl;
-    // 	c->die();
-    //   }
+      cout << "loading" << endl;
+      if (!loadFromFile(c,"./sim_ready_sorter.json")) {
+    	cout << "Could not Load from json!!" << endl;
+    	c->die();
+      }
 
-    //   Module* m = g->getModule("Sorter8");
+      Module* m = g->getModule("Sorter8");
 
-    //   assert(m != nullptr);
+      assert(m != nullptr);
 
-    //   SimulatorState state(m);
-    //   state.setValue("self.I", BitVector(8, "10010011"));
+      SimulatorState state(m);
+      state.setValue("self.I", BitVector(8, "10010011"));
 
-    //   cout << "# of nodes in circuit = " << state.getCircuitGraph().getVerts().size() << endl;
+      cout << "# of nodes in circuit = " << state.getCircuitGraph().getVerts().size() << endl;
 
-    //   BitVector one(16, "1");
-    //   BitVector nextIn(16, "0");
+      BitVector one(16, "1");
+      BitVector nextIn(16, "0");
 
-    //   std::clock_t start, end;
+      std::clock_t start, end;
 
-    //   start = std::clock();
+      start = std::clock();
 
-    //   state.execute();
+      state.execute();
 
-    //   end = std::clock();
+      end = std::clock();
 
-    //   std::cout << "Done. Time to simulate = "
-    // 		<< (end - start) / (double)(CLOCKS_PER_SEC / 1000) << " ms"
-    // 		<< std::endl;
+      std::cout << "Done. Time to simulate = "
+    		<< (end - start) / (double)(CLOCKS_PER_SEC / 1000) << " ms"
+    		<< std::endl;
 
       
-    //   cout << "out = " << state.getBitVec("self.O") << endl;
+      cout << "out = " << state.getBitVec("self.O") << endl;
 
-    //   REQUIRE(state.getBitVec("self.O") == BitVector(8, "11110000"));
-      
-    // }
+      REQUIRE(state.getBitVec("self.O") == BitVector(8, "11110000"));
+    }
 
     deleteContext(c);
   }

--- a/tests/simulator/interpreter.cpp
+++ b/tests/simulator/interpreter.cpp
@@ -873,15 +873,15 @@ namespace CoreIR {
         		 dff,
         		 {{"init", Const::make(c, true)}});
 
-      Wireable* self = def->sel("self");
-      def->connect("self.IN", "dff0.in");
-      def->connect("self.CLK", "dff0.clk");
-      def->connect("self.RST", "dff0.rst");
-      def->connect("dff0.out", "self.OUT");
+      // Wireable* self = def->sel("self");
+      // def->connect("self.IN", "dff0.in");
+      // def->connect("self.CLK", "dff0.clk");
+      // def->connect("self.RST", "dff0.rst");
+      // def->connect("dff0.out", "self.OUT");
 
-      dffTest->setDef(def);
+      // dffTest->setDef(def);
 
-      c->runPasses({"rungenerators","flattentypes","flatten"});
+      // c->runPasses({"rungenerators","flattentypes","flatten"});
 
       // // cout << "loading" << endl;
       // // if (!loadFromFile(c,"./topo_sort_error.json")) {
@@ -891,9 +891,9 @@ namespace CoreIR {
 
       // // Module* m = g->getModule("simple");
 
-      SimulatorState state(dffTest);
-      state.setClock("self.CLK", 0, 1);
-      state.setValue("self.IN", BitVec(1, 0));
+      // SimulatorState state(dffTest);
+      // state.setClock("self.CLK", 0, 1);
+      // state.setValue("self.IN", BitVec(1, 0));
 
       // state.execute();
 

--- a/tests/simulator/interpreter.cpp
+++ b/tests/simulator/interpreter.cpp
@@ -865,7 +865,11 @@ namespace CoreIR {
       Module* m = g->getModule("simple");
 
       SimulatorState state(m);
-      
+      state.setClock("self.CLK", 0, 1);
+
+      state.execute();
+
+      REQUIRE(state.getBitVec("self.COUT") == BitVec(1, 0));
 
     }
 

--- a/tests/simulator/sim_ready_sorter.json
+++ b/tests/simulator/sim_ready_sorter.json
@@ -9,10 +9,10 @@
         }],
         "instances":{
           "inst0$inst0":{
-            "modref":"coreir.bitand"
+            "modref":"corebit.and"
           },
           "inst0$inst1":{
-            "modref":"coreir.bitor"
+            "modref":"corebit.or"
           }
         },
         "connections":[
@@ -31,28 +31,28 @@
         }],
         "instances":{
           "inst1$inst0$inst0":{
-            "modref":"coreir.bitand"
+            "modref":"corebit.and"
           },
           "inst1$inst0$inst1":{
-            "modref":"coreir.bitor"
+            "modref":"corebit.or"
           },
           "inst1$inst1$inst0":{
-            "modref":"coreir.bitand"
+            "modref":"corebit.and"
           },
           "inst1$inst1$inst1":{
-            "modref":"coreir.bitor"
+            "modref":"corebit.or"
           },
           "inst3$inst0$inst0":{
-            "modref":"coreir.bitand"
+            "modref":"corebit.and"
           },
           "inst3$inst0$inst1":{
-            "modref":"coreir.bitor"
+            "modref":"corebit.or"
           },
           "inst4$inst0$inst0":{
-            "modref":"coreir.bitand"
+            "modref":"corebit.and"
           },
           "inst4$inst0$inst1":{
-            "modref":"coreir.bitor"
+            "modref":"corebit.or"
           }
         },
         "connections":[
@@ -85,28 +85,28 @@
         }],
         "instances":{
           "inst1$inst0$inst0":{
-            "modref":"coreir.bitand"
+            "modref":"corebit.and"
           },
           "inst1$inst0$inst1":{
-            "modref":"coreir.bitor"
+            "modref":"corebit.or"
           },
           "inst1$inst1$inst0":{
-            "modref":"coreir.bitand"
+            "modref":"corebit.and"
           },
           "inst1$inst1$inst1":{
-            "modref":"coreir.bitor"
+            "modref":"corebit.or"
           },
           "inst3$inst0$inst0":{
-            "modref":"coreir.bitand"
+            "modref":"corebit.and"
           },
           "inst3$inst0$inst1":{
-            "modref":"coreir.bitor"
+            "modref":"corebit.or"
           },
           "inst4$inst0$inst0":{
-            "modref":"coreir.bitand"
+            "modref":"corebit.and"
           },
           "inst4$inst0$inst1":{
-            "modref":"coreir.bitor"
+            "modref":"corebit.or"
           }
         },
         "connections":[
@@ -139,76 +139,76 @@
         }],
         "instances":{
           "inst1$inst0$inst0":{
-            "modref":"coreir.bitand"
+            "modref":"corebit.and"
           },
           "inst1$inst0$inst1":{
-            "modref":"coreir.bitor"
+            "modref":"corebit.or"
           },
           "inst1$inst1$inst0":{
-            "modref":"coreir.bitand"
+            "modref":"corebit.and"
           },
           "inst1$inst1$inst1":{
-            "modref":"coreir.bitor"
+            "modref":"corebit.or"
           },
           "inst1$inst2$inst0":{
-            "modref":"coreir.bitand"
+            "modref":"corebit.and"
           },
           "inst1$inst2$inst1":{
-            "modref":"coreir.bitor"
+            "modref":"corebit.or"
           },
           "inst1$inst3$inst0":{
-            "modref":"coreir.bitand"
+            "modref":"corebit.and"
           },
           "inst1$inst3$inst1":{
-            "modref":"coreir.bitor"
+            "modref":"corebit.or"
           },
           "inst3$inst1$inst0$inst0":{
-            "modref":"coreir.bitand"
+            "modref":"corebit.and"
           },
           "inst3$inst1$inst0$inst1":{
-            "modref":"coreir.bitor"
+            "modref":"corebit.or"
           },
           "inst3$inst1$inst1$inst0":{
-            "modref":"coreir.bitand"
+            "modref":"corebit.and"
           },
           "inst3$inst1$inst1$inst1":{
-            "modref":"coreir.bitor"
+            "modref":"corebit.or"
           },
           "inst3$inst3$inst0$inst0":{
-            "modref":"coreir.bitand"
+            "modref":"corebit.and"
           },
           "inst3$inst3$inst0$inst1":{
-            "modref":"coreir.bitor"
+            "modref":"corebit.or"
           },
           "inst3$inst4$inst0$inst0":{
-            "modref":"coreir.bitand"
+            "modref":"corebit.and"
           },
           "inst3$inst4$inst0$inst1":{
-            "modref":"coreir.bitor"
+            "modref":"corebit.or"
           },
           "inst4$inst1$inst0$inst0":{
-            "modref":"coreir.bitand"
+            "modref":"corebit.and"
           },
           "inst4$inst1$inst0$inst1":{
-            "modref":"coreir.bitor"
+            "modref":"corebit.or"
           },
           "inst4$inst1$inst1$inst0":{
-            "modref":"coreir.bitand"
+            "modref":"corebit.and"
           },
           "inst4$inst1$inst1$inst1":{
-            "modref":"coreir.bitor"
+            "modref":"corebit.or"
           },
           "inst4$inst3$inst0$inst0":{
-            "modref":"coreir.bitand"
+            "modref":"corebit.and"
           },
           "inst4$inst3$inst0$inst1":{
-            "modref":"coreir.bitor"
+            "modref":"corebit.or"
           },
           "inst4$inst4$inst0$inst0":{
-            "modref":"coreir.bitand"
+            "modref":"corebit.and"
           },
           "inst4$inst4$inst0$inst1":{
-            "modref":"coreir.bitor"
+            "modref":"corebit.or"
           }
         },
         "connections":[
@@ -317,10 +317,10 @@
         }],
         "instances":{
           "inst0$inst0":{
-            "modref":"coreir.bitand"
+            "modref":"corebit.and"
           },
           "inst0$inst1":{
-            "modref":"coreir.bitor"
+            "modref":"corebit.or"
           }
         },
         "connections":[
@@ -339,40 +339,40 @@
         }],
         "instances":{
           "inst0$inst1$inst0$inst0":{
-            "modref":"coreir.bitand"
+            "modref":"corebit.and"
           },
           "inst0$inst1$inst0$inst1":{
-            "modref":"coreir.bitor"
+            "modref":"corebit.or"
           },
           "inst0$inst1$inst1$inst0":{
-            "modref":"coreir.bitand"
+            "modref":"corebit.and"
           },
           "inst0$inst1$inst1$inst1":{
-            "modref":"coreir.bitor"
+            "modref":"corebit.or"
           },
           "inst0$inst3$inst0$inst0":{
-            "modref":"coreir.bitand"
+            "modref":"corebit.and"
           },
           "inst0$inst3$inst0$inst1":{
-            "modref":"coreir.bitor"
+            "modref":"corebit.or"
           },
           "inst0$inst4$inst0$inst0":{
-            "modref":"coreir.bitand"
+            "modref":"corebit.and"
           },
           "inst0$inst4$inst0$inst1":{
-            "modref":"coreir.bitor"
+            "modref":"corebit.or"
           },
           "inst1$inst0$inst0":{
-            "modref":"coreir.bitand"
+            "modref":"corebit.and"
           },
           "inst1$inst0$inst1":{
-            "modref":"coreir.bitor"
+            "modref":"corebit.or"
           },
           "inst2$inst0$inst0":{
-            "modref":"coreir.bitand"
+            "modref":"corebit.and"
           },
           "inst2$inst0$inst1":{
-            "modref":"coreir.bitor"
+            "modref":"corebit.or"
           }
         },
         "connections":[
@@ -413,148 +413,148 @@
         }],
         "instances":{
           "inst0$inst1$inst0$inst0":{
-            "modref":"coreir.bitand"
+            "modref":"corebit.and"
           },
           "inst0$inst1$inst0$inst1":{
-            "modref":"coreir.bitor"
+            "modref":"corebit.or"
           },
           "inst0$inst1$inst1$inst0":{
-            "modref":"coreir.bitand"
+            "modref":"corebit.and"
           },
           "inst0$inst1$inst1$inst1":{
-            "modref":"coreir.bitor"
+            "modref":"corebit.or"
           },
           "inst0$inst1$inst2$inst0":{
-            "modref":"coreir.bitand"
+            "modref":"corebit.and"
           },
           "inst0$inst1$inst2$inst1":{
-            "modref":"coreir.bitor"
+            "modref":"corebit.or"
           },
           "inst0$inst1$inst3$inst0":{
-            "modref":"coreir.bitand"
+            "modref":"corebit.and"
           },
           "inst0$inst1$inst3$inst1":{
-            "modref":"coreir.bitor"
+            "modref":"corebit.or"
           },
           "inst0$inst3$inst1$inst0$inst0":{
-            "modref":"coreir.bitand"
+            "modref":"corebit.and"
           },
           "inst0$inst3$inst1$inst0$inst1":{
-            "modref":"coreir.bitor"
+            "modref":"corebit.or"
           },
           "inst0$inst3$inst1$inst1$inst0":{
-            "modref":"coreir.bitand"
+            "modref":"corebit.and"
           },
           "inst0$inst3$inst1$inst1$inst1":{
-            "modref":"coreir.bitor"
+            "modref":"corebit.or"
           },
           "inst0$inst3$inst3$inst0$inst0":{
-            "modref":"coreir.bitand"
+            "modref":"corebit.and"
           },
           "inst0$inst3$inst3$inst0$inst1":{
-            "modref":"coreir.bitor"
+            "modref":"corebit.or"
           },
           "inst0$inst3$inst4$inst0$inst0":{
-            "modref":"coreir.bitand"
+            "modref":"corebit.and"
           },
           "inst0$inst3$inst4$inst0$inst1":{
-            "modref":"coreir.bitor"
+            "modref":"corebit.or"
           },
           "inst0$inst4$inst1$inst0$inst0":{
-            "modref":"coreir.bitand"
+            "modref":"corebit.and"
           },
           "inst0$inst4$inst1$inst0$inst1":{
-            "modref":"coreir.bitor"
+            "modref":"corebit.or"
           },
           "inst0$inst4$inst1$inst1$inst0":{
-            "modref":"coreir.bitand"
+            "modref":"corebit.and"
           },
           "inst0$inst4$inst1$inst1$inst1":{
-            "modref":"coreir.bitor"
+            "modref":"corebit.or"
           },
           "inst0$inst4$inst3$inst0$inst0":{
-            "modref":"coreir.bitand"
+            "modref":"corebit.and"
           },
           "inst0$inst4$inst3$inst0$inst1":{
-            "modref":"coreir.bitor"
+            "modref":"corebit.or"
           },
           "inst0$inst4$inst4$inst0$inst0":{
-            "modref":"coreir.bitand"
+            "modref":"corebit.and"
           },
           "inst0$inst4$inst4$inst0$inst1":{
-            "modref":"coreir.bitor"
+            "modref":"corebit.or"
           },
           "inst1$inst0$inst1$inst0$inst0":{
-            "modref":"coreir.bitand"
+            "modref":"corebit.and"
           },
           "inst1$inst0$inst1$inst0$inst1":{
-            "modref":"coreir.bitor"
+            "modref":"corebit.or"
           },
           "inst1$inst0$inst1$inst1$inst0":{
-            "modref":"coreir.bitand"
+            "modref":"corebit.and"
           },
           "inst1$inst0$inst1$inst1$inst1":{
-            "modref":"coreir.bitor"
+            "modref":"corebit.or"
           },
           "inst1$inst0$inst3$inst0$inst0":{
-            "modref":"coreir.bitand"
+            "modref":"corebit.and"
           },
           "inst1$inst0$inst3$inst0$inst1":{
-            "modref":"coreir.bitor"
+            "modref":"corebit.or"
           },
           "inst1$inst0$inst4$inst0$inst0":{
-            "modref":"coreir.bitand"
+            "modref":"corebit.and"
           },
           "inst1$inst0$inst4$inst0$inst1":{
-            "modref":"coreir.bitor"
+            "modref":"corebit.or"
           },
           "inst1$inst1$inst0$inst0":{
-            "modref":"coreir.bitand"
+            "modref":"corebit.and"
           },
           "inst1$inst1$inst0$inst1":{
-            "modref":"coreir.bitor"
+            "modref":"corebit.or"
           },
           "inst1$inst2$inst0$inst0":{
-            "modref":"coreir.bitand"
+            "modref":"corebit.and"
           },
           "inst1$inst2$inst0$inst1":{
-            "modref":"coreir.bitor"
+            "modref":"corebit.or"
           },
           "inst2$inst0$inst1$inst0$inst0":{
-            "modref":"coreir.bitand"
+            "modref":"corebit.and"
           },
           "inst2$inst0$inst1$inst0$inst1":{
-            "modref":"coreir.bitor"
+            "modref":"corebit.or"
           },
           "inst2$inst0$inst1$inst1$inst0":{
-            "modref":"coreir.bitand"
+            "modref":"corebit.and"
           },
           "inst2$inst0$inst1$inst1$inst1":{
-            "modref":"coreir.bitor"
+            "modref":"corebit.or"
           },
           "inst2$inst0$inst3$inst0$inst0":{
-            "modref":"coreir.bitand"
+            "modref":"corebit.and"
           },
           "inst2$inst0$inst3$inst0$inst1":{
-            "modref":"coreir.bitor"
+            "modref":"corebit.or"
           },
           "inst2$inst0$inst4$inst0$inst0":{
-            "modref":"coreir.bitand"
+            "modref":"corebit.and"
           },
           "inst2$inst0$inst4$inst0$inst1":{
-            "modref":"coreir.bitor"
+            "modref":"corebit.or"
           },
           "inst2$inst1$inst0$inst0":{
-            "modref":"coreir.bitand"
+            "modref":"corebit.and"
           },
           "inst2$inst1$inst0$inst1":{
-            "modref":"coreir.bitor"
+            "modref":"corebit.or"
           },
           "inst2$inst2$inst0$inst0":{
-            "modref":"coreir.bitand"
+            "modref":"corebit.and"
           },
           "inst2$inst2$inst0$inst1":{
-            "modref":"coreir.bitor"
+            "modref":"corebit.or"
           }
         },
         "connections":[
@@ -671,10 +671,10 @@
         }],
         "instances":{
           "inst0":{
-            "modref":"coreir.bitand"
+            "modref":"corebit.and"
           },
           "inst1":{
-            "modref":"coreir.bitor"
+            "modref":"corebit.or"
           }
         },
         "connections":[
@@ -693,16 +693,16 @@
         }],
         "instances":{
           "inst0$inst0":{
-            "modref":"coreir.bitand"
+            "modref":"corebit.and"
           },
           "inst0$inst1":{
-            "modref":"coreir.bitor"
+            "modref":"corebit.or"
           },
           "inst1$inst0":{
-            "modref":"coreir.bitand"
+            "modref":"corebit.and"
           },
           "inst1$inst1":{
-            "modref":"coreir.bitor"
+            "modref":"corebit.or"
           }
         },
         "connections":[
@@ -727,28 +727,28 @@
         }],
         "instances":{
           "inst0$inst0":{
-            "modref":"coreir.bitand"
+            "modref":"corebit.and"
           },
           "inst0$inst1":{
-            "modref":"coreir.bitor"
+            "modref":"corebit.or"
           },
           "inst1$inst0":{
-            "modref":"coreir.bitand"
+            "modref":"corebit.and"
           },
           "inst1$inst1":{
-            "modref":"coreir.bitor"
+            "modref":"corebit.or"
           },
           "inst2$inst0":{
-            "modref":"coreir.bitand"
+            "modref":"corebit.and"
           },
           "inst2$inst1":{
-            "modref":"coreir.bitor"
+            "modref":"corebit.or"
           },
           "inst3$inst0":{
-            "modref":"coreir.bitand"
+            "modref":"corebit.and"
           },
           "inst3$inst1":{
-            "modref":"coreir.bitor"
+            "modref":"corebit.or"
           }
         },
         "connections":[

--- a/tests/simulator/simple_register_example.json
+++ b/tests/simulator/simple_register_example.json
@@ -1,0 +1,27 @@
+{"top":"global.simple_flattened",
+"namespaces":{
+  "global":{
+    "modules":{
+      "simple_flattened":{
+        "type":["Record",{
+          "I0":["Array",2,"BitIn"],
+          "O":["Array",2,"Bit"],
+          "CLK":["Named","coreir.clkIn"]
+        }],
+        "instances":{
+          "inst0":{
+            "genref":"coreir.reg",
+            "genargs":{"width":["Int",2]},
+            "modargs":{"init":[["BitVector",2],0]}
+          }
+        },
+        "connections":[
+          ["inst0.clk","self.CLK"],
+          ["inst0.in","self.I0"],
+          ["inst0.out","self.O"]
+        ]
+      }
+    }
+  }
+}
+}


### PR DESCRIPTION
The interpreter now supports D flip flops without resets, bitand, as well as bitwise and, or, and xor.

There is also a warning in the interpreter when you try to execute without setting all inputs