### PR TITLE
Patch verilog

### DIFF
--- a/src/definitions/corebitVerilog.hpp
+++ b/src/definitions/corebitVerilog.hpp
@@ -86,8 +86,6 @@ void CoreIRLoadVerilog_corebit(Context* c) {
   }
 
   bit->getModule("const")->getMetaData()["verilog"]["parameters"] = {"value"};
-  bit->getModule("const")->getMetaData()["verilog"]["interface"] = bitIMap.at("const");
-  bit->getModule("const")->getMetaData()["verilog"]["definition"] = "assign out = value;";
   
   {
     //Term

--- a/src/definitions/corebitVerilog.hpp
+++ b/src/definitions/corebitVerilog.hpp
@@ -86,6 +86,8 @@ void CoreIRLoadVerilog_corebit(Context* c) {
   }
 
   bit->getModule("const")->getMetaData()["verilog"]["parameters"] = {"value"};
+  bit->getModule("const")->getMetaData()["verilog"]["interface"] = bitIMap.at("const");
+  bit->getModule("const")->getMetaData()["verilog"]["definition"] = "assign out = value;";
   
   {
     //Term

--- a/src/passes/analysis/verilog.cpp
+++ b/src/passes/analysis/verilog.cpp
@@ -26,7 +26,6 @@ bool Passes::Verilog::runOnInstanceGraphNode(InstanceGraphNode& node) {
   
   //Create a new Vmodule for this node
   Module* m = node.getModule();
-  m->print();
   if (m->isGenerated() && !m->hasDef()) { //TODO linking concern
     Generator* g = m->getGenerator();
     VModule* vmod;

--- a/src/passes/analysis/verilog.cpp
+++ b/src/passes/analysis/verilog.cpp
@@ -26,6 +26,7 @@ bool Passes::Verilog::runOnInstanceGraphNode(InstanceGraphNode& node) {
   
   //Create a new Vmodule for this node
   Module* m = node.getModule();
+  m->print();
   if (m->isGenerated() && !m->hasDef()) { //TODO linking concern
     Generator* g = m->getGenerator();
     VModule* vmod;
@@ -49,15 +50,16 @@ bool Passes::Verilog::runOnInstanceGraphNode(InstanceGraphNode& node) {
   }
   VModule* vmod = new VModule(m);
   modMap[m] = vmod;
-  modList.push_back(vmod);
   if (vmod->hasDef()) {
     ASSERT(!m->hasDef(),"NYI linking error"); //TODO figure out this better
+    modList.push_back(vmod);
     return false;
   }
   if (!m->hasDef()) {
     this->external.insert(m);
     return false;
   }
+  modList.push_back(vmod);
 
   ModuleDef* def = m->getDef();
   


### PR DESCRIPTION
added a Verilog definition for corebit_const to corebitVerilog

externally linked modules were being emitted when they shouldn't. basically check and exit before adding them to `modList`.