### PR TITLE
Use memset to initialize variable-sized object

### DIFF
--- a/src/libs/commonlib.cpp
+++ b/src/libs/commonlib.cpp
@@ -944,7 +944,8 @@ Namespace* CoreIRLoadLibrary_commonlib(Context* c) {
 
           uint num_indices = num_dims - 1;
           //cout << "we have " << num_dims << " dims and " << num_indices << " input dims" << endl;
-          uint indices[num_indices] = { 0 };
+          uint indices[num_indices];
+          memset( indices, 0, num_indices*sizeof(uint) );
 
           bool create_more_lbmems = true;
           while (create_more_lbmems) {


### PR DESCRIPTION
Clang on macOS throws the following error

```
commonlib.cpp:947:24: error: variable-sized object may not be initialized
          uint indices[num_indices] = { 0 };
```