### PR TITLE
Changing connection comparison to just use pointer comparison

### DIFF
--- a/include/coreir/definitions/coreVerilog.hpp
+++ b/include/coreir/definitions/coreVerilog.hpp
@@ -212,7 +212,7 @@ void CoreIRLoadVerilog_coreir(Context* c) {
     vjson["prefix"] = "coreir_";
     vjson["interface"] = coreIMap["mem"];
     vjson["definition"] = ""
-    "reg [width-1:0] data[depth];\n"
+    "reg [width-1:0] data[depth-1:0];\n"
     "always @(posedge clk) begin\n"
     "  if (wen) begin\n"
     "    data[waddr] <= wdata;\n"

--- a/include/coreir/ir/moduledef.h
+++ b/include/coreir/ir/moduledef.h
@@ -27,6 +27,7 @@ class ModuleDef {
     Interface* interface; 
     std::map<std::string,Instance*> instances;
     std::set<Connection,ConnectionComp> connections;
+
     
     // Instances Iterator Internal Fields/API
     Instance* instancesIterFirst = nullptr;

--- a/include/coreir/ir/wireable.h
+++ b/include/coreir/ir/wireable.h
@@ -17,6 +17,7 @@ class Wireable : public MetaData {
     ModuleDef* container; // ModuleDef which it is contained in 
     Type* type;
 
+    std::vector<Select*> selectList;
     std::set<Wireable*> connected; 
     
     //This manages the memory for the selects

--- a/include/coreir/ir/wireable.h
+++ b/include/coreir/ir/wireable.h
@@ -4,8 +4,6 @@
 #include "fwd_declare.h"
 #include "metadata.h"
 
-#include <list>
-
 namespace CoreIR {
 
 class InstanceGraphNode;
@@ -19,7 +17,6 @@ class Wireable : public MetaData {
     ModuleDef* container; // ModuleDef which it is contained in 
     Type* type;
 
-    std::list<Select> selectList;
     std::set<Wireable*> connected; 
     
     //This manages the memory for the selects

--- a/include/coreir/ir/wireable.h
+++ b/include/coreir/ir/wireable.h
@@ -4,6 +4,8 @@
 #include "fwd_declare.h"
 #include "metadata.h"
 
+#include <list>
+
 namespace CoreIR {
 
 class InstanceGraphNode;
@@ -17,7 +19,7 @@ class Wireable : public MetaData {
     ModuleDef* container; // ModuleDef which it is contained in 
     Type* type;
 
-    std::vector<Select*> selectList;
+    std::list<Select> selectList;
     std::set<Wireable*> connected; 
     
     //This manages the memory for the selects

--- a/src/ir/common.cpp
+++ b/src/ir/common.cpp
@@ -26,13 +26,44 @@ bool ConnectionComp::SPComp(const SelectPath& l, const SelectPath& r) {
   }
   return false;
 }
-// bool ConnectionComp::operator() (const Connection& l, const Connection& r) const {
-//   if (l.first!=r.first) return SPComp(l.first->getSelectPath(),r.first->getSelectPath());
-//   return SPComp(l.second->getSelectPath(),r.second->getSelectPath());
-// }
+
+bool ConnectionComp::operator() (const Connection& l, const Connection& r) const {
+  if (l.first < r.first) {
+    return true;
+  }
+
+  // l.first >= r.first
+
+  if (l.first == r.first) {
+    // l.first == r.first
+    return l.second < r.second;
+  }
+
+  // l.first > r.first
+  return false;
+
+
+  // if (l.first == r.first) {
+  //   return l.second < r.second;
+  // } else {
+  //   return false;
+  //   // l.first != r.first
+
+  //   // if (l.second == r.second) {
+  //   //   return false;
+  //   // }
+
+  //   //return l.second < r.second;
+  // }
+
+
+  // if (l.first!=r.first) return SPComp(l.first->getSelectPath(),r.first->getSelectPath());
+  // return SPComp(l.second->getSelectPath(),r.second->getSelectPath());
+}
 
 Connection connectionCtor(Wireable* a, Wireable* b) {
-  if (ConnectionComp::SPComp(a->getSelectPath(),b->getSelectPath())) {
+  //if (ConnectionComp::SPComp(a->getSelectPath(),b->getSelectPath())) {
+  if (a < b) {
     //return Connection(a,b);
     return {a, b};
   }

--- a/src/ir/common.cpp
+++ b/src/ir/common.cpp
@@ -98,7 +98,11 @@ string toString(SelectPath path) {
 }
 
 string toString(Connection con) {
-  return con.first->toString() + " <=> " + con.second->toString();
+  Wireable* fstCon = ConnectionComp::SPComp(con.first->getSelectPath(), con.second->getSelectPath()) ? con.first : con.second;
+  Wireable* sndCon = ConnectionComp::SPComp(con.first->getSelectPath(), con.second->getSelectPath()) ? con.second : con.first;
+  return fstCon->toString() + " <=> " + sndCon->toString();
+
+  //return con.first->toString() + " <=> " + con.second->toString();
 }
 
 string toString(RecordParams rp) {

--- a/src/ir/common.cpp
+++ b/src/ir/common.cpp
@@ -26,17 +26,19 @@ bool ConnectionComp::SPComp(const SelectPath& l, const SelectPath& r) {
   }
   return false;
 }
-bool ConnectionComp::operator() (const Connection& l, const Connection& r) const {
-  if (l.first!=r.first) return SPComp(l.first->getSelectPath(),r.first->getSelectPath());
-  return SPComp(l.second->getSelectPath(),r.second->getSelectPath());
-}
+// bool ConnectionComp::operator() (const Connection& l, const Connection& r) const {
+//   if (l.first!=r.first) return SPComp(l.first->getSelectPath(),r.first->getSelectPath());
+//   return SPComp(l.second->getSelectPath(),r.second->getSelectPath());
+// }
 
 Connection connectionCtor(Wireable* a, Wireable* b) {
   if (ConnectionComp::SPComp(a->getSelectPath(),b->getSelectPath())) {
-    return Connection(a,b);
+    //return Connection(a,b);
+    return {a, b};
   }
   else {
-    return Connection(b,a);
+    //return Connection(b,a);
+    return {b,a};
   }
 }
 

--- a/src/ir/inline.cpp
+++ b/src/ir/inline.cpp
@@ -189,8 +189,8 @@ bool inlineInstance(Instance* inst) {
   //Add a passthrough Module to quarentine 'self'
   addPassthrough(defInline->getInterface(),"_insidePT");
   
-  //string inlinePrefix = inst->getInstname() + "$";
-  string inlinePrefix = inst->getInstname() + "_DLR_";
+  string inlinePrefix = inst->getInstname() + "$";
+  //string inlinePrefix = inst->getInstname() + "_DLR_";
 
   //First add all the instances of defInline into def with a new name
   for (auto instpair : defInline->getInstances()) {
@@ -245,8 +245,8 @@ bool inlineInstance(Instance* inst) {
     if (mref->getMetaData().get<map<string,json>>().count("symtable")) {
       json jisym = mref->getMetaData()["symtable"];
       for (auto p : jisym.get<map<string,json>>()) {
-        //string newkey = instname + "$" + p.first;
-        string newkey = instname + "_DLR_" + p.first;
+        string newkey = instname + "$" + p.first;
+        
         ASSERT(jsym.count(newkey)==0,"DEBUGME");
         SelectPath path = p.second.get<SelectPath>();
         if (path[0] =="self") {

--- a/src/ir/inline.cpp
+++ b/src/ir/inline.cpp
@@ -189,7 +189,8 @@ bool inlineInstance(Instance* inst) {
   //Add a passthrough Module to quarentine 'self'
   addPassthrough(defInline->getInterface(),"_insidePT");
   
-  string inlinePrefix = inst->getInstname() + "$";
+  //string inlinePrefix = inst->getInstname() + "$";
+  string inlinePrefix = inst->getInstname() + "_DLR_";
 
   //First add all the instances of defInline into def with a new name
   for (auto instpair : defInline->getInstances()) {
@@ -244,7 +245,8 @@ bool inlineInstance(Instance* inst) {
     if (mref->getMetaData().get<map<string,json>>().count("symtable")) {
       json jisym = mref->getMetaData()["symtable"];
       for (auto p : jisym.get<map<string,json>>()) {
-        string newkey = instname + "$" + p.first;
+        //string newkey = instname + "$" + p.first;
+        string newkey = instname + "_DLR_" + p.first;
         ASSERT(jsym.count(newkey)==0,"DEBUGME");
         SelectPath path = p.second.get<SelectPath>();
         if (path[0] =="self") {

--- a/src/ir/inline.cpp
+++ b/src/ir/inline.cpp
@@ -190,7 +190,6 @@ bool inlineInstance(Instance* inst) {
   addPassthrough(defInline->getInterface(),"_insidePT");
   
   string inlinePrefix = inst->getInstname() + "$";
-  //string inlinePrefix = inst->getInstname() + "_DLR_";
 
   //First add all the instances of defInline into def with a new name
   for (auto instpair : defInline->getInstances()) {

--- a/src/ir/moduledef.cpp
+++ b/src/ir/moduledef.cpp
@@ -63,41 +63,14 @@ ModuleDef* ModuleDef::copy() {
   map<Wireable*, Wireable*> oldWireablesToCopies;
   
   for (auto inst : this->getInstances()) {
-    auto cpyInst = def->addInstance(inst.second);
-    //addCorrespondingSelects(inst.second, cpyInst, oldWireablesToCopies);
-    //oldWireablesToCopies[inst.second] = cpyInst;
+    def->addInstance(inst.second);
   }
-
-  auto oldSelf = this->sel("self");
-  auto newSelf = def->sel("self");
-
-  addCorrespondingSelects(oldSelf, newSelf, oldWireablesToCopies);
-  //oldWireablesToCopies[oldSelf] = newSelf;
 
   for (auto con: this->getConnections()) {
 
-    auto a = con.first;
-    auto b = con.second;
-
-    // if (!oldWireablesToCopies.count(a)) {
-    //   cout << "Copy map does not contain " << a->toString() << endl;
-    // }
-
-    // if (!oldWireablesToCopies.count(b)) {
-    //   cout << "Copy map does not contain " << b->toString() << endl;
-    // }
-    
-    auto aC = oldWireablesToCopies.at(a);
-    auto bC = oldWireablesToCopies.at(b);
-
-    // assert(aC != nullptr);
-    // assert(bC != nullptr);
-
-    def->connect(aC, bC);
-    
-    // const SelectPath& a = con.first->getSelectPath();
-    // const SelectPath& b = con.second->getSelectPath();
-    // def->connect(a,b);
+    const SelectPath& a = con.first->getSelectPath();
+    const SelectPath& b = con.second->getSelectPath();
+    def->connect(a,b);
 
   }
 

--- a/src/ir/moduledef.cpp
+++ b/src/ir/moduledef.cpp
@@ -281,7 +281,18 @@ void ModuleDef::disconnect(Wireable* a, Wireable* b) {
   Connection connect = connectionCtor(a,b);
   this->disconnect(connect);
 }
-void ModuleDef::disconnect(Connection con) {
+void ModuleDef::disconnect(Connection fstCon) {
+  auto con = connectionCtor(fstCon.first, fstCon.second);
+  
+  if (connections.count(con) == 0) {
+    cout << "All connections" << endl;
+    for (auto conn : getConnections()) {
+      cout << "\t" << toString(conn) << endl;
+    }
+
+    cout << "Contains reverse connection ? " << connections.count({con.second, con.first}) << endl;
+  }
+
   ASSERT(connections.count(con),"Cannot delete connection that is not connected! " + toString(con));
   
   //remove references

--- a/src/ir/moduledef.cpp
+++ b/src/ir/moduledef.cpp
@@ -64,7 +64,7 @@ ModuleDef* ModuleDef::copy() {
   
   for (auto inst : this->getInstances()) {
     auto cpyInst = def->addInstance(inst.second);
-    addCorrespondingSelects(inst.second, cpyInst, oldWireablesToCopies);
+    //addCorrespondingSelects(inst.second, cpyInst, oldWireablesToCopies);
     //oldWireablesToCopies[inst.second] = cpyInst;
   }
 

--- a/src/ir/moduledef_validate.cpp
+++ b/src/ir/moduledef_validate.cpp
@@ -10,13 +10,24 @@ namespace CoreIR {
 //True is error
 //False is no error
 bool ModuleDef::checkTypes(Wireable* a, Wireable* b) {
+
+  //cout << "Getting context of " << a->toString() << endl;
   Context* c = a->getContext();
+  //cout << "Got context" << endl;
+
   Type* ta = a->getType();
   Type* tb = b->getType();
   //TODO This might not be valid if:
   //  2 outputs are connected to the same input
+
+  //cout << "Got types" << endl;
   
-  if (ta == c->Flip(tb) ) return false;
+  if (ta == c->Flip(tb) ) {
+    //cout << "ta flipped" << endl;
+    return false;
+  }
+
+  //cout << "Flipped types" << endl;
   
   Error e;
   e.message(a->getContainer()->getName() + ": Cannot wire together");

--- a/src/ir/wireable.cpp
+++ b/src/ir/wireable.cpp
@@ -34,8 +34,16 @@ Select* Wireable::sel(const std::string& selStr) {
   ASSERT(type->canSel(selStr),"Cannot select " + selStr + " From " + this->toString() + "\n  Type: " + type->toString());
 
   Select* select = new Select(this->getContainer(),this,selStr, type->sel(selStr));
+  //selectList.push_back(new Select(this->getContainer(),this,selStr, type->sel(selStr)));
   selects[selStr] = select;
+
+  //getContainer()->allSelects.push_back(Select(this->getContainer(),this,selStr, type->sel(selStr)));
+  //selects[selStr] = &(getContainer()->allSelects.back()); //&(*end(selectList)); //&(*(selectList.back()));
+
+  //selects[selStr] = selectList.back();
+
   return select;
+  //return selects.at(selStr);
 }
 
 Select* Wireable::sel(uint selStr) { return sel(to_string(selStr)); }
@@ -127,7 +135,10 @@ SelectPath& Wireable::getSelectPath() {
   return selectpath;
 }
 
-Context* Wireable::getContext() { return container->getContext();}
+Context* Wireable::getContext() {
+  ASSERT(container != nullptr, this->toString() + " has null container");
+  return container->getContext();
+}
 string Wireable::wireableKind2Str(WireableKind wb) {
   switch(wb) {
     case WK_Interface: return "Interface";

--- a/src/ir/wireable.cpp
+++ b/src/ir/wireable.cpp
@@ -35,20 +35,9 @@ Select* Wireable::sel(const std::string& selStr) {
 
   Select* select = new Select(this->getContainer(),this,selStr, type->sel(selStr));
 
-  //selectList.push_back(Select(this->getContainer(),this,selStr, type->sel(selStr)));
-  //selectList.push_back(new Select(this->getContainer(),this,selStr, type->sel(selStr)));
-  //selects[selStr] = &(selectList.back()); //select;
-
   selects[selStr] = select;
 
-  //getContainer()->allSelects.push_back(Select(this->getContainer(),this,selStr, type->sel(selStr)));
-  //selects[selStr] = &(getContainer()->allSelects.back()); //&(*end(selectList)); //&(*(selectList.back()));
-
-  //selects[selStr] = selectList.back();
-
   return select;
-  //return selects.at(selStr);
-  //return selects.at(selStr);
 }
 
 Select* Wireable::sel(uint selStr) { return sel(to_string(selStr)); }

--- a/src/ir/wireable.cpp
+++ b/src/ir/wireable.cpp
@@ -22,9 +22,9 @@ namespace CoreIR {
 const string Interface::instname = "self";
 
 Wireable::~Wireable() {
-  for (auto selmap : selects) {
-    delete selmap.second;
-  }
+  // for (auto selmap : selects) {
+  //   delete selmap.second;
+  // }
 }
 
 Select* Wireable::sel(const std::string& selStr) {
@@ -33,17 +33,20 @@ Select* Wireable::sel(const std::string& selStr) {
   }
   ASSERT(type->canSel(selStr),"Cannot select " + selStr + " From " + this->toString() + "\n  Type: " + type->toString());
 
-  Select* select = new Select(this->getContainer(),this,selStr, type->sel(selStr));
+  //Select* select = new Select(this->getContainer(),this,selStr, type->sel(selStr));
+
+  selectList.push_back(Select(this->getContainer(),this,selStr, type->sel(selStr)));
   //selectList.push_back(new Select(this->getContainer(),this,selStr, type->sel(selStr)));
-  selects[selStr] = select;
+  selects[selStr] = &(selectList.back()); //select;
 
   //getContainer()->allSelects.push_back(Select(this->getContainer(),this,selStr, type->sel(selStr)));
   //selects[selStr] = &(getContainer()->allSelects.back()); //&(*end(selectList)); //&(*(selectList.back()));
 
   //selects[selStr] = selectList.back();
 
-  return select;
+  //return select;
   //return selects.at(selStr);
+  return selects.at(selStr);
 }
 
 Select* Wireable::sel(uint selStr) { return sel(to_string(selStr)); }
@@ -112,9 +115,10 @@ void Wireable::disconnectAll() {
 
 void Wireable::removeSel(string selStr) {
   ASSERT(selects.count(selStr),"Cannot remove " + selStr + "Because it does not exist!");
-  Select* s = selects[selStr];
+  //Select* s = selects[selStr];
   selects.erase(selStr);
-  delete s;
+  
+  //delete s;
 }
 
 

--- a/src/ir/wireable.cpp
+++ b/src/ir/wireable.cpp
@@ -22,9 +22,9 @@ namespace CoreIR {
 const string Interface::instname = "self";
 
 Wireable::~Wireable() {
-  // for (auto selmap : selects) {
-  //   delete selmap.second;
-  // }
+  for (auto selmap : selects) {
+    delete selmap.second;
+  }
 }
 
 Select* Wireable::sel(const std::string& selStr) {
@@ -33,20 +33,22 @@ Select* Wireable::sel(const std::string& selStr) {
   }
   ASSERT(type->canSel(selStr),"Cannot select " + selStr + " From " + this->toString() + "\n  Type: " + type->toString());
 
-  //Select* select = new Select(this->getContainer(),this,selStr, type->sel(selStr));
+  Select* select = new Select(this->getContainer(),this,selStr, type->sel(selStr));
 
-  selectList.push_back(Select(this->getContainer(),this,selStr, type->sel(selStr)));
+  //selectList.push_back(Select(this->getContainer(),this,selStr, type->sel(selStr)));
   //selectList.push_back(new Select(this->getContainer(),this,selStr, type->sel(selStr)));
-  selects[selStr] = &(selectList.back()); //select;
+  //selects[selStr] = &(selectList.back()); //select;
+
+  selects[selStr] = select;
 
   //getContainer()->allSelects.push_back(Select(this->getContainer(),this,selStr, type->sel(selStr)));
   //selects[selStr] = &(getContainer()->allSelects.back()); //&(*end(selectList)); //&(*(selectList.back()));
 
   //selects[selStr] = selectList.back();
 
-  //return select;
+  return select;
   //return selects.at(selStr);
-  return selects.at(selStr);
+  //return selects.at(selStr);
 }
 
 Select* Wireable::sel(uint selStr) { return sel(to_string(selStr)); }
@@ -115,10 +117,10 @@ void Wireable::disconnectAll() {
 
 void Wireable::removeSel(string selStr) {
   ASSERT(selects.count(selStr),"Cannot remove " + selStr + "Because it does not exist!");
-  //Select* s = selects[selStr];
+  Select* s = selects[selStr];
   selects.erase(selStr);
   
-  //delete s;
+  delete s;
 }
 
 

--- a/src/passes/analysis/coreirjson.cpp
+++ b/src/passes/analysis/coreirjson.cpp
@@ -203,7 +203,18 @@ string Instances2Json(map<string,Instance*>& insts) {
 
 string Connections2Json(Connections& cons) {
   Array a(8);
-  for (auto con : cons) {
+  vector<Connection> sortedConns;
+  for (auto c : cons) {
+    sortedConns.push_back(c);
+  }
+
+  // Ensure that connections are serialized in select string sorted order
+  ConnectionComp c;
+  std::sort(begin(sortedConns), end(sortedConns), [c](const Connection& l, const Connection& r) {
+      return c(l, r);
+    });
+
+  for (auto con : sortedConns) {
     auto pa = con.first->getSelectPath();
     auto pb = con.second->getSelectPath();
     string sa = join(pa.begin(),pa.end(),string("."));

--- a/src/passes/transform/add_dummy_inputs.cpp
+++ b/src/passes/transform/add_dummy_inputs.cpp
@@ -25,6 +25,9 @@ void connectToDummy(//CoreIR::Instance* const next,
 
     def->connect(replaceConst->sel("out"), sel);
   } else {
+    if (!isBitType(*(sel->getType()))) {
+      cout << "ERROR: " << sel->toString() << " has type " << sel->getType()->toString() << endl;
+    }
     assert(isBitType(*(sel->getType())));
 
 

--- a/src/passes/transform/fold_constants.cpp
+++ b/src/passes/transform/fold_constants.cpp
@@ -593,6 +593,22 @@ namespace CoreIR {
           
         }
         
+      } else if (getQualifiedOpName(*inst) == "coreir.wrap") {
+        Select* in = inst->sel("in");
+
+        vector<Select*> in0Values = getSignalValues(in);
+        maybe<BitVec> sigValue0 = getSignalBitVec(in0Values);
+
+        if (sigValue0.has_value()) {
+          auto recInstances = getReceiverSelects(inst);
+          for (auto elem : recInstances) {
+            auto src = extractSource(elem);
+            if (isa<Instance>(src) && (cast<Instance>(src) != inst)) {
+              toConsider.insert(cast<Instance>(src));
+            }
+          }
+        }
+
       } else if (getQualifiedOpName(*(inst)) == "coreir.orr") {
 
         Select* in = inst->sel("in");
@@ -643,48 +659,6 @@ namespace CoreIR {
 
         }
 
-        // NOTE: Pretty sure this is a duplicate
-      } else if (getQualifiedOpName(*inst) == "coreir.reg") {
-        // Select* inSel = inst->sel("in");
-        // Select* outSel = inst->sel("out");
-
-        // vector<Select*> inValues = getSignalValues(inSel);
-
-        // bool allInsFromOut = true;
-        // for (auto bitVal : inValues) {
-        //   Wireable* src = extractSource(bitVal);
-
-        //   if (src->sel("out") != outSel) {
-        //     allInsFromOut = false;
-        //   }
-        // }
-
-        // if (allInsFromOut) {
-
-        //   BitVector value = inst->getModArgs().at("init")->get<BitVector>();
-        //   auto newConst =
-        //     def->addInstance(inst->toString() + "_reg_const_replacement",
-        //                      "coreir.const",
-        //                      {{"width", Const::make(c, value.bitLength())}},
-        //                      {{"value", Const::make(c, BitVector(value))}});
-
-        //   auto recInstances = getReceiverSelects(inst);
-        //   for (auto elem : recInstances) {
-        //     auto src = extractSource(elem);
-        //     if (isa<Instance>(src)) {
-        //       toConsider.insert(cast<Instance>(src));
-        //     }
-        //   }
-          
-        //   Instance* instPT = addPassthrough(inst, "_remove_reg_PT");
-        //   Select* replacement = newConst->sel("out");
-
-        //   def->removeInstance(inst);
-        //   def->connect(replacement,
-        //                instPT->sel("in")->sel("out"));
-        //   inlineInstance(instPT);
-          
-        // }
       } else {
         cout << "No folding rule for " << getQualifiedOpName(*inst) << endl;
       }

--- a/src/passes/transform/fold_constants.cpp
+++ b/src/passes/transform/fold_constants.cpp
@@ -51,8 +51,8 @@ namespace CoreIR {
       // cout << "Module before trying to fold" << endl;
       // mod->print();
 
-      cout << "Checking instances " << inst->toString() << endl;
-      cout << "Instance name = " << getQualifiedOpName(*inst) << endl;
+      // cout << "Checking instances " << inst->toString() << endl;
+      // cout << "Instance name = " << getQualifiedOpName(*inst) << endl;
       if (getQualifiedOpName(*(inst)) == "coreir.mux") {
 
         //cout << "Found mux " << inst->toString() << endl;
@@ -95,8 +95,8 @@ namespace CoreIR {
 
           int offset = stoi(selStr);
 
-          cout << "\tSource = " << srcConst->toString() << endl;
-          cout << "\tOffset = " << offset << endl;
+          // cout << "\tSource = " << srcConst->toString() << endl;
+          // cout << "\tOffset = " << offset << endl;
 
           uint8_t bit = val.get(offset).binary_value();
 

--- a/src/passes/transform/fold_constants.cpp
+++ b/src/passes/transform/fold_constants.cpp
@@ -551,6 +551,68 @@ namespace CoreIR {
 
         }
 
+      } else if (getQualifiedOpName(*inst) == "coreir.reg_arst") {
+
+        Select* rstSel = inst->sel("arst");
+        auto inSels = getSourceSelects(rstSel);
+
+        ASSERT(inSels.size() == 1, "coreir.reg_arst must have one select");
+
+        Wireable* p = inSels[0]->getTopParent();
+        if (isa<Instance>(p)) {
+          Instance* rstSrcInst = cast<Instance>(p);
+          if (getQualifiedOpName(*rstSrcInst) == "coreir.wrap") {
+            Select* wrapIn = rstSrcInst->sel("in");
+            vector<Select*> in0Values = getSignalValues(wrapIn);
+            maybe<BitVec> rstValue = getSignalBitVec(in0Values);
+
+            // If the reset port is set to a constant then we may be able to constant
+            // fold
+            if (rstValue.has_value()) {
+        
+              Select* inSel = inst->sel("in");
+              Select* outSel = inst->sel("out");
+
+              vector<Select*> inValues = getSignalValues(inSel);
+
+              bool allInsFromOut = true;
+              for (auto bitVal : inValues) {
+                Wireable* src = extractSource(bitVal);
+
+                if (!isa<Instance>(src) || cast<Instance>(src)->sel("out") != outSel) {
+                  allInsFromOut = false;
+                }
+              }
+
+              if (allInsFromOut) {
+
+                BitVector value = inst->getModArgs().at("init")->get<BitVector>();
+                auto newConst =
+                  def->addInstance(inst->toString() + "_reg_const_replacement",
+                                   "coreir.const",
+                                   {{"width", Const::make(c, value.bitLength())}},
+                                   {{"value", Const::make(c, BitVector(value))}});
+
+                auto recInstances = getReceiverSelects(inst);
+                for (auto elem : recInstances) {
+                  auto src = extractSource(elem);
+                  if (isa<Instance>(src) && (cast<Instance>(src) != inst)) {
+                    toConsider.insert(cast<Instance>(src));
+                  }
+                }
+          
+                Instance* instPT = addPassthrough(inst, "_remove_reg_PT");
+                Select* replacement = newConst->sel("out");
+
+                def->removeInstance(inst);
+                def->connect(replacement,
+                             instPT->sel("in")->sel("out"));
+                inlineInstance(instPT);
+          
+              }
+            }
+          }
+        }
       } else if (getQualifiedOpName(*inst) == "coreir.reg") {
         Select* inSel = inst->sel("in");
         Select* outSel = inst->sel("out");

--- a/src/passes/transform/sanitize_names.cpp
+++ b/src/passes/transform/sanitize_names.cpp
@@ -46,6 +46,7 @@ bool Passes::SanitizeNames::runOnModule(Module* m) {
 
   auto def = m->getDef();
 
+  cout << "Sanitizing names in " << m->getName() << endl;
   set<Instance*> allInstances;
   for (auto inst : def->getInstances()) {
     allInstances.insert(inst.second);

--- a/src/simulator/interpret.cpp
+++ b/src/simulator/interpret.cpp
@@ -1140,7 +1140,8 @@ namespace CoreIR {
 
       setMemory(inst->toString(), waddrBits, wdata->getBits());
 
-      assert(getMemory(inst->toString(), waddrBits) == wdata->getBits());
+      //assert(getMemory(inst->toString(), waddrBits) == wdata->getBits());
+      assert(same_representation(getMemory(inst->toString(), waddrBits), wdata->getBits()));
     }
 
   }

--- a/src/simulator/interpret.cpp
+++ b/src/simulator/interpret.cpp
@@ -9,14 +9,14 @@ namespace CoreIR {
     return ceil(log2(depth)) + 1;
   }
 
-  void SimMemory::setAddr(const BitVec& bv, const BitVec& val) {
+  void SimMemory::setAddr(const BitVec& addr, const BitVec& val) {
 
     assert(val.bitLength() == ((int) width));
     // Cannot access out of range elements
-    assert(bv.to_type<uint>() < depth);
+    assert(addr.to_type<uint>() < depth);
 
-    values.erase(bv);
-    values.insert({bv, val});
+    values.erase(addr);
+    values.insert({addr, val});
   }
 
   BitVec SimMemory::getAddr(const BitVec& bv) const {

--- a/src/simulator/subcircuit.cpp
+++ b/src/simulator/subcircuit.cpp
@@ -250,7 +250,7 @@ namespace CoreIR {
 
     for (auto inst : instances) {
       if ((getQualifiedOpName(*inst) == "coreir.reg") ||
-          (getQualifiedOpName(*inst) == "coreir.regrst") ||
+          (getQualifiedOpName(*inst) == "coreir.reg_arst") ||
           (getQualifiedOpName(*inst) == "corebit.reg")) {
 
         Type* tp = inst->sel("out")->getType();
@@ -273,7 +273,7 @@ namespace CoreIR {
 
     for (auto inst : instances) {
       if ((getQualifiedOpName(*inst) == "coreir.reg") ||
-          (getQualifiedOpName(*inst) == "coreir.regrst") ||
+          (getQualifiedOpName(*inst) == "coreir.reg_arst") ||
           (getQualifiedOpName(*inst) == "corebit.reg")) {
 
         string destName = "self." + inst->toString() + "_subcircuit_out";
@@ -381,7 +381,7 @@ namespace CoreIR {
         auto inst = instR.second;
 
         if ((getQualifiedOpName(*inst) == "coreir.reg") ||
-            (getQualifiedOpName(*inst) == "coreir.regrst")) {
+            (getQualifiedOpName(*inst) == "coreir.reg_arst")) {
 
           //cout << "Found register = " << inst->toString() << endl;
 

--- a/src/simulator/subcircuit.cpp
+++ b/src/simulator/subcircuit.cpp
@@ -357,6 +357,8 @@ namespace CoreIR {
 
     }
 
+    cout << "Done with submod definition" << endl;
+
     subMod->setDef(def);
   }
 

--- a/src/simulator/wiring_utils.cpp
+++ b/src/simulator/wiring_utils.cpp
@@ -421,7 +421,7 @@ namespace CoreIR {
     Instance* inst = def->getInstances().at(instanceName);
     assert(inst != nullptr);
     assert((getQualifiedOpName(*inst) == "coreir.reg") ||
-           (getQualifiedOpName(*inst) == "coreir.regrst"));
+           (getQualifiedOpName(*inst) == "coreir.reg_arst"));
 
     string instName = inst->getInstname();
     auto pt = addPassthrough(inst, inst->toString() + "_reg_replace_pt");
@@ -437,8 +437,8 @@ namespace CoreIR {
     if (instTp == "coreir.reg") {
       replacement = def->addInstance(instName, "coreir.reg", genArgs, args);
     } else {
-      assert(instTp == "coreir.regrst");
-      replacement = def->addInstance(instName, "coreir.regrst", genArgs, args);
+      assert(instTp == "coreir.reg_arst");
+      replacement = def->addInstance(instName, "coreir.reg_arst", genArgs, args);
     }
 
     assert(replacement != nullptr);

--- a/src/simulator/wiring_utils.cpp
+++ b/src/simulator/wiring_utils.cpp
@@ -418,7 +418,17 @@ namespace CoreIR {
 
     auto def = mod->getDef();
 
+
+    cout << "Checking for instance name in def" << endl;
+    if (!contains_key(instanceName, def->getInstances())) {
+      return;
+    }
+
+    cout << "Getting instance name from def " << endl;    
     Instance* inst = def->getInstances().at(instanceName);
+
+    cout << "Got instance name from def " << endl;
+
     assert(inst != nullptr);
     assert((getQualifiedOpName(*inst) == "coreir.reg") ||
            (getQualifiedOpName(*inst) == "coreir.reg_arst"));
@@ -426,6 +436,7 @@ namespace CoreIR {
     string instName = inst->getInstname();
     auto pt = addPassthrough(inst, inst->toString() + "_reg_replace_pt");
     Values args = inst->getModArgs();
+    cout << "Getting init value for " << getQualifiedOpName(*inst) << endl;
     args["init"] = Const::make(mod->getContext(), value);
 
     string instTp = getQualifiedOpName(*inst);

--- a/tests/unit/constant_folding.cpp
+++ b/tests/unit/constant_folding.cpp
@@ -112,7 +112,68 @@ void testFoldRegister() {
 
 }
 
+void testFoldRegArst() {
+  Context* c = newContext();
+
+  Namespace* g = c->getGlobal();
+  Type* tp = c->Record({{"in", c->BitIn()->Arr(3)},
+        {"clk", c->Named("coreir.clkIn")},
+          {"out", c->Bit()->Arr(3)}});
+
+  Module* md = g->newModuleDecl("port_in", tp);
+  ModuleDef* def = md->newModuleDef();
+
+
+  def->addInstance("rstVal", "corebit.const", {{"value", Const::make(c, true)}});
+
+  def->addInstance("wrapRst",
+                   "coreir.wrap",
+                   {{"type", Const::make(c, c->Named("coreir.arst"))}});
+
+  def->addInstance("reg", "coreir.reg_arst",
+                   {{"width", Const::make(c, 3)}},
+                   {{"init", Const::make(c, BitVec(3, 2))}});
+
+  def->connect("reg.out", "reg.in");
+  def->connect("rstVal.out", "wrapRst.in");
+  def->connect("wrapRst.out", "reg.arst");
+  def->connect("self.clk", "reg.clk");
+  def->connect("reg.out", "self.out");
+
+  md->setDef(def);
+
+  c->runPasses({"rungenerators", "fold-constants", "deletedeadinstances"});
+
+  cout << "After folding constants" << endl;
+
+  md->print();
+  assert(def->getInstances().size() == 1);
+
+  bool containsConst = false;
+  for (auto instR : def->getInstances()) {
+    Instance* inst = instR.second;
+    if (getQualifiedOpName(*inst) == "coreir.const") {
+      containsConst = true;
+      break;
+    }
+  }
+
+  assert(containsConst);
+
+  SimulatorState state(md);
+  state.setClock("self.clk", 0, 1);
+  state.setValue("self.in", BitVec(3, 0));
+
+  state.execute();
+
+  assert(state.getBitVec("self.out") == BitVec(3, 2));
+
+  deleteContext(c);
+
+}
+
 int main() {
   testFoldEquals();
   testFoldRegister();
+  testFoldRegArst();
 }


### PR DESCRIPTION
@rdaly525 I've been playing with ways to improve performance. The connection comparison function was a huge performance drain because it was iterating over select paths and comparing strings.

Since it looked like all the connection comparison function needed to do was provide some arbitrary order for pairs of pointers I changed it to just compare the pointer values.

This resulted in about a 40% improvement in flattening performance for the 16 x 16 CGRA. Is this change acceptable or does connection comparison need to compare select strings for some other reason?