### PR TITLE
Added strip and wrap

### DIFF
--- a/src/definitions/coreVerilog.hpp
+++ b/src/definitions/coreVerilog.hpp
@@ -45,6 +45,8 @@ void CoreIRLoadVerilog_coreir(Context* c) {
       {"concat","{in0,in1}"},
       {"zext","{(width_out-width_in){1'b0},in}"},
       {"sext","{(width_out-width_in){in[width_in-1]},in}"},
+      {"strip","in"},
+      {"wrap","in"},
       {"const","value"}
       //{"term",""}
       //{"reg",""}, 
@@ -94,6 +96,14 @@ void CoreIRLoadVerilog_coreir(Context* c) {
     {"sext",{
       "input [width_in-1:0] in",
       "output [width_out-1:0] out"
+    }},
+    {"strip",{
+      "input in",
+      "output out"
+    }},
+    {"wrap",{
+      "input in",
+      "output out"
     }},
     {"const",{"output [width-1:0] out"}},
     {"term",{"input [width-1:0] in"}},

--- a/src/ir/headers/core.hpp
+++ b/src/ir/headers/core.hpp
@@ -64,6 +64,51 @@ void core_convert(Context* c, Namespace* core) {
   core->newGeneratorDecl("zext",extTypeGen,extParams);
   core->newGeneratorDecl("sext",extTypeGen,extParams);
 
+
+  //strip
+  Params stripParams({
+    {"type",CoreIRType::make(c)}
+  });
+  auto stripTypeGen = core->newTypeGen(
+    "stripTypeFun",
+    stripParams,
+    [](Context* c, Values args) {
+      Type* type = args.at("type")->get<Type*>();
+      ASSERT(isa<NamedType>(type),"type needs to be a named type");
+      NamedType* ntype = cast<NamedType>(type);
+      ASSERT(!ntype->isGen(),"NYI named type generators");
+      ASSERT(ntype->isBaseType(), "NYI named type that is not Bit or BitIn");
+      ASSERT(ntype->isOutput(), "NYI named types that are not outputs");
+      return c->Record({
+        {"in",ntype->getFlipped()},
+        {"out",ntype->getRaw()}
+      });
+    }
+  );
+  core->newGeneratorDecl("strip",stripTypeGen,stripParams);
+
+  //wrap
+  Params wrapParams({
+    {"type",CoreIRType::make(c)}
+  });
+  auto wrapTypeGen = core->newTypeGen(
+    "wrapTypeFun",
+    wrapParams,
+    [](Context* c, Values args) {
+      Type* type = args.at("type")->get<Type*>();
+      ASSERT(isa<NamedType>(type),"type needs to be a named type");
+      NamedType* ntype = cast<NamedType>(type);
+      ASSERT(!ntype->isGen(),"NYI named type generators");
+      ASSERT(ntype->isBaseType(), "NYI named type that is not Bit or BitIn");
+      ASSERT(ntype->isOutput(), "NYI named type that is not output");
+      return c->Record({
+        {"in",ntype->getRaw()->getFlipped()},
+        {"out",ntype}
+      });
+    }
+  );
+  core->newGeneratorDecl("wrap",wrapTypeGen,wrapParams);
+
 }
 
 void core_state(Context* c, Namespace* core) {


### PR DESCRIPTION
added coreir.strip and coreir.wrap.

both take in an genparam {"type":CoreIRType}

if you want to cast from a clk to a bit, pass in the clk type to strip and it will "strip" away the named type.
if you want to cast from a bit to a clk, pass in the clk type to wrap and it will "wrap" the bit into a clock type.
 you can get the clk type by calling `c->Named("coreir.clk")`

The final interface for strip will look something like:
{"in":Named(coreir.clkIn"), "out": Bit}

The final interface for wrap will look something like:
{"in":BitIn, "out": Named(coreir.clk)}



Currently this is very limited, bit it should (hopefully) work for clk and rst. 








  