### PR TITLE
Eliminated need for to_bv node in rtlil and added a pass to infer clock port

### DIFF
--- a/include/coreir/passes/common.h
+++ b/include/coreir/passes/common.h
@@ -24,6 +24,7 @@
 #include "transform/flattentypes.h"
 #include "transform/packconnections.h"
 #include "transform/unpackconnections.h"
+#include "transform/clockifyinterface.h"
 #include "transform/removebulkconnections.h"
 #include "transform/removepassthroughs.h"
 #include "transform/removeunconnected.h"
@@ -72,6 +73,7 @@ namespace CoreIR {
     pm.addPass(new Passes::AddDirected());
     pm.addPass(new Passes::PackConnections());
     pm.addPass(new Passes::UnpackConnections());
+    pm.addPass(new Passes::ClockifyInterface());
     pm.addPass(new Passes::RegisterInputs("registerinputs"));
     pm.addPass(new Passes::Transform2CombView());
   }

--- a/include/coreir/passes/common.h
+++ b/include/coreir/passes/common.h
@@ -73,7 +73,7 @@ namespace CoreIR {
     pm.addPass(new Passes::AddDirected());
     pm.addPass(new Passes::PackConnections());
     pm.addPass(new Passes::UnpackConnections());
-    pm.addPass(new Passes::ClockifyInterface());
+    pm.addPass(new Passes::ClockifyInterface("clockifyinterface"));
     pm.addPass(new Passes::RegisterInputs("registerinputs"));
     pm.addPass(new Passes::Transform2CombView());
   }

