### PR TITLE
added TypeGenImplicit

### DIFF
--- a/doc/JsonSpec.md
+++ b/doc/JsonSpec.md
@@ -32,6 +32,7 @@ NamedRef = "<namespaceName>.<name>"
 NamedType = {"flippedname":<name>,"rawtype":Type}
 
 TypeGen = [Params, "sparse", [[Values,Type],[Values,Type],...]]
+        | [Params, "implicit"]
         | //TODO Type language?
 
 //Note if there are no instances and no connections, this is a declaration

--- a/include/coreir/ir/generator.h
+++ b/include/coreir/ir/generator.h
@@ -35,6 +35,10 @@ class Generator : public GlobalValue {
     //Note, this is stored in the generator itself and is not in the namespace
     Module* getModule(Values genargs);
     
+    //This will create a new generated module with the specified type.
+    //If the typegen can create a type, it will verify types match, else it will just use the type
+    Module* getModule(Values genargs, Type* type);
+    
     //Will delete the cached Module
     void eraseModule(Values genargs);
 

--- a/include/coreir/ir/typegen.h
+++ b/include/coreir/ir/typegen.h
@@ -57,6 +57,23 @@ class TypeGenSparse : public TypeGen {
     static TypeGenSparse* make(Namespace* ns, std::string name, Params params, std::vector<std::pair<Values,Type*>>& typelist);
 };
 
+//TODO could potentially turn into singlton?
+//This is used for 'blank' typegens.
+//createType always fails
+//hasType always returns false
+//This allows the existence of generators with functionally no typegen
+class TypeGenImplicit : public TypeGen {
+  protected :
+    TypeGenImplicit(Namespace* ns, std::string name, Params params) : TypeGen(ns,name,params,false) {}
+  public :
+    Type* createType(Values genargs) override;
+    bool hasType(Values genargs) override;
+    std::string toString() const override;
+    
+    //Creation function
+    static TypeGenImplicit* make(Namespace* ns, std::string name, Params params);
+};
+
 
 
 }// CoreIR

--- a/src/ir/generator.cpp
+++ b/src/ir/generator.cpp
@@ -43,7 +43,47 @@ Module* Generator::getModule(Values genargs) {
   }
   
   checkValuesAreParams(genargs,genparams,getRefName());
+  ASSERT(typegen->hasType(genargs),"Cannot create generated module!");
   Type* type = typegen->getType(genargs);
