### PR TITLE
Add iterator methods for c api

### DIFF
--- a/include/coreir-c/coreir.h
+++ b/include/coreir-c/coreir.h
@@ -52,6 +52,8 @@ COREModule* COREGeneratorGetModule(COREGenerator* core_gen, void* genargs);
 extern COREModule* CORENewModule(CORENamespace* ns, char* name, COREType* type, void* configparams);
 extern COREGenerator* CORENamespaceGetGenerator(CORENamespace* _namespace, const char* name);
 extern COREModule* CORENamespaceGetModule(CORENamespace* _namespace, const char* name);
+extern void CORENamespaceGetGenerators(CORENamespace* core_namespace, const char*** keys, COREGenerator*** values, int* num_items);
+extern void CORENamespaceGetModules(CORENamespace* core_namespace, const char*** keys, COREModule*** values, int* num_items);
 extern bool CORENamespaceHasGenerator(CORENamespace* _namespace, const char* name);
 extern bool CORENamespaceHasModule(CORENamespace* _namespace, const char* name);
 
@@ -69,6 +71,7 @@ extern COREWireable* COREModuleDefAddGeneratorInstance(COREModuleDef* module_def
 
 extern COREWireable* COREModuleDefGetInterface(COREModuleDef* m);
 extern COREValue* COREGetModArg(COREWireable* i, char* s);
+extern void COREGetModArgs(COREWireable* core_wireable, const char*** keys, COREValue*** values, int* num_items);
 extern bool COREHasModArg(COREWireable* i, char* s);
 
 //Errors:
@@ -107,5 +110,7 @@ extern COREDirectedConnection** COREDirectedInstanceGetInputs(COREDirectedInstan
 // END   : directedview
 
 int COREValueTypeGetKind(COREValueType* value_type);
+
+void COREFree(void* ptr);
 
 #endif //COREIR_C_H_

--- a/src/coreir-c/coreir-c.cpp
+++ b/src/coreir-c/coreir-c.cpp
@@ -102,6 +102,19 @@ extern "C" {
     return context->runPasses(vec_passes, vec_namespaces);
   }
 
+  void COREGetModArgs(COREWireable* core_wireable, const char*** keys, COREValue*** values, int* num_items) {
+    Values modargs = cast<Instance>(rcast<Wireable*>(core_wireable))->getModArgs();
+    *num_items = modargs.size();
+    *keys = (const char **) malloc(*num_items * sizeof(char*));
+    *values = (COREValue **) malloc(*num_items * sizeof(COREValue*));
+    int i = 0;
+    for (auto const& item : modargs) {
+        (*keys)[i] = item.first.c_str();
+        (*values)[i] = rcast<COREValue*>(item.second);
+        i++;
+    }
+  }
+
   COREValue* COREGetModArg(COREWireable* i, char* s) {
     string str(s);
     Values modargs =cast<Instance>(rcast<Wireable*>(i))->getModArgs();
@@ -377,6 +390,38 @@ extern "C" {
       return rcast<COREModule*>(rcast<Namespace*>(_namespace)->getModule(std::string(name)));
   }
 
+  void CORENamespaceGetModules(CORENamespace* core_namespace, const char*** keys, COREModule*** values, int* num_items) {
+
+    std::map<std::string, Module*> modules =
+        rcast<Namespace*>(core_namespace)->getModules();
+
+    *num_items = modules.size();
+    *keys = (const char **) malloc(*num_items * sizeof(char*));
+    *values = (COREModule **) malloc(*num_items * sizeof(COREModule*));
+    int i = 0;
+    for (auto const& item : modules) {
+        (*keys)[i] = item.first.c_str();
+        (*values)[i] = rcast<COREModule*>(item.second);
+        i++;
+    }
+  }
+
+  void CORENamespaceGetGenerators(CORENamespace* core_namespace, const char*** keys, COREGenerator*** values, int* num_items) {
+
+    std::map<std::string, Generator*> generators =
+        rcast<Namespace*>(core_namespace)->getGenerators();
+
+    *num_items = generators.size();
+    *keys = (const char **) malloc(*num_items * sizeof(char*));
+    *values = (COREGenerator **) malloc(*num_items * sizeof(COREGenerator*));
+    int i = 0;
+    for (auto const& item : generators) {
+        (*keys)[i] = item.first.c_str();
+        (*values)[i] = rcast<COREGenerator*>(item.second);
+        i++;
+    }
+  }
+
   bool CORENamespaceHasModule(CORENamespace* _namespace, const char* name) {
       std::map<std::string,Module*> modules =
           rcast<Namespace*>(_namespace)->getModules();
@@ -516,6 +561,10 @@ extern "C" {
 
   int COREValueTypeGetKind(COREValueType* value_type) {
       return rcast<ValueType*>(value_type)->getKind();
+  }
+
+  void COREFree(void * ptr) {
+      free(ptr);
   }
 
 }//extern "C"


### PR DESCRIPTION
Enables me to implement the `Mapping` interface in the Python api request by @cdonovick 
See https://github.com/leonardt/pycoreir/issues/6

Also demonstrates a proposed new C api memory model where the user is responsible for freeing the memory after they are done with the provided data.