### PR TITLE
Interpreter cycle counter

### DIFF
--- a/src/binary/Makefile
+++ b/src/binary/Makefile
@@ -3,7 +3,7 @@
 HOME = ../..
 INCS = -I$(HOME)/include -I.
 LPATH = -L$(HOME)/lib
-LIBS =  -Wl,-rpath,$(HOME)/lib -lcoreir -ldl
+LIBS =  -Wl,-rpath,$(HOME)/lib -lcoreir -ldl -lcoreir-commonlib
 SRCFILES = $(wildcard [^_]*.cpp)
 OBJS = $(patsubst %.cpp,build/%.o,$(SRCFILES))
 EXES = $(patsubst %.cpp,build/%,$(SRCFILES))

--- a/src/binary/interpreter.cpp
+++ b/src/binary/interpreter.cpp
@@ -7,6 +7,7 @@
 #include "coreir/passes/analysis/coreirjson.h"
 #include "coreir/passes/analysis/verilog.h"
 #include "coreir/simulator/interpreter.h"
+#include "coreir/libs/commonlib.h"
 
 using namespace std;
 using namespace CoreIR;
@@ -159,7 +160,9 @@ int main(int argc, char *argv[]) {
     c->setTop(topRef);
   }
 
-  c->runPasses({"rungenerators","flattentypes","flatten"});
+  CoreIRLoadLibrary_commonlib(c);
+
+  c->runPasses({"rungenerators","flattentypes","flatten", "liftclockports-coreir", "wireclocks-coreir"});
 
   SimulatorState state(top);
 

