### PR TITLE
catch std::out_of_range by const ref

### DIFF
--- a/src/ir/typegen.cpp
+++ b/src/ir/typegen.cpp
@@ -15,7 +15,7 @@ Type* TypeGen::getType(Values args) {
     Type* t = this->createType(ns->getContext(),args);
     return flipped ? t->getFlipped() : t;
   }
-  catch(std::out_of_range) {
+  catch(const std::out_of_range&) {
     cout << "Failed on " << this->getRefName() << " with args=" << ::CoreIR::toString(args) << endl;
     assert(0);
     return nullptr;


### PR DESCRIPTION
fixes compatibility with compilers that warn on catching polymorphic exceptions by value