### PR TITLE
Symtable

### DIFF
--- a/include/coreir/ir/context.h
+++ b/include/coreir/ir/context.h
@@ -11,6 +11,8 @@ class Context {
   Namespace* global;
   std::map<std::string,Namespace*> namespaces;
   PassManager* pm;
+  
+  bool symtable = false;
 
   uint maxErrors;
   std::vector<std::string> errors;
@@ -57,8 +59,8 @@ class Context {
     void printerrors();
     void print();
 
-    //bool linkLib(Namespace* defns, Namespace* declns);
-    
+    void enSymtable() {symtable = true;}
+    bool hasSymtable() { return symtable;}
     Namespace* newNamespace(std::string name);
     bool hasNamespace(std::string name) { return namespaces.count(name) > 0; }
     Namespace* getNamespace(std::string s);

--- a/src/passes/transform/flatten.cpp
+++ b/src/passes/transform/flatten.cpp
@@ -9,7 +9,7 @@ bool Passes::Flatten::runOnInstanceGraphNode(InstanceGraphNode& node) {
   //cout << "inlining all " << node.getModule()->toString() << endl;
   //cout << "number of instances = " << node.getInstanceList().size() << endl;
   bool changed = false;
-  int i = 0;
+  //int i = 0;
   for (auto inst : node.getInstanceList()) {
     //cout << "inlining " << i++ << endl;
     changed |= inlineInstance(inst);

--- a/src/passes/transform/flatten.cpp
+++ b/src/passes/transform/flatten.cpp
@@ -6,8 +6,12 @@ using namespace CoreIR;
 
 string Passes::Flatten::ID = "flatten";
 bool Passes::Flatten::runOnInstanceGraphNode(InstanceGraphNode& node) {
+  //cout << "inlining all " << node.getModule()->toString() << endl;
+  //cout << "number of instances = " << node.getInstanceList().size() << endl;
   bool changed = false;
+  int i = 0;
   for (auto inst : node.getInstanceList()) {
+    //cout << "inlining " << i++ << endl;
     changed |= inlineInstance(inst);
   }
   return changed;

--- a/tests/simulator/interpreter.cpp
+++ b/tests/simulator/interpreter.cpp
@@ -293,6 +293,7 @@ namespace CoreIR {
     }
 
     SECTION("Counter") {
+      c->enSymtable();
 
       addCounter(c, g);
 
@@ -1294,6 +1295,8 @@ namespace CoreIR {
     }
 
     SECTION("Counter 2 read by original name") {
+      c->enSymtable();
+
       if (!loadFromFile(c,"./tmprb3ud4p2.json")) {
     	cout << "Could not Load from json!!" << endl;
     	c->die();

--- a/tests/simulator/linebuffermem.json
+++ b/tests/simulator/linebuffermem.json
@@ -75,8 +75,7 @@
           ["m0$waddr$enMux.out","m0$waddr$reg0.in"],
           ["m0$waddr$enMux.sel","self.wen"],
           ["m0$waddr$reg0.clk","self.clk"]
-        ],
-        "metadata":{"symtable":{"m0$raddr.clk":["m0","clk"],"m0$raddr.en":["m0","wen"],"m0$raddr.in":["m0$add_r","out"],"m0$raddr.out":["m0$mem","raddr"],"m0$waddr.clk":["m0","clk"],"m0$waddr.en":["m0","wen"],"m0$waddr.in":["m0$add_w","out"],"m0$waddr.out":["m0$mem","waddr"],"m0.clk":["self","clk"],"m0.rdata":["self","rdata"],"m0.valid":["self","valid"],"m0.wdata":["self","wdata"],"m0.wen":["self","wen"]}}
+        ]
       }
     }
   }


### PR DESCRIPTION
This PR disables the symtable creation by default.

To turn it on, just call Context.enSymtable();

Note, a few simulation tests are failing. I suspect that they require the symtable.