### PR TITLE
Support for unknown values and high impedance values in bit vectors

### DIFF
--- a/include/coreir/ir/dynamic_bit_vector.h
+++ b/include/coreir/ir/dynamic_bit_vector.h
@@ -225,7 +225,7 @@ namespace bsim {
     quad_value_bit_vector(const int N_) : N(N_) {
       //bits.resize(NUM_BYTES(N));
       bits.resize(N);
-      for (uint i = 0; i < ((int) bits.size()); i++) {
+      for (uint i = 0; i < ((uint) bits.size()); i++) {
 	bits[i] = quad_value(0);
       }
       

--- a/include/coreir/ir/dynamic_bit_vector.h
+++ b/include/coreir/ir/dynamic_bit_vector.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <bitset>
 #include <cassert>
 #include <iostream>

--- a/include/coreir/ir/dynamic_bit_vector.h
+++ b/include/coreir/ir/dynamic_bit_vector.h
@@ -6,6 +6,8 @@
 #include <stdint.h>
 #include <type_traits>
 
+// This is a comment
+
 typedef int8_t  bv_sint8;
 typedef int32_t  bv_sint32;
 
@@ -223,7 +225,7 @@ namespace bsim {
     quad_value_bit_vector(const int N_) : N(N_) {
       //bits.resize(NUM_BYTES(N));
       bits.resize(N);
-      for (uint i = 0; i < bits.size(); i++) {
+      for (uint i = 0; i < ((int) bits.size()); i++) {
 	bits[i] = quad_value(0);
       }
       
@@ -346,7 +348,7 @@ namespace bsim {
       bits.resize(N);
 
       for (int i = 0; i < N; i++) {
-        if (i < sizeof(int)*8) {
+        if (i < ((int) sizeof(int)*8)) {
           set(i, quad_value((val >> i) & 0x01));
         } else {
           set(i, quad_value(0));
@@ -361,13 +363,13 @@ namespace bsim {
 
       std::string hex_digits = "";
 
-      for (int i = 0; i < bits.size(); i += 4) {
+      for (int i = 0; i < ((int) bits.size()); i += 4) {
         unsigned char bit_l = 0;
         bool found_abnormal = false;
 
         for (int j = 0; j < 4; j++) {
           int index = i + j;
-          if (index >= bits.size()) {
+          if (index >= ((int) bits.size())) {
           } else {
             if (bits[index].is_binary()) {
               bit_l |= (bits[index].binary_value() & 0x01) << j;
@@ -928,7 +930,7 @@ namespace bsim {
   quad_value_bit_vector
   extend(const quad_value_bit_vector& a, const int extra_bits) {
     quad_value_bit_vector res(a.bitLength() + extra_bits);
-    for (uint i = 0; i < a.bitLength(); i++) {
+    for (int i = 0; i < a.bitLength(); i++) {
       res.set(i, a.get(i));
     }
 

--- a/include/coreir/ir/dynamic_bit_vector.h
+++ b/include/coreir/ir/dynamic_bit_vector.h
@@ -6,9 +6,6 @@
 #include <stdint.h>
 #include <type_traits>
 
-#define GEN_NUM_BYTES(N) (((N) / 8) + 1 - (((N) % 8 == 0)))
-#define NUM_BYTES(N) GEN_NUM_BYTES(N)
-
 typedef int8_t  bv_sint8;
 typedef int32_t  bv_sint32;
 
@@ -16,6 +13,9 @@ typedef uint8_t  bv_uint8;
 typedef uint16_t bv_uint16;
 typedef uint32_t bv_uint32;
 typedef uint64_t bv_uint64;
+
+#define QBV_UNKNOWN_VALUE 2
+#define QBV_HIGH_IMPEDANCE_VALUE 3
 
 namespace bsim {
 
@@ -53,6 +53,10 @@ namespace bsim {
       return "1110";
     case 'f':
       return "1111";
+    case 'x':
+      return "xxxx";
+    case 'z':
+      return "zzzz";
       
     default:
       assert(false);
@@ -61,18 +65,166 @@ namespace bsim {
     assert(false);
   }
 
-  class dynamic_bit_vector {
-    std::vector<unsigned char> bits;
+  class quad_value {
+  protected:
+    unsigned char value;
+
+  public:
+    quad_value() : value(0) {}
+
+    quad_value(unsigned char v) : value(v) {
+      assert(v < 4);
+    }
+
+    unsigned char get_char() const {
+      return value;
+    }
+
+    bool is_binary() const {
+      return (value == 1) || (value == 0);
+    }
+
+    bool is_unknown() const {
+      return (value == QBV_UNKNOWN_VALUE);
+    }
+
+    bool is_high_impedance() const {
+      return (value == QBV_HIGH_IMPEDANCE_VALUE);
+    }
+    
+    quad_value plus(const quad_value& other) const {
+      assert(other.is_binary());
+      assert(is_binary());
+
+      return quad_value((other.binary_value() + binary_value()) & 0x01);
+    }
+    
+    bool equals(const quad_value& other) const {
+      if ((value == QBV_UNKNOWN_VALUE) ||
+          (other.value == QBV_UNKNOWN_VALUE)) {
+        return false;
+      }
+
+      // All high impedance values are equal
+      return value == other.value;
+    }
+
+    unsigned char binary_value() const {
+      assert((value == 1) || (value == 0));
+      return value;
+    }
+
+    std::string binary_string() const {
+      if (value == 1) {
+        return "1";
+      } else if (value == 0) {
+        return "0";
+      } else if (value == QBV_UNKNOWN_VALUE) {
+        return "x";
+      } else if (value == QBV_HIGH_IMPEDANCE_VALUE) {
+        return "z";
+      }
+      assert(false);
+    }
+
+    void print(std::ostream& out) const {
+      if (value == 1) {
+        out << "1";
+      } else if (value == 0) {
+        out << "0";
+      } else if (value == QBV_UNKNOWN_VALUE) {
+        out << "x";
+      } else if (value == QBV_HIGH_IMPEDANCE_VALUE) {
+        out << "z";
+      }
+    }
+  };
+
+  static inline quad_value operator+(const quad_value& a,
+                                     const quad_value& b) {
+    return a.plus(b);
+  }
+
+  static inline quad_value operator&(const quad_value& a,
+                                     const quad_value& b) {
+    assert(a.is_binary());
+    assert(b.is_binary());
+
+    return quad_value(a.binary_value() & b.binary_value());
+  }
+
+  static inline quad_value operator|(const quad_value& a,
+                                     const quad_value& b) {
+
+    assert(a.is_binary());
+    assert(b.is_binary());
+
+    return quad_value(a.binary_value() | b.binary_value());
+  }
+
+  static inline quad_value operator^(const quad_value& a,
+                                     const quad_value& b) {
+    assert(a.is_binary());
+    assert(b.is_binary());
+
+    return quad_value(a.binary_value() ^ b.binary_value());
+
+  }
+
+  static inline bool operator>(const quad_value& a,
+                               const quad_value& b) {
+
+    assert(a.is_binary());
+    assert(b.is_binary());
+
+    return a.binary_value() > b.binary_value();
+  }
+
+  static inline bool operator<(const quad_value& a,
+                               const quad_value& b) {
+
+    assert(a.is_binary());
+    assert(b.is_binary());
+
+    return a.binary_value() < b.binary_value();
+  }
+  
+  static inline quad_value operator~(const quad_value& a) {
+
+    assert(a.is_binary());
+
+    return quad_value((~a.binary_value()) & 0x01);
+  }
+  
+  static inline bool operator==(const quad_value& a,
+                                const quad_value& b) {
+    return a.equals(b);
+  }
+
+  static inline bool operator!=(const quad_value& a,
+                                const quad_value& b) {
+    return !(a == b);
+  }
+
+  static inline std::ostream& operator<<(std::ostream& out,
+					 const quad_value& a) {
+    a.print(out);
+    return out;
+  }  
+
+  class quad_value_bit_vector {
+    std::vector<quad_value> bits;
     int N;
 
   public:
 
-    dynamic_bit_vector() : N(0) {}
+    quad_value_bit_vector() : N(0) {}
 
-    dynamic_bit_vector(const int N_) : N(N_) {
-      bits.resize(NUM_BYTES(N));
+    quad_value_bit_vector(const int N_) : N(N_) {
+      //bits.resize(NUM_BYTES(N));
+      bits.resize(N);
       for (uint i = 0; i < bits.size(); i++) {
-	bits[i] = 0;
+	bits[i] = quad_value(0);
       }
       
       for (int i = 0; i < N; i++) {
@@ -80,7 +232,7 @@ namespace bsim {
       }
     }
 
-    dynamic_bit_vector(const std::string& str_raw) : N(0) {
+    quad_value_bit_vector(const std::string& str_raw) : N(0) {
       std::string bv_size = "";
       int ind = 0;
       while (str_raw[ind] != '\'') {
@@ -94,7 +246,7 @@ namespace bsim {
       ind++;
 
       char format = str_raw[ind];
-      (void) format;
+
       assert((format == 'b') ||
              (format == 'h') ||
              (format == 'd'));
@@ -109,7 +261,8 @@ namespace bsim {
 
       int num_bits = stoi(bv_size);
       N = num_bits;
-      bits.resize(NUM_BYTES(num_bits));
+      //bits.resize(NUM_BYTES(num_bits));
+      bits.resize(num_bits);
       for (int i = 0; i < ((int) bits.size()); i++) {
         bits[i] = 0;
       }
@@ -129,7 +282,18 @@ namespace bsim {
         for (int j = hex_to_binary.size() - 1; j >= 0; j--) {
           // Dont add past the end
           if ((bit_ind + k) < bitLength()) {
-            set(bit_ind + k, hex_to_binary[j]);
+            //std::cout << "setting digit = " << hex_to_binary[j] << std::endl;
+            if (hex_to_binary[j] == '1') {
+              set(bit_ind + k, quad_value(1));
+            } else if (hex_to_binary[j] == '0') {
+              set(bit_ind + k, quad_value(0));
+            } else if (hex_to_binary[j] == 'x') {
+              set(bit_ind + k, quad_value(QBV_UNKNOWN_VALUE));
+            } else if (hex_to_binary[j] == 'z') {
+              set(bit_ind + k, quad_value(QBV_HIGH_IMPEDANCE_VALUE));
+            } else {
+              assert(false);
+            }
             k++;
           } else {
             assert(hex_to_binary[j] == '0');
@@ -140,58 +304,108 @@ namespace bsim {
 
     }
 
-    dynamic_bit_vector(const int N_, const std::string& str_raw) : N(N_) {
+    quad_value_bit_vector(const int N_, const std::string& str_raw) : N(N_) {
       int num_digits = 0;
       std::string str;
       for (int i = 0; i < ((int) str_raw.size()); i++) {
 	if (isdigit(str_raw[i])) {
 	  num_digits++;
 	  str += str_raw[i];
-	} else {
+	} else if (str_raw[i] == 'z') {
+          str += str_raw[i];
+        } else if (str_raw[i] == 'x') {
+          str += str_raw[i];
+        } else {
 	  assert(str_raw[i] == '_');
 	}
       }
       assert(num_digits <= N);
 
       int len = str.size();      
-      bits.resize(NUM_BYTES(N));
+
+      bits.resize(N);
       for (int i = len - 1; i >= 0; i--) {
         unsigned char val = (str[i] == '0') ? 0 : 1;
+        if (str[i] == 'x') {
+          val = QBV_UNKNOWN_VALUE;
+        }
+        if (str[i] == 'z') {
+          val = QBV_HIGH_IMPEDANCE_VALUE;
+        }
+
         int ind = len - i - 1;
         set(ind, val);
       }
-      for (int i = N-1; i>=len; i--) {
+      for (int i = N - 1; i >= len; i--) {
         set(i,0);
       }
     }
 
-    dynamic_bit_vector(const int N_, const int val) : N(N_) {
-      bits.resize(NUM_BYTES(N));
-      *((int*) (&(bits[0]))) = val;
+    quad_value_bit_vector(const int N_, const int val) : N(N_) {
+      //bits.resize(NUM_BYTES(N));
+      bits.resize(N);
+
+      for (int i = 0; i < N; i++) {
+        if (i < sizeof(int)*8) {
+          set(i, quad_value((val >> i) & 0x01));
+        } else {
+          set(i, quad_value(0));
+        }
+      }
     }
 
+    // Note: Need to check that all digits in each clump that
+    // contain 'x' or 'z' values are 'x' or 'z' values
     std::string hex_string() {
       std::string hex = std::to_string(N) + "'h";
 
-      for (int i = bits.size() - 1; i >= 0; i--) {
-        char bit_h = bits[i] & 0x0f;
-        char bit_l = (bits[i] >> 4) & 0x0f;
+      std::string hex_digits = "";
 
-        hex += bit_l > 9 ? bit_l + 87 : bit_l + 48;
-        hex += bit_h > 9 ? bit_h + 87 : bit_h + 48;
+      for (int i = 0; i < bits.size(); i += 4) {
+        unsigned char bit_l = 0;
+        bool found_abnormal = false;
+
+        for (int j = 0; j < 4; j++) {
+          int index = i + j;
+          if (index >= bits.size()) {
+          } else {
+            if (bits[index].is_binary()) {
+              bit_l |= (bits[index].binary_value() & 0x01) << j;
+            } else if (bits[index].is_unknown()) {
+              bit_l = 'x';
+              found_abnormal = true;
+              break;
+            } else {
+              assert(bits[index].is_high_impedance());
+              bit_l = 'z';
+              found_abnormal = true;
+              break;
+            }
+          }
+        }
+
+        if (!found_abnormal) {
+          hex_digits += bit_l > 9 ? bit_l + 87 : bit_l + 48;
+        } else {
+          hex_digits += bit_l;
+        }
+
       }
-      return hex;
+
+      std::reverse(std::begin(hex_digits), std::end(hex_digits));
+      return hex + hex_digits;
     }
     
-    dynamic_bit_vector(const dynamic_bit_vector& other) {
+    quad_value_bit_vector(const quad_value_bit_vector& other) {
       bits.resize(other.bits.size());
       N = other.bitLength();
-      for (int i = 0; i < NUM_BYTES(N); i++) {
+
+      for (int i = 0; i < other.bitLength(); i++) {
 	bits[i] = other.bits[i];
       }
     }
 
-    dynamic_bit_vector& operator=(const dynamic_bit_vector& other) {
+    quad_value_bit_vector& operator=(const quad_value_bit_vector& other) {
       if (&other == this) {
     	return *this;
       }
@@ -199,34 +413,56 @@ namespace bsim {
       bits.resize(other.bits.size());
 
       N = other.bitLength();
-      for (int i = 0; i < NUM_BYTES(N); i++) {
+
+      for (int i = 0; i < other.bitLength(); i++) {
         bits[i] = other.bits[i];
       }
-
 
       return *this;
     }
 
-    inline void set(const int ind, const unsigned char val) {
-      int byte_num = ind / 8;
-      int bit_num = ind % 8;
+    std::string binary_string() const {
+      std::string str = "";
+      const int N = bitLength();
+      for (int i = N - 1; i >= 0; i--) {
+        str += get(i).binary_string();
+      }
 
-      unsigned char old = bits[byte_num];
-      // The & 0x01 only seems to be needed for logical not
-      old ^= (-(val & 0x01) ^ old) & (1 << bit_num);
+      return str;
+    }
+    
+    inline void set(const int ind, const int v) {
+      // if ((v != 0) && (v != 1)) {
+      //   std::cout << "\tv = " << (int) v << std::endl;
+      // }
+      // assert((v == 0) || (v == 1));
 
-      bits[byte_num] = old;
+      bits[ind] = quad_value(v);
     }
 
-    unsigned char get(const int ind) const {
-      int byte_num = ind / 8;
-      int bit_num = ind % 8;
+    inline void set(const int ind, const quad_value val) {
+      //const unsigned char val) {
+      // int byte_num = ind / 8;
+      // int bit_num = ind % 8;
 
-      unsigned char target_byte = bits[byte_num];
-      return 0x01 & (target_byte >> bit_num);
+      // unsigned char old = bits[byte_num];
+      // // The & 0x01 only seems to be needed for logical not
+      // old ^= (-(val & 0x01) ^ old) & (1 << bit_num);
+
+      //bits[byte_num] = old;
+      bits[ind] = val;
     }
 
-    inline bool equals(const dynamic_bit_vector& other) const {
+    quad_value get(const int ind) const {
+      return bits[ind];
+      // int byte_num = ind / 8;
+      // int bit_num = ind % 8;
+
+      // unsigned char target_byte = bits[byte_num];
+      // return 0x01 & (target_byte >> bit_num);
+    }
+
+    inline bool equals(const quad_value_bit_vector& other) const {
 
       if (other.bitLength() != this->bitLength()) {
         return false;
@@ -243,10 +479,17 @@ namespace bsim {
 
     template<typename ConvType>
     ConvType to_type() const {
-      ConvType tmp = *(const_cast<ConvType*>((const ConvType*) (&(bits[0]))));
-      //TODO FIXME I am a sketchy hack.
-      ConvType mask = sizeof(ConvType) > bits.size() ? (1<<N)-1 : -1; 
-      return tmp & mask;
+      ConvType tmp = 0;
+      ConvType exp = 1;
+      for (int i = 0; i < bitLength(); i++) {
+        tmp += exp*get(i).binary_value();
+        exp *= 2;
+      }
+      return tmp;
+      // ConvType tmp = *(const_cast<ConvType*>((const ConvType*) (&(bits[0]))));
+      // //TODO FIXME I am a sketchy hack.
+      // ConvType mask = sizeof(ConvType) > bits.size() ? (1<<N)-1 : -1; 
+      // return tmp & mask;
     }
 
     inline bv_uint64 as_native_int32() const {
@@ -276,192 +519,37 @@ namespace bsim {
   };
 
   static inline std::ostream& operator<<(std::ostream& out,
-					 const dynamic_bit_vector& a) {
-    const int N = a.bitLength();
-    for (int i = N - 1; i >= 0; i--) {
-      if (a.get(i) == 0) {
-	out << "0";
-      } else if (a.get(i) == 1) {
-	out << "1";
-      } else {
-	assert(false);
-      }
-    }
+					 const quad_value_bit_vector& a) {
+    out << a.binary_string();
 
     return out;
   }
 
-  static inline bool operator==(const dynamic_bit_vector& a,
-				const dynamic_bit_vector& b) {
+  static inline bool operator==(const quad_value_bit_vector& a,
+				const quad_value_bit_vector& b) {
     return a.equals(b);
   }
 
-  static inline unsigned char highBit(const dynamic_bit_vector& a) {
+  static inline quad_value highBit(const quad_value_bit_vector& a) {
     return a.get(a.bitLength() - 1);
   }
 
-  // template<int N>
-  // class unsigned_int {
-  // protected:
-  //   dynamic_bit_vector<N> bits;
-
-  // public:
-  //   unsigned_int() {}
-
-  //   unsigned_int(const std::string& bitstr) : bits(bitstr){}
-
-  //   unsigned_int(const dynamic_bit_vector<N>& bits_) : bits(bits_) {}
-
-  //   unsigned_int(const bv_uint8 val) : bits(val) {}
-  //   unsigned_int(const bv_uint16 val) : bits(val) {}
-  //   unsigned_int(const bv_uint32 val) : bits(val) {}
-  //   unsigned_int(const bv_uint64 val) : bits(val) {}
-
-  //   void set(const int ind, const unsigned char val) {
-  //     bits.set(ind, val);
-  //   }
-
-  //   dynamic_bit_vector<N> get_bits() const { return bits; }    
-
-  //   unsigned char get(const int ind) const { return bits.get(ind); }
-
-  //   inline bool equals(const unsigned_int<N>& other) const {
-  //     return (this->bits).equals((other.bits));
-  //   }
-
-  //   inline bv_uint64 as_native_uint64() const {
-  //     return bits.as_native_uint64();
-  //   }
-    
-  //   inline bv_uint32 as_native_uint32() const {
-  //     return bits.as_native_uint32();
-  //   }
-
-  //   inline bv_uint16 as_native_uint16() const {
-  //     return bits.as_native_uint16();
-  //   }
-
-  //   inline bv_uint8 as_native_uint8() const {
-  //     return bits.as_native_uint8();
-  //   }
-    
-  //   inline std::ostream& print(std::ostream& out) const {
-  //     out << bits << "U";
-  //     return out;
-  //   }
-    
-  // };
-
-  // template<int N>
-  // class signed_int {
-  // protected:
-  //   dynamic_bit_vector<N> bits;
-
-  // public:
-  //   signed_int() {}
-
-
-  //   signed_int(const dynamic_bit_vector<N>& bits_) : bits(bits_) {}
-
-  //   signed_int(const int val) : bits(val) {}
-
-  //   signed_int(const std::string& bitstr) : bits(bitstr) {}
-
-  //   signed_int(const bv_uint8 val) : bits(val) {}
-  //   signed_int(const bv_uint16 val) : bits(val) {}
-  //   signed_int(const bv_uint32 val) : bits(val) {}
-  //   signed_int(const bv_uint64 val) : bits(val) {}
-
-  //   void set(const int ind, const unsigned char val) {
-  //     bits.set(ind, val);
-  //   }
-
-  //   dynamic_bit_vector<N> get_bits() const { return bits; }
-
-  //   unsigned char get(const int ind) const { return bits.get(ind); }
-
-  //   inline bool equals(const signed_int<N>& other) const {
-  //     return (this->bits).equals((other.bits));
-  //   }
-
-  //   template<int HighWidth>
-  //   signed_int<HighWidth> sign_extend() const {
-  //     signed_int<HighWidth> hw;
-
-  //     for (int i = 0; i < N; i++) {
-  // 	hw.set(i, get(i));
-  //     }
-    
-  //     if (get(N - 1) == 0) {
-      
-  // 	return hw;
-  //     }
-
-  //     for (int i = N; i < HighWidth; i++) {
-  // 	hw.set(i, 1);
-  //     }
-
-  //     return hw;
-  //   }
-    
-  //   bv_sint32 as_native_int32() const {
-  //     if (N < 32) {
-  // 	signed_int<32> extended = sign_extend<32>();
-
-  // 	dynamic_bit_vector<32> bv = extended.get_bits();
-
-  // 	return bv.as_native_int32();
-  //     }
-
-  //     if (N == 32) {
-  // 	return get_bits().as_native_int32();
-  //     }
-
-  //     assert(false);
-  //   }
-
-  //   template<typename ConvType>
-  //   ConvType to_type() const {
-  //     return bits.template to_type<ConvType>();
-  //   }
-    
-  //   inline bv_uint64 as_native_uint64() const {
-  //     return bits.as_native_uint64();
-  //   }
-    
-  //   inline bv_uint32 as_native_uint32() const {
-  //     return bits.as_native_uint32();
-  //   }
-
-  //   inline bv_uint16 as_native_uint16() const {
-  //     return bits.as_native_uint16();
-  //   }
-
-  //   inline bv_uint8 as_native_uint8() const {
-  //     return bits.as_native_uint8();
-  //   }
-    
-  //   inline std::ostream& print(std::ostream& out) const {
-  //     out << bits << "S";
-  //     return out;
-  //   }
-    
-  // };
-
   static inline
-  dynamic_bit_vector
-  add_general_width_bv(const dynamic_bit_vector& a,
-  		       const dynamic_bit_vector& b) {
+  quad_value_bit_vector
+  add_general_width_bv(const quad_value_bit_vector& a,
+  		       const quad_value_bit_vector& b) {
 
-    dynamic_bit_vector res(a.bitLength());
+    quad_value_bit_vector res(a.bitLength());
     unsigned char carry = 0;
     for (int i = 0; i < ((int) a.bitLength()); i++) {
-      unsigned char sum = a.get(i) + b.get(i) + carry;
+
+      unsigned char sum = a.get(i).binary_value() + b.get(i).binary_value() + carry;
 
       carry = 0;
 
-      unsigned char z_i = sum & 0x01; //sum % 2;
-      res.set(i, z_i);
+      unsigned char z_i = sum & 0x01;
+      res.set(i, quad_value(z_i));
+
       if (sum >= 2) {
   	carry = 1;
       }
@@ -472,12 +560,12 @@ namespace bsim {
   }
 
   static inline
-  dynamic_bit_vector
-  sub_general_width_bv(const dynamic_bit_vector& a,
-  		       const dynamic_bit_vector& b) {
+  quad_value_bit_vector
+  sub_general_width_bv(const quad_value_bit_vector& a,
+  		       const quad_value_bit_vector& b) {
     int Width = a.bitLength();
-    dynamic_bit_vector diff(a.bitLength());
-    dynamic_bit_vector a_cpy = a;
+    quad_value_bit_vector diff(a.bitLength());
+    quad_value_bit_vector a_cpy = a;
 
     for (int i = 0; i < Width; i++) {
 
@@ -513,16 +601,16 @@ namespace bsim {
   }    
 
   static inline
-  dynamic_bit_vector
-  mul_general_width_bv(const dynamic_bit_vector& a,
-  		       const dynamic_bit_vector& b) {
+  quad_value_bit_vector
+  mul_general_width_bv(const quad_value_bit_vector& a,
+  		       const quad_value_bit_vector& b) {
     int Width = a.bitLength();
-    dynamic_bit_vector full_len(2*Width);
+    quad_value_bit_vector full_len(2*Width);
 
     for (int i = 0; i < Width; i++) {
       if (b.get(i) == 1) {
 
-  	dynamic_bit_vector shifted_a(2*Width);
+  	quad_value_bit_vector shifted_a(2*Width);
 
   	for (int j = 0; j < Width; j++) {
   	  shifted_a.set(j + i, a.get(j));
@@ -533,21 +621,21 @@ namespace bsim {
       }
     }
 
-    dynamic_bit_vector res(Width);
+    quad_value_bit_vector res(Width);
     for (int i = 0; i < Width; i++) {
       res.set(i, full_len.get(i));
     }
     return res;
   }    
   
-  class dynamic_bit_vector_operations {
+  class quad_value_bit_vector_operations {
   public:
 
     static inline
-    dynamic_bit_vector
-    land(const dynamic_bit_vector& a,
-  	 const dynamic_bit_vector& b) {
-      dynamic_bit_vector a_and_b(a.bitLength());
+    quad_value_bit_vector
+    land(const quad_value_bit_vector& a,
+  	 const quad_value_bit_vector& b) {
+      quad_value_bit_vector a_and_b(a.bitLength());
       for (int i = 0; i < a.bitLength(); i++) {
   	a_and_b.set(i, a.get(i) & b.get(i));
       }
@@ -555,46 +643,8 @@ namespace bsim {
 
     }
 
-  //   template<int Q = Width>
-  //   static inline
-  //   typename std::enable_if<33 <= Q && Q <= 64, dynamic_bit_vector<Q> >::type
-  //   land(const dynamic_bit_vector<Width>& a,
-  // 	 const dynamic_bit_vector<Width>& b) {
-  //     bv_uint64 a_and_b = a.as_native_uint64() & b.as_native_uint64();
-  //     return dynamic_bit_vector<Width>(a_and_b);
-  //   }
-    
-  //   template<int Q = Width>
-  //   static inline
-  //   typename std::enable_if<17 <= Q && Q <= 32, dynamic_bit_vector<Q> >::type
-  //   land(const dynamic_bit_vector<Width>& a,
-  // 	 const dynamic_bit_vector<Width>& b) {
-  //     bv_uint32 a_and_b = a.as_native_uint32() & b.as_native_uint32();
-  //     return dynamic_bit_vector<Width>(a_and_b);
-  //   }
-    
-  //   template<int Q = Width>
-  //   static inline
-  //   typename std::enable_if<9 <= Q && Q <= 16, dynamic_bit_vector<Q> >::type
-  //   land(const dynamic_bit_vector<Width>& a,
-  // 	 const dynamic_bit_vector<Width>& b) {
-  //     bv_uint16 a_and_b = a.as_native_uint16() & b.as_native_uint16();
-  //     return dynamic_bit_vector<Width>(a_and_b);
-  //   }
-    
-  //   template<int Q = Width>
-  //   static inline
-  //   typename std::enable_if<1 <= Q && Q <= 8, dynamic_bit_vector<Q> >::type
-  //   land(const dynamic_bit_vector<Width>& a,
-  // 	 const dynamic_bit_vector<Width>& b) {
-  //     bv_uint8 a_and_b = a.as_native_uint8() & b.as_native_uint8();
-  //     return dynamic_bit_vector<Width>(a_and_b);
-  //   }
-
-
-
-    static inline dynamic_bit_vector lnot(const dynamic_bit_vector& a) {
-      dynamic_bit_vector not_a(a.bitLength());
+    static inline quad_value_bit_vector lnot(const quad_value_bit_vector& a) {
+      quad_value_bit_vector not_a(a.bitLength());
       for (int i = 0; i < a.bitLength(); i++) {
   	not_a.set(i, ~a.get(i));
       }
@@ -602,9 +652,9 @@ namespace bsim {
 
     }
       
-    static inline dynamic_bit_vector lor(const dynamic_bit_vector& a,
-					 const dynamic_bit_vector& b) {
-      dynamic_bit_vector a_or_b(a.bitLength());
+    static inline quad_value_bit_vector lor(const quad_value_bit_vector& a,
+					 const quad_value_bit_vector& b) {
+      quad_value_bit_vector a_or_b(a.bitLength());
       for (int i = 0; i < a.bitLength(); i++) {
   	a_or_b.set(i, a.get(i) | b.get(i));
       }
@@ -612,10 +662,10 @@ namespace bsim {
     }
 
     static inline
-    dynamic_bit_vector
-    lxor(const dynamic_bit_vector& a,
-  	 const dynamic_bit_vector& b) {
-      dynamic_bit_vector a_or_b(a.bitLength());
+    quad_value_bit_vector
+    lxor(const quad_value_bit_vector& a,
+  	 const quad_value_bit_vector& b) {
+      quad_value_bit_vector a_or_b(a.bitLength());
       for (int i = 0; i < a.bitLength(); i++) {
   	a_or_b.set(i, a.get(i) ^ b.get(i));
       }
@@ -625,50 +675,32 @@ namespace bsim {
     
   };
 
-  static inline dynamic_bit_vector operator~(const dynamic_bit_vector& a) {
-    return dynamic_bit_vector_operations::lnot(a);
+  static inline quad_value_bit_vector operator~(const quad_value_bit_vector& a) {
+    return quad_value_bit_vector_operations::lnot(a);
   }
   
-  static inline dynamic_bit_vector operator&(const dynamic_bit_vector& a,
-					     const dynamic_bit_vector& b) {
-    return dynamic_bit_vector_operations::land(a, b);
+  static inline quad_value_bit_vector operator&(const quad_value_bit_vector& a,
+					     const quad_value_bit_vector& b) {
+    return quad_value_bit_vector_operations::land(a, b);
   }
 
-  static inline dynamic_bit_vector operator|(const dynamic_bit_vector& a,
-					     const dynamic_bit_vector& b) {
-    return dynamic_bit_vector_operations::lor(a, b);
+  static inline quad_value_bit_vector operator|(const quad_value_bit_vector& a,
+					     const quad_value_bit_vector& b) {
+    return quad_value_bit_vector_operations::lor(a, b);
   }
 
-  static inline dynamic_bit_vector operator^(const dynamic_bit_vector& a,
-					     const dynamic_bit_vector& b) {
-    return dynamic_bit_vector_operations::lxor(a, b);
+  static inline quad_value_bit_vector operator^(const quad_value_bit_vector& a,
+					     const quad_value_bit_vector& b) {
+    return quad_value_bit_vector_operations::lxor(a, b);
   }
 
-  static inline bool operator!=(const dynamic_bit_vector& a,
-  				const dynamic_bit_vector& b) {
+  static inline bool operator!=(const quad_value_bit_vector& a,
+  				const quad_value_bit_vector& b) {
     return !a.equals(b);
   }
 
-  // template<int N>
-  // static inline bool operator==(const unsigned_int<N>& a,
-  // 				const unsigned_int<N>& b) {
-  //   return a.equals(b);
-  // }
-
-  // template<int N>
-  // static inline bool operator==(const signed_int<N>& a,
-  // 				const signed_int<N>& b) {
-  //   return a.get_bits() == b.get_bits();
-  // }
-
-  // template<int N>
-  // static inline bool operator!=(const unsigned_int<N>& a,
-  // 				const unsigned_int<N>& b) {
-  //   return !(a == b);
-  // }
-  
-  static inline bool operator>(const dynamic_bit_vector& a,
-  			       const dynamic_bit_vector& b) {
+  static inline bool operator>(const quad_value_bit_vector& a,
+  			       const quad_value_bit_vector& b) {
     int N = a.bitLength();
     for (int i = N - 1; i >= 0; i--) {
       if (a.get(i) > b.get(i)) {
@@ -683,42 +715,42 @@ namespace bsim {
     return false;
   }
 
-  static inline bool operator>=(const dynamic_bit_vector& a,
-				const dynamic_bit_vector& b) {
+  static inline bool operator>=(const quad_value_bit_vector& a,
+				const quad_value_bit_vector& b) {
     return (a > b) || (a == b);
   }
   
-  static inline bool operator<(const dynamic_bit_vector& a,
-  			       const dynamic_bit_vector& b) {
+  static inline bool operator<(const quad_value_bit_vector& a,
+  			       const quad_value_bit_vector& b) {
     if (a == b) { return false; }
 
     return !(a > b);
   }
 
-  static inline dynamic_bit_vector
-  andr(const dynamic_bit_vector& a) {
+  static inline quad_value_bit_vector
+  andr(const quad_value_bit_vector& a) {
     for (int i = 0; i < a.bitLength(); i++) {
       if (a.get(i) != 1) {
-	return dynamic_bit_vector(1, "0");
+	return quad_value_bit_vector(1, "0");
       }
     }
 
-    return dynamic_bit_vector(1, "1");
+    return quad_value_bit_vector(1, "1");
   }
 
-  static inline dynamic_bit_vector
-  orr(const dynamic_bit_vector& a) {
+  static inline quad_value_bit_vector
+  orr(const quad_value_bit_vector& a) {
     for (int i = 0; i < a.bitLength(); i++) {
       if (a.get(i) == 1) {
-	return dynamic_bit_vector(1, "1");
+	return quad_value_bit_vector(1, "1");
       }
     }
 
-    return dynamic_bit_vector(1, "0");
+    return quad_value_bit_vector(1, "0");
   }
 
-  static inline dynamic_bit_vector
-  xorr(const dynamic_bit_vector& a) {
+  static inline quad_value_bit_vector
+  xorr(const quad_value_bit_vector& a) {
     int numSet = 0;
     for (int i = 0; i < a.bitLength(); i++) {
       if (a.get(i) == 1) {
@@ -727,40 +759,15 @@ namespace bsim {
     }
 
     if ((numSet % 2) == 0) {
-      return dynamic_bit_vector(1, "0");
+      return quad_value_bit_vector(1, "0");
     }
 
-    return dynamic_bit_vector(1, "1");
+    return quad_value_bit_vector(1, "1");
   }
   
-  // template<int N>
-  // static inline bool operator<=(const unsigned_int<N>& a,
-  // 				const unsigned_int<N>& b) {
-  //   return !(a > b);
-  // }
-
-  // template<int N>
-  // static inline bool operator>=(const unsigned_int<N>& a,
-  // 				const unsigned_int<N>& b) {
-  //   return (a > b) || (a == b);
-  // }
-
-  // template<int N>
-  // static inline unsigned_int<N> operator/(const unsigned_int<N>& a,
-  // 					  const unsigned_int<N>& b) {
-  //   unsigned_int<N> quotient;
-  //   unsigned_int<N> val = a;
-
-  //   while (b <= val) {
-  //     val = val - 
-  //   }
-
-  //   return quotient;
-  // }
-
   static inline bool
-  signed_gt(const dynamic_bit_vector& a,
-	    const dynamic_bit_vector& b) {
+  signed_gt(const quad_value_bit_vector& a,
+	    const quad_value_bit_vector& b) {
 
     assert(a.bitLength() == b.bitLength());
 
@@ -793,13 +800,13 @@ namespace bsim {
 
   }
 
-  static inline bool signed_gte(const dynamic_bit_vector& a,
-  				const dynamic_bit_vector& b) {
+  static inline bool signed_gte(const quad_value_bit_vector& a,
+  				const quad_value_bit_vector& b) {
     return (signed_gt(a, b)) || (a == b);
   }
 
   static inline
-  bv_uint64 get_shift_int(const dynamic_bit_vector& shift_amount) {
+  bv_uint64 get_shift_int(const quad_value_bit_vector& shift_amount) {
     bv_uint64 shift_int = 0;
     if (shift_amount.bitLength() > 64) {
       assert(false);
@@ -825,10 +832,10 @@ namespace bsim {
     return shift_int;
   }
 
-  static inline dynamic_bit_vector
-  lshr(const dynamic_bit_vector& a,
-       const dynamic_bit_vector& shift_amount) {
-    dynamic_bit_vector res(a.bitLength());
+  static inline quad_value_bit_vector
+  lshr(const quad_value_bit_vector& a,
+       const quad_value_bit_vector& shift_amount) {
+    quad_value_bit_vector res(a.bitLength());
 
     bv_uint64 shift_int = get_shift_int(shift_amount);
 
@@ -850,19 +857,19 @@ namespace bsim {
 
   // Arithmetic shift right
   static inline
-  dynamic_bit_vector
-  ashr(const dynamic_bit_vector& a,
-       const dynamic_bit_vector& shift_amount) {
+  quad_value_bit_vector
+  ashr(const quad_value_bit_vector& a,
+       const quad_value_bit_vector& shift_amount) {
 
-    if (shift_amount == dynamic_bit_vector(shift_amount.bitLength(), 0)) {
+    if (shift_amount == quad_value_bit_vector(shift_amount.bitLength(), 0)) {
       return a;
     }
 
-    dynamic_bit_vector res(a.bitLength());
+    quad_value_bit_vector res(a.bitLength());
 
     bv_uint64 shift_int = get_shift_int(shift_amount);
 
-    unsigned char sign_bit = a.get(a.bitLength() - 1);
+    quad_value sign_bit = a.get(a.bitLength() - 1);
     for (uint i = a.bitLength() - 1; i >= shift_int; i--) {
       res.set(i - shift_int, a.get(i));
     }
@@ -875,10 +882,10 @@ namespace bsim {
   }
   
   static inline
-  dynamic_bit_vector
-  shl(const dynamic_bit_vector& a,
-      const dynamic_bit_vector& shift_amount) {
-    dynamic_bit_vector res(a.bitLength());
+  quad_value_bit_vector
+  shl(const quad_value_bit_vector& a,
+      const quad_value_bit_vector& shift_amount) {
+    quad_value_bit_vector res(a.bitLength());
 
     bv_uint64 shift_int = get_shift_int(shift_amount);    
     for (int i = shift_int; i < a.bitLength(); i++) {
@@ -889,10 +896,10 @@ namespace bsim {
   }
 
   static inline
-  dynamic_bit_vector
-  concat(const dynamic_bit_vector& a,
-	 const dynamic_bit_vector& b) {
-    dynamic_bit_vector res(a.bitLength() + b.bitLength());
+  quad_value_bit_vector
+  concat(const quad_value_bit_vector& a,
+	 const quad_value_bit_vector& b) {
+    quad_value_bit_vector res(a.bitLength() + b.bitLength());
     for (int i = 0; i < a.bitLength(); i++) {
       res.set(i, a.get(i));
     }
@@ -904,11 +911,11 @@ namespace bsim {
   }
   
   static inline
-  dynamic_bit_vector
-  slice(const dynamic_bit_vector& a,
+  quad_value_bit_vector
+  slice(const quad_value_bit_vector& a,
 	const int start,
 	const int end) {
-    dynamic_bit_vector res(end - start);
+    quad_value_bit_vector res(end - start);
 
     for (int i = 0; i < res.bitLength(); i++) {
       res.set(i, a.get(i + start));
@@ -917,346 +924,15 @@ namespace bsim {
   }
   
 
-  // static inline
-  // dynamic_bit_vector
-  // extend(const dynamic_bit_vector& a, const int extra_bits) {
-  //   dynamic_bit_vector res(a.bitLength() + extra_bits);
-  //   for (uint i = 0; i < a.bitLength(); i++) {
-  //     res.set(i, a.get(i));
-  //   }
+  static inline
+  quad_value_bit_vector
+  extend(const quad_value_bit_vector& a, const int extra_bits) {
+    quad_value_bit_vector res(a.bitLength() + extra_bits);
+    for (uint i = 0; i < a.bitLength(); i++) {
+      res.set(i, a.get(i));
+    }
+
+    return res;
+  }
 
-  //   return res;
-  // }
-
-  // static inline
-  // dynamic_bit_vector
-  // set_ops(const dynamic_bit_vector& a_exp,
-  //         const dynamic_bit_vector& b_exp,
-  //         const dynamic_bit_vector& a_ext,
-  //         const dynamic_bit_vector& b_ext,	  
-  //         dynamic_bit_vector& a_op,
-  //         dynamic_bit_vector& b_op) {
-
-  //   dynamic_bit_vector tentative_exp(a_exp.bitLength());
-
-  //   if (a_exp > b_exp) {
-  //     tentative_exp = a_exp;
-
-  //     auto diff = sub_general_width_bv(a_exp, b_exp);
-
-  //     auto shift_b = lshr(b_ext, diff);
-
-  //     a_op = a_ext;
-  //     b_op = shift_b;
-
-  //   } else {
-  //     tentative_exp = b_exp;
-
-  //     auto diff = sub_general_width_bv(b_exp, a_exp);
-
-  //     auto shift_a = lshr(a_ext, diff);
-
-  //     a_op = shift_a;
-  //     b_op = b_ext;
-
-  //   }
-
-  //   return tentative_exp;
-  // }
-
-  // static inline
-  // dynamic_bit_vector
-  // renormalize_zeros(dynamic_bit_vector& sliced_sum,
-  //       	    const dynamic_bit_vector& tentative_exp,
-  //       	    const int width) {
-
-  //   dynamic_bit_vector new_exp(tentative_exp.bitLength());
-
-  //   int num_leading_zeros = 0;
-  //   for (int i = sliced_sum.bitLength(); i >= 0; i--) {
-  //     if (sliced_sum.get(i) == 1) {
-  //       break;
-  //     }
-
-  //     num_leading_zeros++;
-  //   }
-
-  //   dynamic_bit_vector shift_w(width, num_leading_zeros);
-  //   sliced_sum = shl(sliced_sum, shift_w);
-  //   new_exp = sub_general_width_bv(tentative_exp, shift_w);
-
-  //   std::cout << "Sum after shifting " << num_leading_zeros << " = " << sliced_sum << std::endl;
-
-  //   return new_exp;
-  // }  
-
-  // // NOTE: This should implement "round to nearest even"
-  // static inline
-  // dynamic_bit_vector
-  // ieee_round(const dynamic_bit_vector& sum) {
-  //   dynamic_bit_vector guards = slice(sum, 0, 2);
-  //   dynamic_bit_vector last_three = slice(sum, 0, 3);
-
-  //   std::cout << "to round       = " << sum << std::endl;
-  //   std::cout << "last 3 digits  = " << last_three << std::endl;
-
-  //   std::cout << "guards         =  " << guards << std::endl;
-
-  //   dynamic_bit_vector upper(2, "10");
-
-  //   dynamic_bit_vector res = sum;
-  //   dynamic_bit_vector app(sum.bitLength(), "10");
-  //   if (guards > upper) {
-  //     res = add_general_width_bv(sum, app);
-  //   } else if (guards == upper) {
-  //     if (sum.get(2) == 0) {
-  //       res = sub_general_width_bv(sum, app);
-  //     } else {
-  //       assert(sum.get(2) == 1);
-  //       res = add_general_width_bv(sum, app);
-  //     }
-  //   }
-
-  //   auto rnd_last_3 = slice(res, 0, 3);
-  //   std::cout << "rounded last 3 = " << rnd_last_3 << std::endl;
-  //   std::cout << "res      = " << res << std::endl;
-
-  //   return res;
-  // }
-
-  // static inline
-  // dynamic_bit_vector
-  // floating_point_add(const dynamic_bit_vector& a,
-  //       	     const dynamic_bit_vector& b,
-  //       	     const unsigned precision_width,
-  //       	     const unsigned exp_width) {
-  //   unsigned width = 1 + precision_width + exp_width;
-
-  //   assert(a.bitLength() == width);
-  //   assert(b.bitLength() == width);
-
-  //   dynamic_bit_vector a_mant = slice(a, 0, precision_width);
-  //   dynamic_bit_vector b_mant = slice(b, 0, precision_width);
-
-  //   assert(a_mant.bitLength() == ((int) precision_width));
-  //   assert(b_mant.bitLength() == ((int) precision_width));
-
-  //   // TODO: Check normalization
-  //   dynamic_bit_vector a_exp = slice(a,
-  //       			     precision_width,
-  //       			     precision_width + exp_width);
-
-  //   dynamic_bit_vector b_exp = slice(b,
-  //       			     precision_width,
-  //       			     precision_width + exp_width);
-
-  //   assert(a_exp.bitLength() == exp_width);
-  //   assert(b_exp.bitLength() == exp_width);
-
-  //   // auto a_ext = extend(a_mant, 2);
-  //   // a_ext.set(precision_width, 1);
-  //   // auto b_ext = extend(b_mant, 2);
-  //   // b_ext.set(precision_width, 1);
-
-  //   std::cout << "a_man      = " << a_mant << std::endl;
-  //   std::cout << "b_man      = " << b_mant << std::endl;
-    
-  //   auto a_ext = extend(a_mant, 4);
-  //   a_ext = shl(a_ext, dynamic_bit_vector(width, 2));
-  //   a_ext.set(precision_width + 2, 1);
-
-  //   auto b_ext = extend(b_mant, 4);
-  //   b_ext = shl(b_ext, dynamic_bit_vector(width, 2));
-  //   b_ext.set(precision_width + 2, 1);
-    
-  //   std::cout << "a_ext      = " << a_ext << std::endl;
-  //   std::cout << "b_ext      = " << b_ext << std::endl;
-    
-  //   dynamic_bit_vector a_op(a_ext.bitLength());
-  //   dynamic_bit_vector b_op(b_ext.bitLength());
-
-  //   auto tentative_exp = set_ops(a_exp, b_exp,
-  //       			 a_ext, b_ext,
-  //       			 a_op, b_op);
-
-  //   std::cout << "a_op       = " << a_op << std::endl;
-  //   std::cout << "b_op       = " << b_op << std::endl;
-    
-  //   std::cout << "Operating" << std::endl;
-
-  //   dynamic_bit_vector sum(a_op.bitLength());
-  //   if ((highBit(a) == 0) && (highBit(b) == 1)) {
-  //     sum = sub_general_width_bv(a_op , b_op);
-  //   } else {
-  //     sum = add_general_width_bv(a_op , b_op);
-  //   }
-
-  //   bool overflow = sum.get(sum.bitLength() - 1) == 1;
-
-  //   std::cout << "sum =    " << sum << std::endl;
-
-  //   dynamic_bit_vector final_sum(precision_width);
-
-  //   if ((highBit(a) == 0) && (highBit(b) == 1)) {
-
-  //     sum = ieee_round(sum);      
-
-  //     dynamic_bit_vector sliced_sum(sum.bitLength() - 2);
-  //     sliced_sum = slice(sum, 2, sum.bitLength() - 2);
-
-  //     assert(sliced_sum.bitLength() == ((int) precision_width));
-
-  //     tentative_exp = renormalize_zeros(sliced_sum, tentative_exp, width);
-
-  //     final_sum = sliced_sum;
-
-  //   } else {
-
-  //     if (overflow) {
-  //       //sum = ieee_round(sum);
-
-  //       dynamic_bit_vector one(exp_width, 1);
-  //       tentative_exp = add_general_width_bv(tentative_exp, one);
-
-  //       auto shift_sum = ieee_round(lshr(sum, one));
-  //       final_sum = slice(shift_sum, 2, sum.bitLength() - 2);
-
-  //       std::cout << "sss =   " << final_sum << std::endl;
-  //     } else {
-
-  //       sum = ieee_round(sum);
-  //       dynamic_bit_vector sliced_sum(sum.bitLength() - 2);
-  //       sliced_sum = slice(sum, 2, sum.bitLength() - 2);
-
-  //       assert(sliced_sum.bitLength() == ((int) precision_width));
-  //       final_sum = sliced_sum;      
-  //     }
-
-  //   }
-
-
-
-  //   dynamic_bit_vector sign_bit(1);
-  //   sign_bit.set(0, 0);
-
-  //   auto res = concat(final_sum, concat(tentative_exp, sign_bit));
-
-  //   assert(res.bitLength() == width);
-
-  //   return res;
-  // }
-
-  
-  // static inline
-  // bool
-  // floating_point_gt(const dynamic_bit_vector& a,
-  //       	    const dynamic_bit_vector& b,
-  //       	    const unsigned precision_width,
-  //       	    const unsigned exp_width) {
-
-  //   unsigned width = 1 + precision_width + exp_width;
-
-  //   assert(a.bitLength() == width);
-  //   assert(b.bitLength() == width);
-
-  //   dynamic_bit_vector a_mant = slice(a, 0, precision_width);
-  //   dynamic_bit_vector b_mant = slice(b, 0, precision_width);
-
-  //   assert(a_mant.bitLength() == ((int) precision_width));
-  //   assert(b_mant.bitLength() == ((int) precision_width));
-
-  //   // TODO: Check normalization
-  //   dynamic_bit_vector a_exp = slice(a,
-  //       			     precision_width,
-  //       			     precision_width + exp_width);
-
-  //   dynamic_bit_vector b_exp = slice(b,
-  //       			     precision_width,
-  //       			     precision_width + exp_width);
-
-  //   assert(a_exp.bitLength() == exp_width);
-  //   assert(b_exp.bitLength() == exp_width);
-
-  //   bool a_pos = highBit(a) == 0;
-  //   bool b_pos = highBit(b) == 0;
-
-  //   if (a_pos && b_pos) {
-
-  //     if (a_exp > b_exp) {
-  //       return true;
-  //     }
-
-  //     if (b_exp > a_exp) {
-  //       return false;
-  //     }
-    
-
-  //     assert(b_exp == a_exp);
-
-  //     return a_mant > b_mant;
-  //   } else if (!a_pos && !b_pos) {
-  //     if (a_exp > b_exp) {
-  //       return false;
-  //     }
-
-  //     if (b_exp > a_exp) {
-  //       return true;
-  //     }
-
-  //     assert(b_exp == a_exp);
-
-  //     return a_mant < b_mant;
-  //   } else if (!a_pos && b_pos) {
-  //     return false;
-  //   } else if (a_pos && !b_pos) {
-  //     return true;
-  //   } else {
-  //     assert(false);
-  //   }
-  // }
-  // template<int N>
-  // static inline bool operator<=(const signed_int<N>& a,
-  // 				const signed_int<N>& b) {
-  //   return !(a > b);
-  // }
-
-  // template<int N>
-  // static inline bool operator!=(const signed_int<N>& a,
-  // 				const signed_int<N>& b) {
-  //   return !(a == b);
-  // }
-  
-  // template<int N>
-  // static inline std::ostream&
-  // operator<<(std::ostream& out, const unsigned_int<N>& a) {
-  //   a.print(out);
-  //   return out;
-  // }
-
-  // template<int N>
-  // static inline std::ostream&
-  // operator<<(std::ostream& out, const signed_int<N>& a) {
-  //   a.print(out);
-  //   return out;
-  // }
-  
-  // template<int LowWidth, int HighWidth>
-  // signed_int<HighWidth> sign_extend(const signed_int<LowWidth>& a) {
-  //   signed_int<HighWidth> hw;
-
-  //   for (int i = 0; i < LowWidth; i++) {
-  //     hw.set(i, a.get(i));
-  //   }
-    
-  //   if (a.get(LowWidth - 1) == 0) {
-      
-  //     return hw;
-  //   }
-
-  //   for (int i = LowWidth; i < HighWidth; i++) {
-  //     hw.set(i, 1);
-  //   }
-
-  //   return hw;
-  // }
 }

--- a/include/coreir/ir/fwd_declare.h
+++ b/include/coreir/ir/fwd_declare.h
@@ -30,9 +30,9 @@
 typedef uint32_t uint;
 
 namespace bsim {
-  class dynamic_bit_vector;
+  class quad_value_bit_vector;
 }
-typedef bsim::dynamic_bit_vector BitVector;
+typedef bsim::quad_value_bit_vector BitVector;
 
 namespace CoreIR {
 

--- a/include/coreir/simulator/interpreter.h
+++ b/include/coreir/simulator/interpreter.h
@@ -6,7 +6,7 @@
 
 namespace CoreIR {
 
-  typedef bsim::dynamic_bit_vector BitVec;
+  typedef bsim::quad_value_bit_vector BitVec;
 
   enum SimValueType {
     SIM_VALUE_BV,

--- a/src/coreir-c/simulator-c.cpp
+++ b/src/coreir-c/simulator-c.cpp
@@ -21,7 +21,7 @@ extern "C" {
     SimValue* val = rcast<SimValue*>(cval);
     if (val->getType() == SIM_VALUE_BV) {
       SimBitVector* bv = static_cast<SimBitVector*>(val);
-      return bv->getBits().get(bit);
+      return bv->getBits().get(bit).binary_value();
     }
     else if (val->getType() == SIM_VALUE_CLK) {
       ClockValue* cv = static_cast<ClockValue*>(val);

--- a/src/passes/transform/fold_constants.cpp
+++ b/src/passes/transform/fold_constants.cpp
@@ -102,7 +102,7 @@ namespace CoreIR {
           cout << "\tSource = " << srcConst->toString() << endl;
           cout << "\tOffset = " << offset << endl;
 
-          uint8_t bit = val.get(offset);
+          uint8_t bit = val.get(offset).binary_value();
 
           assert((bit == 0) || (bit == 1));
 
@@ -141,7 +141,7 @@ namespace CoreIR {
             (srcConst->getModArgs().find("value"))->second->get<bool>();
 
           BitVector val(1, valB == true ? 1 : 0);
-          uint8_t bit = val.get(0);
+          uint8_t bit = val.get(0).binary_value();
 
           assert((bit == 0) || (bit == 1));
 

--- a/src/simulator/interpret.cpp
+++ b/src/simulator/interpret.cpp
@@ -1049,6 +1049,8 @@ namespace CoreIR {
       updateBitVecUnop(vd, [](const BitVec& r) {
           return r;
       });
+    } else if ((opName == "coreir.term") || (opName == "corebit.term")) {
+      // No-op
     } else if (opName == "coreir.slice") {
       updateSliceNode(vd);
     } else if (opName == "coreir.concat") {

--- a/src/simulator/interpret.cpp
+++ b/src/simulator/interpret.cpp
@@ -581,7 +581,7 @@ namespace CoreIR {
 
       int index = selectNum(sel);
 
-      return makeSimBitVector(BitVec(1, (val->getBits()).get(index)));
+      return makeSimBitVector(BitVec(1, (val->getBits()).get(index).binary_value()));
     }
 
     assert(mod->getDef()->canSel(sel->toString()));
@@ -982,7 +982,7 @@ namespace CoreIR {
     assert(vals.bitLength() == (1 << width));
 
     bv_uint64 i = get_shift_int(bv1); //get_shift_int(s1->getBits());
-    unsigned char lutBit = vals.get(i);
+    unsigned char lutBit = vals.get(i).binary_value();
     
     setValue(toSelect(outPair.second), makeSimBitVector(BitVector(1, lutBit)));
   }
@@ -1849,7 +1849,7 @@ namespace CoreIR {
 
     // SimBitVector* sbv = static_cast<SimBitVector*>(sv);
 
-    return makeSimBitVector(BitVector(1, sbv->getBits().get(stoi(access))));
+    return makeSimBitVector(BitVector(1, sbv->getBits().get(stoi(access)).binary_value()));
 
     // assert(sv->getType() == SIM_VALUE_BV);
 

--- a/src/simulator/wiring_utils.cpp
+++ b/src/simulator/wiring_utils.cpp
@@ -363,7 +363,7 @@ namespace CoreIR {
       //assert(isBitType(*(sel->getType())));
       constReplace = def->addInstance("def_self_const_replace_" + portName,
                                       "corebit.const",
-                                      {{"value", Const::make(c, value.get(0) ? true : false)}});
+                                      {{"value", Const::make(c, value.get(0).binary_value() ? true : false)}});
     }
 
     assert(constReplace != nullptr);

--- a/tests/simulator/interpreter.cpp
+++ b/tests/simulator/interpreter.cpp
@@ -114,6 +114,63 @@ namespace CoreIR {
     deleteContext(c);
   }
 
+  TEST_CASE("Interpreting coreir.term and corebit.term") {
+
+    Context* c = newContext();
+    Namespace* g = c->getGlobal();
+
+    SECTION("coreir.term") {
+      uint width = 4;
+      Type* tp = c->Record({{"in", c->BitIn()->Arr(width)},
+            {"out", c->Bit()->Arr(width)}});
+
+      Module* mod = g->newModuleDecl("md", tp);
+      ModuleDef* def = mod->newModuleDef();
+
+      def->addInstance("w", "coreir.term", {{"width", Const::make(c, width)}});
+      def->connect("self.in", "w.in");
+
+      def->addInstance("c", "coreir.const", {{"width", Const::make(c, width)}}, {{"value", Const::make(c, BitVector(width, 1))}});
+      def->connect("c.out", "self.out");
+
+      mod->setDef(def);
+
+      c->runPasses({"rungenerators"});
+
+      SimulatorState state(mod);
+      state.setValue("self.in", BitVector(width, 12));
+      state.execute();
+
+      REQUIRE(state.getBitVec("self.out") == BitVector(width, 1));
+    }
+
+    SECTION("corebit.term") {
+      Type* tp = c->Record({{"in", c->BitIn()},
+            {"out", c->Bit()}});
+
+      Module* mod = g->newModuleDecl("md", tp);
+      ModuleDef* def = mod->newModuleDef();
+
+      def->addInstance("w", "corebit.term");
+      def->connect("self.in", "w.in");
+
+      def->addInstance("c", "corebit.const", {{"value", Const::make(c, false)}});
+      def->connect("c.out", "self.out");
+
+      mod->setDef(def);
+
+      c->runPasses({"rungenerators"});
+
+      SimulatorState state(mod);
+      state.setValue("self.in", BitVector(1, 1));
+      state.execute();
+
+      REQUIRE(state.getBitVec("self.out") == BitVector(1, 0));
+    }
+    
+    deleteContext(c);
+  }
+  
   TEST_CASE("Interpreting circuits with combinational loops") {
     Context* c = newContext();
     Namespace* g = c->getGlobal();

--- a/tests/simulator/linebuffermem.json
+++ b/tests/simulator/linebuffermem.json
@@ -22,7 +22,7 @@
           "m0$c1":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",2]},
-            "modargs":{"value":[["BitVector",2],"2'h01"]}
+            "modargs":{"value":[["BitVector",2],"2'h1"]}
           },
           "m0$mem":{
             "genref":"coreir.mem",
@@ -35,7 +35,7 @@
           "m0$raddr$reg0":{
             "genref":"coreir.reg",
             "genargs":{"width":["Int",2]},
-            "modargs":{"init":[["BitVector",2],"2'h00"]}
+            "modargs":{"init":[["BitVector",2],"2'h0"]}
           },
           "m0$veq":{
             "genref":"coreir.neq",
@@ -48,7 +48,7 @@
           "m0$waddr$reg0":{
             "genref":"coreir.reg",
             "genargs":{"width":["Int",2]},
-            "modargs":{"init":[["BitVector",2],"2'h00"]}
+            "modargs":{"init":[["BitVector",2],"2'h0"]}
           }
         },
         "connections":[

--- a/tests/simulator/partial_evaluation.cpp
+++ b/tests/simulator/partial_evaluation.cpp
@@ -59,7 +59,7 @@ namespace CoreIR {
 
         int index = selectNum(sel);
 
-        return makeSimBitVector(BitVec(1, (val->getBits()).get(index)));
+        return makeSimBitVector(BitVec(1, (val->getBits()).get(index).binary_value()));
       }
 
       assert(mod->getDef()->canSel(sel->toString()));


### PR DESCRIPTION
Changed the bit vector class so that it can support unknown values 'x', and high impedance values, 'z'.

The logical operations do not yet support unknowns and high impedance values, but includes enough code to construct, serialize and de-serialize.

@rdaly525 x and z values can be used in both hex and binary construction, but for storage bit vectors will have to be stored as binary, since there are no hexadecimal characters for the values like: ```4'b1z11```