### PR TITLE
Rename COREWireableGetModuleDef -> COREWireableGetContainer

### DIFF
--- a/include/coreir-c/coreir.h
+++ b/include/coreir-c/coreir.h
@@ -84,7 +84,7 @@ extern COREWireable* COREConnectionGetFirst(COREConnection* c);
 extern COREWireable* COREConnectionGetSecond(COREConnection* c);
 extern COREWireable** COREWireableGetConnectedWireables(COREWireable* wireable, int* numWireables);
 extern COREWireable* COREModuleDefSelect(COREModuleDef* m, char* name);
-extern COREModuleDef* COREWireableGetModuleDef(COREWireable* w);
+extern COREModuleDef* COREWireableGetContainer(COREWireable* w);
 extern COREModule* COREModuleDefGetModule(COREModuleDef* m);
 extern const char** COREWireableGetSelectPath(COREWireable* w, int* num_selects);
 extern void COREPrintErrors(COREContext* c);

--- a/src/coreir-c/coreir-c.cpp
+++ b/src/coreir-c/coreir-c.cpp
@@ -329,7 +329,7 @@ extern "C" {
     return rcast<COREWireable*>(rcast<ModuleDef*>(m)->sel(string(name)));
   }
 
-  COREModuleDef* COREWireableGetModuleDef(COREWireable* w) {
+  COREModuleDef* COREWireableGetContainer(COREWireable* w) {
     return rcast<COREModuleDef*>(rcast<Wireable*>(w)->getContainer());
   }
 


### PR DESCRIPTION
Fixes https://github.com/rdaly525/coreir/issues/135#issuecomment-365362515