### PR TITLE
Extend

### DIFF
--- a/src/definitions/coreVerilog.hpp
+++ b/src/definitions/coreVerilog.hpp
@@ -43,6 +43,8 @@ void CoreIRLoadVerilog_coreir(Context* c) {
       {"mux","sel ? in1 : in0"},
       {"slice","in[hi-1:lo]"},
       {"concat","{in0,in1}"},
+      {"zext","{(width_out-width_in){1'b0},in"},
+      {"sext","{(width_out-width_in){in[width_in-1]},in"},
       {"const","value"}
       //{"term",""}
       //{"reg",""}, 
@@ -84,6 +86,14 @@ void CoreIRLoadVerilog_coreir(Context* c) {
       "input [width0-1:0] in0",
       "input [width1-1:0] in1",
       "output [width0+width1-1:0] out"
+    }},
+    {"zext",{
+      "input [width_in-1:0] in",
+      "output [width_out-1:0] out"
+    }},
+    {"sext",{
+      "input [width_in-1:0] in",
+      "output [width_out-1:0] out"
     }},
     {"const",{"output [width-1:0] out"}},
     {"term",{"input [width-1:0] in"}},

--- a/src/definitions/coreVerilog.hpp
+++ b/src/definitions/coreVerilog.hpp
@@ -43,8 +43,8 @@ void CoreIRLoadVerilog_coreir(Context* c) {
       {"mux","sel ? in1 : in0"},
       {"slice","in[hi-1:lo]"},
       {"concat","{in0,in1}"},
-      {"zext","{(width_out-width_in){1'b0},in"},
-      {"sext","{(width_out-width_in){in[width_in-1]},in"},
+      {"zext","{(width_out-width_in){1'b0},in}"},
+      {"sext","{(width_out-width_in){in[width_in-1]},in}"},
       {"const","value"}
       //{"term",""}
       //{"reg",""}, 

--- a/src/ir/headers/core.hpp
+++ b/src/ir/headers/core.hpp
@@ -43,9 +43,26 @@ void core_convert(Context* c, Namespace* core) {
   
   core->newGeneratorDecl("concat",concatTypeGen,concatParams);
 
-  //TODO sign extend
-  //TODO zero extend
-  //TODO repeat
+  Params extParams({
+    {"width_in",c->Int()},
+    {"width_out",c->Int()}
+  });
+  auto extTypeGen = core->newTypeGen(
+    "extTypeFun",
+    extParams,
+    [](Context* c, Values args) {
+      uint width_in = args.at("width_in")->get<int>();
+      uint width_out = args.at("width_out")->get<int>();
+      ASSERT(width_out >= width_in,"Bad valudes for widths")
+      return c->Record({
+        {"in",c->BitIn()->Arr(width_in)},
+        {"out",c->Bit()->Arr(width_out)}
+      });
+    }
+  );
+  
+  core->newGeneratorDecl("zext",extTypeGen,extParams);
+  core->newGeneratorDecl("sext",extTypeGen,extParams);
 
 }
 


### PR DESCRIPTION
Added the following coreir ops:

coreir.zext (zero extend)
coreir.sext (sign extend)

They both have genparams {"width_in":Int, "width_out":Int}