+  string modname;
+  if (nameGen) {
+    modname = nameGen(genargs);
+  }
+  else {
+    modname = this->name;
+  }
+  Module* m;
+  if (modParamsGen) {
+    auto pc = modParamsGen(getContext(),genargs);
+    m = new Module(ns,modname,type,pc.first,this,genargs);
+    m->addDefaultModArgs(pc.second);
+  }
+  else {
+     m = new Module(ns,modname,type,Params(),this,genargs);
+  }
+  genCache[genargs] = m;
+  
+  //TODO I am not sure what the default behavior should be
+  //for not having a def
+  //Run the generator if it has the def
+  //if (this->hasDef()) {
+  //  ModuleDef* mdef = m->newModuleDef();
+  //  def->createModuleDef(mdef,genargs); 
+  //  m->setDef(mdef);
+  //}
+  return m;
+}
+
+Module* Generator::getModule(Values genargs, Type* type) {
+  mergeValues(genargs,defaultGenArgs);
+  if (genCache.count(genargs)) {
+    return genCache[genargs];
+  }
+  
+  checkValuesAreParams(genargs,genparams,getRefName());
+  if (typegen->hasType(genargs)) {
+    ASSERT(typegen->getType(genargs) == type,"Cannot create module with inconsistent types");
+  }
   string modname;
   if (nameGen) {
     modname = nameGen(genargs);

--- a/src/ir/typegen.cpp
+++ b/src/ir/typegen.cpp
@@ -3,6 +3,7 @@
 #include "coreir/ir/common.h"
 #include "coreir/ir/types.h"
 #include "coreir/ir/value.h"
+#include "coreir/ir/generator.h"
 
 using namespace std;
 
@@ -71,6 +72,24 @@ std::string TypeGenSparse::toString() const {
 
 TypeGenSparse* TypeGenSparse::make(Namespace* ns, std::string name, Params params, std::vector<std::pair<Values,Type*>>& typelist) {
   TypeGenSparse* tg = new TypeGenSparse(ns,name,params,typelist);
+  ns->addTypeGen(tg);
+  return tg;
+}
+
+bool TypeGenImplicit::hasType(Values genargs) {
+  return false;
+}
+
+Type* TypeGenImplicit::createType(Values genargs) {
+  ASSERT(0,"Cannot ever create a type with a TypeGenImplicit");
+}
+
+std::string TypeGenImplicit::toString() const {
+  return this->getRefName() + ::CoreIR::toString(this->getParams());
+}
+
+TypeGenImplicit* TypeGenImplicit::make(Namespace* ns, std::string name, Params params) {
+  TypeGenImplicit* tg = new TypeGenImplicit(ns,name,params);
   ns->addTypeGen(tg);
   return tg;
 }

--- a/src/passes/analysis/coreirjson.cpp
+++ b/src/passes/analysis/coreirjson.cpp
@@ -327,15 +327,20 @@ bool Passes::CoreIRJson::runOnNamespace(Namespace* ns) {
       TypeGen* tg = tgpair.second;
       Array jtypegen;
       jtypegen.add(Params2Json(tg->getParams()));
-      jtypegen.add(quote("sparse"));
-      Array jsparselist(6);
-      for (auto vtpair : tg->getCached()) {
-        Array jvtpair;
-        jvtpair.add(Values2Json(vtpair.first));
-        jvtpair.add(Type2Json(vtpair.second));
-        jsparselist.add(jvtpair.toString());
+      if (tg->getCached().size()==0) {
+        jtypegen.add(quote("implicit"));
       }
-      jtypegen.add(jsparselist.toMultiString());
+      else {
+        jtypegen.add(quote("sparse"));
+        Array jsparselist(6);
+        for (auto vtpair : tg->getCached()) {
+          Array jvtpair;
+          jvtpair.add(Values2Json(vtpair.first));
+          jvtpair.add(Type2Json(vtpair.second));
+          jsparselist.add(jvtpair.toString());
+        }
+        jtypegen.add(jsparselist.toMultiString());
+      }
       jtypegens.add(tgname,jtypegen.toString());
     }
     jns.add("typegens",jtypegens.toMultiString());

--- a/tests/unit/typegen_implicit.cpp
+++ b/tests/unit/typegen_implicit.cpp
@@ -56,8 +56,25 @@ int main() {
   top->setDef(def);
   top->print();
   
+  cout << "Checking saving and loading postgen" << endl;
+  if (!saveToFile(g, "_typegen_implicit.json",top)) {
+    cout << "Could not save to json!!" << endl;
+    c->die();
+  }
+  
+  deleteContext(c);
+  
+  c = newContext();
+  
+  top = nullptr;
+  if (!loadFromFile(c,"_typegen_implicit.json", &top)) {
+    cout << "Could not Load from json!!" << endl;
+    c->die();
+  }
+  ASSERT(top, "Could not load top: typegen_implicit");
+  top->print();
+
   c->runPasses({"rungenerators","flatten"});
   top->print();
 
-  deleteContext(c);
 }

--- a/tests/unit/typegen_implicit.cpp
+++ b/tests/unit/typegen_implicit.cpp
@@ -1,0 +1,63 @@
+#include "coreir.h"
+
+using namespace std;
+using namespace CoreIR;
+
+
+int main() {
+  
+  Context* c = newContext();
+  Namespace* g = c->getGlobal();
+  
+  //Declare an implicit TypeGenerator
+  TypeGen* tg = TypeGenImplicit::make(
+    g,
+    "add_type", //name for the typegen
+    {{"width",c->Int()}} //generater parameters
+  );
+
+  Generator* add = g->newGeneratorDecl("add",tg,{{"width",c->Int()}});
+  
+  {
+    Module* m5 = add->getModule(
+      {{"width",Const::make(c,5)}},
+      c->Record({
+        {"in0",c->BitIn()->Arr(5)},
+        {"in1",c->BitIn()->Arr(5)},
+        {"out",c->Bit()->Arr(5)}
+      })
+    );
+
+    ModuleDef* def = m5->newModuleDef();
+    def->addInstance("i0","coreir.add",{{"width",Const::make(c,5)}});
+    def->connect("self","i0");
+  }
+
+  {
+    Module* m9 = add->getModule(
+      {{"width",Const::make(c,9)}},
+      c->Record({
+        {"in0",c->BitIn()->Arr(9)},
+        {"in1",c->BitIn()->Arr(9)},
+        {"out",c->Bit()->Arr(9)}
+      })
+    );
+
+    ModuleDef* def = m9->newModuleDef();
+    def->addInstance("i0","coreir.add",{{"width",Const::make(c,9)}});
+    def->connect("self","i0");
+  }
+
+  // Define Add12 Module
+  Module* top = g->newModuleDecl("top",c->Record());
+  ModuleDef* def = top->newModuleDef();
+    def->addInstance("add5","global.add",{{"width",Const::make(c,5)}});
+    def->addInstance("add9","global.add",{{"width",Const::make(c,9)}});
+  top->setDef(def);
+  top->print();
+  
+  c->runPasses({"rungenerators","flatten"});
+  top->print();
+
+  deleteContext(c);
+}


### PR DESCRIPTION
Added an implicit typegen that does not actually do anything. Generators can now create modules without an explicit typegen function.

This means at the moment that Generators with implicit typegens cannot have a generator definition, but rather have to fill out circuits one by one using getModule(Values,Type*)