--- a/include/coreir/passes/transform/clockifyinterface.h
+++ b/include/coreir/passes/transform/clockifyinterface.h
@@ -8,12 +8,12 @@ namespace CoreIR {
 namespace Passes {
 
 //This will add directed connection metadata to modules
-  class ClockifyInterface : public ModulePass {
+  class ClockifyInterface : public InstanceGraphPass {
   
   public:
-    static std::string ID;
-    ClockifyInterface() : ModulePass(ID, "Convert any BitIn fields in the interface that are only used as clocks into fields with named type coreir.clkIn") {}
-    bool runOnModule(Module* m) override;
+
+    ClockifyInterface(std::string name) : InstanceGraphPass(name, "Convert any BitIn fields in the interface that are only used as clocks into fields with named type coreir.clkIn") {}
+    bool runOnInstanceGraphNode(InstanceGraphNode& node) override;
 };
 
 }

--- a/include/coreir/passes/transform/clockifyinterface.h
+++ b/include/coreir/passes/transform/clockifyinterface.h
@@ -1,0 +1,22 @@
+#ifndef COREIR_CLOCKIFYINTERFACE_HPP_
+#define COREIR_CLOCKIFYINTERFACE_HPP_
+
+#include "coreir.h"
+
+//Define the analysis passes in CoreIR::Passes
+namespace CoreIR {
+namespace Passes {
+
+//This will add directed connection metadata to modules
+class Clockifyinterface : public ModulePass {
+  
+  public:
+    static std::string ID;
+    Clockifyinterface() : ModulePass(ID, "Convert any BitIn fields in the interface that are only used as clocks into fields with named type coreir.clkIn") {}
+    bool runOnModule(Module* m) override
+};
+
+}
+}
+
+#endif

--- a/include/coreir/passes/transform/clockifyinterface.h
+++ b/include/coreir/passes/transform/clockifyinterface.h
@@ -8,12 +8,12 @@ namespace CoreIR {
 namespace Passes {
 
 //This will add directed connection metadata to modules
-class Clockifyinterface : public ModulePass {
+  class ClockifyInterface : public ModulePass {
   
   public:
     static std::string ID;
-    Clockifyinterface() : ModulePass(ID, "Convert any BitIn fields in the interface that are only used as clocks into fields with named type coreir.clkIn") {}
-    bool runOnModule(Module* m) override
+    ClockifyInterface() : ModulePass(ID, "Convert any BitIn fields in the interface that are only used as clocks into fields with named type coreir.clkIn") {}
+    bool runOnModule(Module* m) override;
 };
 
 }

--- a/src/libs/rtlil.cpp
+++ b/src/libs/rtlil.cpp
@@ -194,18 +194,13 @@ Namespace* CoreIRLoadLibrary_rtlil(CoreIR::Context* c) {
         string opGenName = rtlilCoreirName(name);
         def->addInstance("op0", opGenName, {{"width", Const::make(c, ext_width)}});
 
-        //def->addInstance("conv0", "rtlil.to_bv");
-        //def->addInstance("conv0", "coreir.wrap", );
-
         def->connect("self.A", "extendA.in");
         def->connect("self.B", "extendB.in");
-        
+
         def->connect("extendA.out", "op0.in0");
         def->connect("extendB.out", "op0.in1");
 
         def->connect("op0.out", "self.Y.0");
-        // def->connect("op0.out.0", "conv0.in");
-        // def->connect("conv0.out", "self.Y");
     };
 
     gen->setGeneratorDefFromFun(genFun);

--- a/src/libs/rtlil.cpp
+++ b/src/libs/rtlil.cpp
@@ -194,7 +194,8 @@ Namespace* CoreIRLoadLibrary_rtlil(CoreIR::Context* c) {
         string opGenName = rtlilCoreirName(name);
         def->addInstance("op0", opGenName, {{"width", Const::make(c, ext_width)}});
 
-        def->addInstance("conv0", "rtlil.to_bv");
+        //def->addInstance("conv0", "rtlil.to_bv");
+        //def->addInstance("conv0", "coreir.wrap", );
 
         def->connect("self.A", "extendA.in");
         def->connect("self.B", "extendB.in");
@@ -202,8 +203,9 @@ Namespace* CoreIRLoadLibrary_rtlil(CoreIR::Context* c) {
         def->connect("extendA.out", "op0.in0");
         def->connect("extendB.out", "op0.in1");
 
-        def->connect("op0.out", "conv0.in");
-        def->connect("conv0.out", "self.Y");
+        def->connect("op0.out", "self.Y.0");
+        // def->connect("op0.out.0", "conv0.in");
+        // def->connect("conv0.out", "self.Y");
     };
 
     gen->setGeneratorDefFromFun(genFun);
@@ -309,7 +311,7 @@ Namespace* CoreIRLoadLibrary_rtlil(CoreIR::Context* c) {
       //def->addInstance("toClk0", "rtlil.to_clkIn");
       def->addInstance("toClk0",
                        "coreir.wrap",
-                       {{"type", Const::make(c, c->Named("coreir.clkIn"))}});
+                       {{"type", Const::make(c, c->Named("coreir.clk"))}});
 
       def->connect("self.CLK", "toClk0.in");
       def->connect("toClk0.out", "reg0.clk");

--- a/src/libs/rtlil.cpp
+++ b/src/libs/rtlil.cpp
@@ -78,36 +78,6 @@ std::string rtlilCoreirName(const std::string& name) {
 Namespace* CoreIRLoadLibrary_rtlil(CoreIR::Context* c) {
   auto rtLib = c->newNamespace("rtlil");
 
-  // Casting nodes
-
-  // // Unsigned extend
-  // Params extendParams = {{"width_in", c->Int()}, {"width_out", c->Int()}};
-  // TypeGen* extendTP =
-  //   rtLib->newTypeGen("extend",
-  //                     extendParams,
-  //                     [](Context* c, Values genargs) {
-  //                       uint width_in = genargs.at("width_in")->get<int>();
-  //                       uint width_out = genargs.at("width_out")->get<int>();
-
-  //                       ASSERT(width_in <= width_out, "width_in > width_out in extend node");
-
-  //                       return c->Record({
-  //                           {"in", c->BitIn()->Arr(width_in)},
-  //                             {"out", c->Bit()->Arr(width_out)}
-  //                         });
-  //                     });
-
-  // rtLib->newGeneratorDecl("extend", extendTP, extendParams);
-
-  // // Cast bit to clock
-  // Type* toClockType = c->Record({{"in", c->BitIn()},
-  //       {"out", c->Named("coreir.clk")}});
-  // rtLib->newModuleDecl("to_clkIn", toClockType);
-
-  // // Cast bit to bit vector of length one
-  // Type* toBVType = c->Record({{"in", c->BitIn()}, {"out", c->Bit()->Arr(1)}});
-  // rtLib->newModuleDecl("to_bv", toBVType);
-
   // Operation related nodes
   vector<string> rtlilBinops{"and", "or", "xor", "xnor",
       "shl", "shr", "sshl", "sshr",

--- a/src/passes/transform/clockifyinterface.cpp
+++ b/src/passes/transform/clockifyinterface.cpp
@@ -1,0 +1,20 @@
+#include "coreir.h"
+#include "coreir/passes/transform/clockifyinterface.h"
+
+using namespace std;
+using namespace CoreIR;
+
+
+//Do not forget to set this static variable!!
+string Passes::Clockifyinterface::ID = "clockifyinterface";
+bool Passes::Clockifyinterface::runOnModule(Module* m) {
+  if (!m->hasDef()) {
+    return false;
+  }
+
+  cout << "Processing module: " << m->getName() << endl;
+
+  ModuleDef* def = m->getDef();
+
+  return true;
+}

--- a/src/passes/transform/clockifyinterface.cpp
+++ b/src/passes/transform/clockifyinterface.cpp
@@ -6,15 +6,23 @@ using namespace CoreIR;
 
 
 //Do not forget to set this static variable!!
-string Passes::Clockifyinterface::ID = "clockifyinterface";
-bool Passes::Clockifyinterface::runOnModule(Module* m) {
+string Passes::ClockifyInterface::ID = "clockifyinterface";
+bool Passes::ClockifyInterface::runOnModule(Module* m) {
   if (!m->hasDef()) {
     return false;
   }
 
+  ModuleDef* def = m->getDef();
+  Context* c = def->getContext();
+
   cout << "Processing module: " << m->getName() << endl;
 
-  ModuleDef* def = m->getDef();
+  Wireable* topclk = nullptr;
+  for (auto field : m->getType()->getRecord()) {
+    if (field.second == c->BitIn()) {
+      topclk = def->sel("self")->sel(field.first);
+    }
+  }
 
   return true;
 }

--- a/tests/simulator/partial_evaluation.cpp
+++ b/tests/simulator/partial_evaluation.cpp
@@ -137,6 +137,11 @@ namespace CoreIR {
 
       current.valMap[sel] = val;
     }
+
+    void incrementTime() {
+      last = current;
+      current = {};
+    }
     
     void eval() {
 

--- a/tests/unit/clockify_interface.cpp
+++ b/tests/unit/clockify_interface.cpp
@@ -39,7 +39,7 @@ int main() {
   
   cl->setDef(def);
 
-  c->runPasses({"clockifyinterface"});
+  c->runPasses({"rungenerators", "clockifyinterface"});
 
   // clockification deletes the cast to clock
   assert(cl->getDef()->getInstances().size() == 1);

--- a/tests/unit/clockify_interface.cpp
+++ b/tests/unit/clockify_interface.cpp
@@ -39,5 +39,10 @@ int main() {
   
   cl->setDef(def);
 
+  c->runPasses({"clockifyinterface"});
+
+  // clockification deletes the cast to clock
+  assert(cl->getDef()->getInstances().size() == 1);
+
   deleteContext(c);
 }

--- a/tests/unit/clockify_interface.cpp
+++ b/tests/unit/clockify_interface.cpp
@@ -1,0 +1,22 @@
+#include "coreir.h"
+#include "coreir/passes/transform/clockifyinterface.h"
+
+using namespace std;
+using namespace CoreIR;
+
+int main() {
+  Context* c = newContext();
+
+  Namespace* g = c->getGlobal();
+
+  uint width = 8;
+
+  Type* clType = c->Record({
+      {"clk", c->BitIn()},
+        {"in", c->BitIn()->Arr(width)}
+    });
+
+  CoreIRLoadLibrary_rtlil(c);
+
+  deleteContext(c);
+}


### PR DESCRIPTION
@rdaly525 This should fix the to_bv error you mentioned when flattening the CGRA.

I also added a pass to infer which ports (if any) in a converted design are clocks and to modify the module to use clkIn instead of BitIn for those ports.