--- a/src/simulator/interpret.cpp
+++ b/src/simulator/interpret.cpp
@@ -1253,7 +1253,6 @@ namespace CoreIR {
     //start = clock();
 
     CircuitState next = circStates[stateIndex];
-
     circStates.push_back(next);
     stateIndex++;
 

--- a/src/simulator/interpret.cpp
+++ b/src/simulator/interpret.cpp
@@ -235,18 +235,15 @@ namespace CoreIR {
 
   }
 
-  //<<<<<<< HEAD
   void SimulatorState::setMainClock(CoreIR::Select* s) {
     mainClock = s;
   }
   
-  //=======
   void SimulatorState::setMainClock(const std::vector<std::string>& path) {
     std::string name = concatInlined(path);
     setMainClock(name);
   }
 
-  //>>>>>>> upstream/dev
   void SimulatorState::setWatchPoint(const std::string& val,
                                      const BitVec& bv) {
 

--- a/src/simulator/interpret.cpp
+++ b/src/simulator/interpret.cpp
@@ -1258,6 +1258,7 @@ namespace CoreIR {
 
     if (hasMainClock()) {
       ClockValue* clockCopy = new ClockValue(*toClock(getValue(mainClock)));
+      allocatedValues.insert(clockCopy);
       setValue(mainClock, clockCopy);
     }
 

--- a/src/simulator/interpret.cpp
+++ b/src/simulator/interpret.cpp
@@ -1256,6 +1256,11 @@ namespace CoreIR {
     circStates.push_back(next);
     stateIndex++;
 
+    if (hasMainClock()) {
+      ClockValue* clockCopy = new ClockValue(*toClock(getValue(mainClock)));
+      setValue(mainClock, clockCopy);
+    }
+
     vector<vdisc> unsetIns = unsetInputs();
     if (unsetIns.size() > 0) {
       cout << "Cannot execute because " << unsetIns.size() << " input(s) are not set:" << endl;

--- a/src/simulator/interpret.hpp
+++ b/src/simulator/interpret.hpp
@@ -188,6 +188,8 @@ namespace CoreIR {
 
     void setMainClock(const std::string& val);
 
+    bool hasMainClock() const { return mainClock != nullptr; }
+
     bool rewind(const int halfCycles);
 
     CoreIR::Select* findSelect(const std::string& name) const;

--- a/src/simulator/interpret.hpp
+++ b/src/simulator/interpret.hpp
@@ -171,6 +171,7 @@ namespace CoreIR {
 
     int numCircStates() const;
 
+    void findMainClock();
     void setInputDefaults();
     std::vector<vdisc> unsetInputs();
 
@@ -187,6 +188,7 @@ namespace CoreIR {
     bool hitWatchPoint() const;
 
     void setMainClock(const std::string& val);
+    void setMainClock(CoreIR::Select* s);
 
     bool hasMainClock() const { return mainClock != nullptr; }
 

--- a/src/simulator/interpret.hpp
+++ b/src/simulator/interpret.hpp
@@ -60,10 +60,11 @@ namespace CoreIR {
   class ClockValue : public SimValue {
   protected:
     unsigned char lastVal, val;
+    int halfCycleCount;
 
   public:
     ClockValue(const unsigned char lastVal_,
-	       const unsigned char val_) : lastVal(lastVal_), val(val_) {}
+	       const unsigned char val_) : lastVal(lastVal_), val(val_), halfCycleCount(0) {}
 
     unsigned char value() const { return val; }
     unsigned char lastValue() const { return lastVal; }
@@ -72,7 +73,11 @@ namespace CoreIR {
       unsigned char tmp = lastVal;
       lastVal = val;
       val = tmp;
+      halfCycleCount++;
     }
+
+    int getCycleCount() const { return halfCycleCount / 2; }
+    int getHalfCycleCount() const { return halfCycleCount; }
 
     virtual SimValueType getType() const { return SIM_VALUE_CLK; }
   };

--- a/src/simulator/interpret.hpp
+++ b/src/simulator/interpret.hpp
@@ -188,13 +188,12 @@ namespace CoreIR {
     bool hitWatchPoint() const;
 
     void setMainClock(const std::string& val);
-    //<<<<<<< HEAD
+
     void setMainClock(CoreIR::Select* s);
 
     bool hasMainClock() const { return mainClock != nullptr; }
-// =======
+
     void setMainClock(const std::vector<std::string>& path);
-// >>>>>>> upstream/dev
 
     bool rewind(const int halfCycles);
 

--- a/tests/simulator/interpreter.cpp
+++ b/tests/simulator/interpreter.cpp
@@ -392,7 +392,7 @@ namespace CoreIR {
         state.setValue("self.en", BitVec(1, 1));
 
         state.setWatchPoint("self.counterOut", BitVec(pcWidth, 10));
-        state.setMainClock("self.clk");
+        //state.setMainClock("self.clk");
 
         state.run();
 
@@ -641,7 +641,7 @@ namespace CoreIR {
 
       state.setValue("self.wdata", BitVector(width, "11"));
       state.setValue("self.wen", BitVector(1, "1"));
-      state.setMainClock("self.clk");
+      //state.setMainClock("self.clk");
       state.setClock("self.clk", 0, 1);
 
       // SECTION("Before execution valid is 0") {

--- a/tests/simulator/interpreter.cpp
+++ b/tests/simulator/interpreter.cpp
@@ -418,7 +418,8 @@ namespace CoreIR {
 
           state.rewind(3);
 
-          int newCount = clk->getHalfCycleCount();
+          ClockValue* clockAfterRewind = toClock(state.getValue("self.clk"));
+          int newCount = clockAfterRewind->getHalfCycleCount();
 
           REQUIRE(newCount == (oldCount - 3));
         }

--- a/tests/simulator/interpreter.cpp
+++ b/tests/simulator/interpreter.cpp
@@ -422,6 +422,14 @@ namespace CoreIR {
           int newCount = clockAfterRewind->getHalfCycleCount();
 
           REQUIRE(newCount == (oldCount - 3));
+
+          state.runHalfCycle();
+
+          ClockValue* clockLater = toClock(state.getValue("self.clk"));
+
+          int countLater = clockLater->getHalfCycleCount();
+
+          REQUIRE(countLater == (newCount + 1));
         }
 
         SECTION("Setting a value after rewinding reverts all earlier states") {

--- a/tests/simulator/interpreter.cpp
+++ b/tests/simulator/interpreter.cpp
@@ -300,7 +300,6 @@ namespace CoreIR {
 
       SECTION("Count from zero, enable set") {
 
-    	//state.setValue("counter$ri$reg0.out", BitVec(pcWidth, 0));
         state.setRegister("counter$ri$reg0", BitVec(pcWidth, 0));
     	state.setValue("self.en", BitVec(1, 1));
     	state.setClock("self.clk", 0, 1);
@@ -374,7 +373,7 @@ namespace CoreIR {
       }
 
       SECTION("Enable on") {
-    	//state.setValue("counter$ri$reg0.out", BitVec(pcWidth, 400));
+
         state.setRegister("counter$ri$reg0", BitVec(pcWidth, 400));
     	state.setValue("self.en", BitVec(1, 1));
     	state.setClock("self.clk", 1, 0);
@@ -387,7 +386,7 @@ namespace CoreIR {
       }
 
       SECTION("Setting watchpoint") {
-        //state.setValue("counter$ri$reg0.out", BitVec(pcWidth, 0));
+
         state.setRegister("counter$ri$reg0", BitVec(pcWidth, 0));
         state.setClock("self.clk", 1, 0);
         state.setValue("self.en", BitVec(1, 1));
@@ -409,6 +408,19 @@ namespace CoreIR {
           cout << "state index after rewind  = " << state.getStateIndex() << endl;
 
           REQUIRE(state.getBitVec("self.counterOut") == BitVec(pcWidth, 9));
+        }
+
+        SECTION("Rewinding the changes clock cycle count") {
+
+          ClockValue* clk = toClock(state.getValue("self.clk"));
+
+          int oldCount = clk->getHalfCycleCount();
+
+          state.rewind(3);
+
+          int newCount = clk->getHalfCycleCount();
+
+          REQUIRE(newCount == (oldCount - 3));
         }
 
         SECTION("Setting a value after rewinding reverts all earlier states") {


### PR DESCRIPTION
At the request of @shacklettbp I have added a cycle counter. You can now read out total cycles executed by the clock. As part of this change the simulator now automatically detects the main clock and crashes with an error if the circuit has more than clock.

For example, if the circuit has one clock named "self.clk" you can get the number of cycles executed like so:

```cpp
ClockValue* clk = toClock(state.getValue("self.clk"));
int cycleCount = clk->getCycleCount();
```