### PR TITLE
Add `simulator/` install rule to release makefile

### DIFF
--- a/release/Makefile
+++ b/release/Makefile
@@ -27,6 +27,7 @@ install:
 	install include/coreir/passes/*.h $(prefix)/include/coreir/passes
 	install include/coreir/passes/analysis/* $(prefix)/include/coreir/passes/analysis
 	install include/coreir/passes/transform/* $(prefix)/include/coreir/passes/transform
+	install include/coreir/simulator/* $(prefix)/include/coreir/simulator
 
 .PHONY: uninstall
 uninstall:


### PR DESCRIPTION
This rule is missing in the release Makefile, unfortunately you'll need to do a new release to fix this issue. This breaks the pycoreir/magma/mantle/... master travis builds because they use the install rule in the release package.