### PR TITLE
Rmnamegen

### DIFF
--- a/include/coreir/ir/fwd_declare.h
+++ b/include/coreir/ir/fwd_declare.h
@@ -126,7 +126,6 @@ bool operator==(const Values& l, const Values& r);
 
 //Function prototypes for APIs
 typedef std::function<Type*(Context* c, Values genargs)> TypeGenFun;
-typedef std::string (*NameGenFun)(Values);
 typedef std::function<std::pair<Params,Values>(Context*,Values)> ModParamsGenFun;
   //typedef void (*ModuleDefGenFun)(Context* c,Values genargs,ModuleDef*);
 typedef std::function<void (Context* c,Values genargs,ModuleDef*) > ModuleDefGenFun;

--- a/include/coreir/ir/generator.h
+++ b/include/coreir/ir/generator.h
@@ -14,7 +14,6 @@ class Generator : public GlobalValue {
   Params genparams;
   Values defaultGenArgs; 
   
-  NameGenFun nameGen=nullptr;
   ModParamsGenFun modParamsGen=nullptr;
 
   //This is memory managed
@@ -56,7 +55,6 @@ class Generator : public GlobalValue {
     void addDefaultGenArgs(Values defaultGenargs);
     Values getDefaultGenArgs() { return defaultGenArgs;}
   
-    void setNameGen(NameGenFun ng) {nameGen = ng;}
     void setModParamsGen(ModParamsGenFun mpg) {modParamsGen = mpg;}
     void setModParamsGen(Params modparams,Values defaultModArgs=Values()) {
       this->modParamsGen = [modparams,defaultModArgs](Context* c,Values genargs) mutable -> std::pair<Params,Values> {

--- a/src/ir/generator.cpp
+++ b/src/ir/generator.cpp
@@ -45,13 +45,7 @@ Module* Generator::getModule(Values genargs) {
   checkValuesAreParams(genargs,genparams,getRefName());
   ASSERT(typegen->hasType(genargs),"Cannot create generated module!");
   Type* type = typegen->getType(genargs);
-  string modname;
-  if (nameGen) {
-    modname = nameGen(genargs);
-  }
-  else {
-    modname = this->name;
-  }
+  string modname = this->name;
   Module* m;
   if (modParamsGen) {
     auto pc = modParamsGen(getContext(),genargs);
@@ -84,13 +78,7 @@ Module* Generator::getModule(Values genargs, Type* type) {
   if (typegen->hasType(genargs)) {
     ASSERT(typegen->getType(genargs) == type,"Cannot create module with inconsistent types");
   }
-  string modname;
-  if (nameGen) {
-    modname = nameGen(genargs);
-  }
-  else {
-    modname = this->name;
-  }
+  string modname = this->name;
   Module* m;
   if (modParamsGen) {
     auto pc = modParamsGen(getContext(),genargs);


### PR DESCRIPTION
Depreciate "name gen". This was old code that was a hack. Currently generated modules have the same module name as the generator. This is fine because they are cached by name + parameters.