### PR TITLE
Rmcommondep

### DIFF
--- a/include/coreir/ir/common.h
+++ b/include/coreir/ir/common.h
@@ -8,22 +8,6 @@
 
 namespace CoreIR {
 
-class ConnectionComp {
-  public:
-    static bool SPComp(const SelectPath& l, const SelectPath& r);
-    bool operator() (const Connection& l, const Connection& r) const;
-};
-
-class ConnectionStrComp {
-  public:
-    static bool SPComp(const SelectPath& l, const SelectPath& r);
-    bool operator() (const Connection& l, const Connection& r) const;
-};
-
-class ValuesComp {
-  public:
-    bool operator() (const Values& l, const Values& r) const;
-};
 
 //TODO Ugly hack to create a sorted connection. Should make my own connection class
 Connection connectionCtor(Wireable* a, Wireable* b);

--- a/include/coreir/ir/fwd_declare.h
+++ b/include/coreir/ir/fwd_declare.h
@@ -57,6 +57,8 @@ class NamedType;
 
 class TypeGen;
 
+
+
 class TypeCache;
 class ValueCache;
 
@@ -111,6 +113,7 @@ class PassManager;
 typedef std::map<std::string,Value*> Values;
 typedef std::map<std::string,ValueType*> Params;
 
+
 bool operator==(const Values& l, const Values& r);
 
 
@@ -128,6 +131,30 @@ typedef std::vector<std::reference_wrapper<const std::string>> ConstSelectPath;
 typedef std::pair<Wireable*,Wireable*> Connection;
 //This is meant to be in relation to an instance. First wireable of the pair is of that instance.
 typedef std::vector<std::pair<Wireable*,Wireable*>> LocalConnections;
+
+
+//Comparison classes for caches
+class ConnectionComp {
+  public:
+    static bool SPComp(const SelectPath& l, const SelectPath& r);
+    bool operator() (const Connection& l, const Connection& r) const;
+};
+
+class ConnectionStrComp {
+  public:
+    static bool SPComp(const SelectPath& l, const SelectPath& r);
+    bool operator() (const Connection& l, const Connection& r) const;
+};
+
+class ValuesComp {
+  public:
+    bool operator() (const Values& l, const Values& r) const;
+};
+
+
+
+
+
 
 //TODO This stuff is super fragile. 
 // Magic hash function I found online

--- a/include/coreir/ir/generator.h
+++ b/include/coreir/ir/generator.h
@@ -4,7 +4,6 @@
 
 #include "fwd_declare.h"
 #include "globalvalue.h"
-#include "common.h"
 
 namespace CoreIR {
 

--- a/include/coreir/ir/generatordef.h
+++ b/include/coreir/ir/generatordef.h
@@ -2,7 +2,6 @@
 #define COREIR_GENERATORDEF_HPP_
 
 #include "fwd_declare.h"
-#include "common.h"
 
 namespace CoreIR {
 class GeneratorDef {

--- a/include/coreir/ir/module.h
+++ b/include/coreir/ir/module.h
@@ -5,7 +5,6 @@
 #include "fwd_declare.h"
 #include "args.h"
 #include "globalvalue.h"
-//#include "common.h"
 
 namespace CoreIR {
 

--- a/include/coreir/ir/moduledef.h
+++ b/include/coreir/ir/moduledef.h
@@ -3,7 +3,6 @@
 
 
 #include "fwd_declare.h"
-#include "common.h"
 #include "context.h"
 #include "module.h"
 #include "wireable.h"

--- a/include/coreir/ir/namespace.h
+++ b/include/coreir/ir/namespace.h
@@ -2,7 +2,6 @@
 #define COREIR_NAMESPACE_HPP_
 
 #include "fwd_declare.h"
-#include "common.h"
 
 namespace CoreIR {
 

--- a/include/coreir/ir/typegen.h
+++ b/include/coreir/ir/typegen.h
@@ -3,7 +3,6 @@
 
 #include "fwd_declare.h"
 #include "globalvalue.h"
-#include "common.h" //This should really be moved to fwd_declare
 
 namespace CoreIR {
 

--- a/src/ir/context.cpp
+++ b/src/ir/context.cpp
@@ -12,6 +12,7 @@
 #include "coreir/ir/generator.h"
 #include "coreir/ir/module.h"
 #include "coreir/ir/moduledef.h"
+#include "coreir/ir/common.h"
 
 using namespace std;
 

--- a/src/ir/generatordef.cpp
+++ b/src/ir/generatordef.cpp
@@ -1,5 +1,6 @@
 #include "coreir/ir/generatordef.h"
 #include "coreir/ir/generator.h"
+#include "coreir/ir/common.h"
 
 namespace CoreIR {
 void GeneratorDefFromFun::createModuleDef(ModuleDef* mdef, Values genargs) {

--- a/src/ir/globalvalue.cpp
+++ b/src/ir/globalvalue.cpp
@@ -1,5 +1,6 @@
 #include "coreir/ir/globalvalue.h"
 #include "coreir/ir/namespace.h"
+#include "coreir/ir/common.h"
 
 using namespace std;
 namespace CoreIR {


### PR DESCRIPTION
A few of the header files were including 'common.h'. This pull request removes that dependency by moving some comparison classes (used in caching) to fwd_declare.