### PR TITLE
remove simulator layout warning

### DIFF
--- a/include/coreir/simulator/layout.h
+++ b/include/coreir/simulator/layout.h
@@ -159,6 +159,7 @@ namespace CoreIR {
       }
 
       int oldSize = varDecls.size();
+      
 
       std::vector<std::pair<Type*, std::string> > adj;
       for (auto& ind : adjacentInds) {
@@ -176,7 +177,7 @@ namespace CoreIR {
       varDecls = others;
       concat(varDecls, adj);
 
-      assert(varDecls.size() == ((unsigned) oldSize));
+      ASSERT(varDecls.size() == ((unsigned) oldSize), "oldsize is " + std::to_string(oldSize));
     }
 
     std::string lastClkVarName(InstanceValue& clk) {


### PR DESCRIPTION
This needs to be changed to prevent a warning in building halide (unused variable).