### PR TITLE
[c-api] InstanceGetInstName

### DIFF
--- a/src/coreir-c/coreir-c.cpp
+++ b/src/coreir-c/coreir-c.cpp
@@ -467,6 +467,10 @@ extern "C" {
       return rcast<COREDirectedConnection**>(ptr_arr);
   }
 
+  const char* COREInstanceGetInstname(COREWireable* instance) {
+      return rcast<Instance*>(instance)->getInstname().c_str();
+  }
+
 
 }//extern "C"
 }//CoreIR namespace


### PR DESCRIPTION
Is this the proper way to pass the underlying c_str for instname to python? I remember there being issues before related to passing strings through the C api.