### PR TITLE
Rmnamedtypegens

### DIFF
--- a/doc/JsonSpec.md
+++ b/doc/JsonSpec.md
@@ -24,13 +24,12 @@ Type = "BitIn"
      | "Bit" 
      | ["Array", <N>, Type] 
      | ["Record", [[<key>,Type],... ] 
-     | ["Named",NamedRef, Args?]
+     | ["Named",NamedRef]
 
 //This could be referring a type, module, or generator
 NamedRef = "<namespaceName>.<name>"
 
 NamedType = {"flippedname":<name>,"rawtype":Type}
-NamedTypeGen = {"flippedname"?:<name>,"genparams":Parameter}
 
 TypeGen = [Params, "sparse", [[Values,Type],[Values,Type],...]]
         | //TODO Type language?

--- a/include/coreir/ir/context.h
+++ b/include/coreir/ir/context.h
@@ -92,8 +92,6 @@ class Context {
     ArrayType* Array(uint n, Type* t);
     RecordType* Record(RecordParams rp=RecordParams());
     NamedType* Named(std::string nameref);
-    NamedType* Named(std::string nameref, Values args);
-
 
     //Factory functions for ValueTypes
     BoolType* Bool();

--- a/include/coreir/ir/namespace.h
+++ b/include/coreir/ir/namespace.h
@@ -19,13 +19,6 @@ class Namespace {
   //Mapping name to typegen 
   std::map<std::string,TypeGen*> typeGenList;
   
-  //Caches the NamedTypes with args
-  std::map<std::string,std::map<Values,NamedType*,ValuesComp>> namedTypeGenCache;
-
-  //Save the unflipped names for json file
-  std::map<std::string,std::string> namedTypeNameMap;
-  std::map<std::string,std::string> typeGenNameMap;
-
   public :
     Namespace(Context* c, std::string name);
     ~Namespace();
@@ -37,19 +30,17 @@ class Namespace {
     const std::map<std::string,Generator*>& getGenerators() { return generatorList;}
 
     NamedType* newNamedType(std::string name, std::string nameFlip, Type* raw);
-    //void newNominalTypeGen(std::string name, std::string nameFlip,Params genparams, TypeGenFun fun);
-    
     bool hasNamedType(std::string name);
     
-    //Only returns named types without args
-    //TODO depreciate Named Types with args
+    //Returns a list of named types
     std::map<std::string,NamedType*> getNamedTypes() { return namedTypeList;}
     NamedType* getNamedType(std::string name);
-    NamedType* getNamedType(std::string name, Values genargs);
     
     //This is transferring control of typegen to Namespace
+    //TODO make this accept a unique pointer
     void addTypeGen(TypeGen* typegen);
-    //TODO depreciate the following function
+    
+    //TODO depreciate the following function from namespace. Should only be created from a static make function
     TypeGen* newTypeGen(std::string name, Params genparams, TypeGenFun fun);
     TypeGen* getTypeGen(std::string name);
     const std::map<std::string,TypeGen*>& getTypeGens() { return typeGenList; }

--- a/src/ir/context.cpp
+++ b/src/ir/context.cpp
@@ -252,14 +252,6 @@ NamedType* Context::Named(string nameref) {
   return this->getNamespace(split[0])->getNamedType(split[1]);
 }
 
-NamedType* Context::Named(string nameref,Values args) {
-  checkValuesAreConst(args);
-  vector<string> split = splitRef(nameref);
-  ASSERT(this->hasNamespace(split[0]),"Missing Namespace + " + split[0]);
-  ASSERT(this->getNamespace(split[0])->hasNamedType(split[1]),"Missing Named type + " + nameref);
-  return this->getNamespace(split[0])->getNamedType(split[1],args);
-}
-
 Type* Context::Flip(Type* t) { return t->getFlipped();}
 
 Type* Context::In(Type* t) {

--- a/src/ir/fileReader.cpp
+++ b/src/ir/fileReader.cpp
@@ -449,14 +449,10 @@ Type* json2Type(Context* c, json jt) {
       return c->Record(rparams);
     }
     else if (kind == "Named") {
+      ASSERTTHROW(args.size()==2,"Invalid Named Type field" + toString(jt));
       vector<string> info = getRef(args[1].get<string>());
       std::string nsname = info[0];
       std::string name   = info[1];
-      if (args.size()==3) { //Has args
-        Params genparams = c->getNamespace(nsname)->getTypeGen(name)->getParams();
-        Values genargs = json2Values(c,args[2]);
-        return c->Named(nsname+"."+name,genargs);
-      }
       return c->Named(nsname+"."+name);
     }
     else {

--- a/src/ir/namespace.cpp
+++ b/src/ir/namespace.cpp
@@ -18,11 +18,6 @@ Namespace::~Namespace() {
   for (auto m : moduleList) delete m.second;
   for (auto g : generatorList) delete g.second;
   for (auto n : namedTypeList) delete n.second;
-  for (auto nmap : namedTypeGenCache) {
-    for (auto n : nmap.second) {
-      delete n.second;
-    }
-  }
   for (auto tg : typeGenList) delete tg.second;
 }
 
@@ -47,7 +42,7 @@ NamedType* Namespace::newNamedType(string name, string nameFlip, Type* raw) {
   assert(!namedTypeList.count(name) && !namedTypeList.count(nameFlip) );
   
   //Add name to namedTypeNameMap
-  namedTypeNameMap[name] = nameFlip;
+  //namedTypeNameMap[name] = nameFlip;
 
   //Create two new NamedTypes
   NamedType* named = new NamedType(this,name,raw);
@@ -58,24 +53,6 @@ NamedType* Namespace::newNamedType(string name, string nameFlip, Type* raw) {
   namedTypeList[nameFlip] = namedFlip;
   return named;
 }
-
-//TODO remove this code
-//void Namespace::newNominalTypeGen(string name, string nameFlip, Params genparams, TypeGenFun fun) {
-//  //Make sure the name and its flip are different
-//  assert(name != nameFlip);
-//  //Verify this name and the flipped name do not exist yet
-//  assert(!typeGenList.count(name) && !typeGenList.count(nameFlip));
-//  assert(!namedTypeList.count(name) && !namedTypeList.count(nameFlip) );
-// 
-//  //Add name to typeGenNameMap
-//  typeGenNameMap[name] = nameFlip;
-//  typeGenNameMap[nameFlip] = name;
-//
-//  //Create the TypeGens
-//  TypeGenFromFun::make(this,name,genparams,fun,false);
-//  TypeGenFromFun::make(this,nameFlip,genparams,fun,true);
-//  
-//}
 
 bool Namespace::hasNamedType(string name) {
   return namedTypeList.count(name) > 0;
@@ -88,43 +65,11 @@ NamedType* Namespace::getNamedType(string name) {
   return found->second;
 }
 
-//Check if cached in namedTypeGenCache
-//Make sure the name is found in the typeGenCache. Error otherwise
-//Then create a new entry in NamedCache if it does not exist
-NamedType* Namespace::getNamedType(string name, Values genargs) {
-  ASSERT(typeGenList.count(name),this->name + "." + name + " was never defined");
-  assert(typeGenNameMap.count(name));
-
-  if (namedTypeGenCache[name].count(genargs)) {
-    return namedTypeGenCache[name][genargs];
-  }
-  //Not found in cache. Create the entry
-  //Not found. Verify that name exists in TypeGenList
-  TypeGen* tgen = typeGenList[name];
-  assert(typeGenNameMap.count(name));
-  string nameFlip = typeGenNameMap.at(name);
-  assert(typeGenList.count(nameFlip));
-  TypeGen* tgenFlip = typeGenList.at(nameFlip);
-
-  //Create two new named entries
-  NamedType* named = new NamedType(this,name,tgen,genargs);
-  NamedType* namedFlip = new NamedType(this,nameFlip,tgenFlip,genargs);
-  named->setFlipped(namedFlip);
-  namedFlip->setFlipped(named);
-  namedTypeGenCache[name][genargs] = named;
-  namedTypeGenCache[nameFlip][genargs] = namedFlip;
-  ASSERT(namedTypeGenCache.count(name),"Bad name missing");
-  ASSERT(namedTypeGenCache[name].count(genargs),"Bad args missing");
-
-  return named;
-}
 
 void Namespace::addTypeGen(TypeGen* typegen) {
   ASSERT(typegen->getNamespace() == this, "Adding typegen to a namespace different than its own");
   ASSERT(namedTypeList.count(typegen->getName())==0, "Name collision in addTypeGen");
 
-  //Add name to typeGenNameMap
-  typeGenNameMap[typegen->getName()] = "";
   typeGenList[typegen->getName()] = typegen;
 }
 
@@ -214,7 +159,6 @@ GlobalValue* Namespace::getGlobalValue(string iname) {
   return nullptr;
 }
 
-//TODO Update this
 void Namespace::print() {
   cout << "Namespace: " << name << endl;
   cout << "  Generators:" << endl;


### PR DESCRIPTION
This is (hopefully) a small commit which depreciates Named Type Gens (Also referred to in my code as a Nominal Type Gen). This was a feature in CoreIR which allowed you to specify parameterized Named Types. I am removing it is a feature that was complicated, never used, and probably should be a language feature instead of an IR feature. 

