### PR TITLE
Aetherling Reduce Fixing Unnconnected Input On Power 2 Inputs

### DIFF
--- a/tests/simulator/aetherlingSim.cpp
+++ b/tests/simulator/aetherlingSim.cpp
@@ -178,7 +178,8 @@ namespace CoreIR {
         Namespace* g = c->getGlobal();
 
         uint width = 16;
-        uint numInputs = 9;
+        uint numInputs4 = 4;
+        uint numInputs9 = 4;
         uint constInput = 3;
 
         CoreIRLoadLibrary_commonlib(c);
@@ -187,9 +188,14 @@ namespace CoreIR {
         Module* add = c->getGenerator("coreir.add")->getModule({{"width", Const::make(c, width)}});
         add->print();
 
-        Values reduceModArgs = {
-            {"numInputs", Const::make(c, numInputs)},
+        Values reduce4ModArgs = {
+            {"numInputs", Const::make(c, numInputs4)},
             {"operator", Const::make(c, add)}
+        };
+
+        Values reduce9ModArgs = {
+          {"numInputs", Const::make(c, numInputs9)},
+          {"operator", Const::make(c, add)}
         };
             
         SECTION("aetherlinglib reduceParallel with 4 inputs, coreir.add as op, 16 bit width") {
@@ -200,14 +206,14 @@ namespace CoreIR {
             Module* mainModule = c->getGlobal()->newModuleDecl("mainReduceParallelTest", mainModuleType);
             ModuleDef* def = mainModule->newModuleDef();
             
-            string reduceParallelName = "reduce" + to_string(numInputs);
-            Instance* reduceParallel_add = def->addInstance(reduceParallelName, "aetherlinglib.reduceParallel", reduceModArgs);
+            string reduceParallelName = "reduce" + to_string(numInputs4);
+            Instance* reduceParallel_add = def->addInstance(reduceParallelName, "aetherlinglib.reduceParallel", reduce4ModArgs);
             string addIdentityConst = Aetherling_addCoreIRConstantModule(c, def, width, Const::make(c, width, 0));
 
             def->connect(addIdentityConst + ".out", reduceParallelName + ".in.identity");
             // create different input for each operator
             uint rightOutput = 0;
-            for (uint i = 0 ; i < numInputs; i++) {
+            for (uint i = 0 ; i < numInputs4; i++) {
                 string constName = "constInput" + to_string(i);
                 def->addInstance(
                     constName,
@@ -220,14 +226,67 @@ namespace CoreIR {
             }
 
             def->connect(reduceParallelName + ".out", "self.out");
+            cout << "a" << endl;
             mainModule->setDef(def);
+            cout << "b" << endl;
             mainModule->print();
+            cout << "c" << endl;
             reduceParallel_add->getModuleRef()->print();
-            c->runPasses({"rungenerators", "verifyconnectivity-onlyinputs-noclkrst",
+            cout << "d" << endl;
+            c->runPasses({"rungenerators", "verifyconnectivity-noclkrst",
                         "wireclocks-coreir", "flatten", "flattentypes", "verifyconnectivity",
                         "deletedeadinstances"},
                 {"aetherlinglib", "commonlib", "mantle", "coreir", "global"});
             mainModule->print();
+            cout << "howdy" << endl;
+                                    
+            SimulatorState state(mainModule);
+            state.exeCombinational();
+
+            REQUIRE(state.getBitVec("self.out") == BitVector(width, rightOutput));
+        }
+
+        SECTION("aetherlinglib reduceParallel with 9 inputs, coreir.add as op, 16 bit width") {
+            // create the main module to run the test on the adder
+            Type* mainModuleType = c->Record({
+                    {"out", c->Bit()->Arr(width)}
+                });
+            Module* mainModule = c->getGlobal()->newModuleDecl("mainReduceParallelTest", mainModuleType);
+            ModuleDef* def = mainModule->newModuleDef();
+            
+            string reduceParallelName = "reduce" + to_string(numInputs9);
+            Instance* reduceParallel_add = def->addInstance(reduceParallelName, "aetherlinglib.reduceParallel", reduce9ModArgs);
+            string addIdentityConst = Aetherling_addCoreIRConstantModule(c, def, width, Const::make(c, width, 0));
+
+            def->connect(addIdentityConst + ".out", reduceParallelName + ".in.identity");
+            // create different input for each operator
+            uint rightOutput = 0;
+            for (uint i = 0 ; i < numInputs9; i++) {
+                string constName = "constInput" + to_string(i);
+                def->addInstance(
+                    constName,
+                    "coreir.const",
+                    {{"width", Const::make(c, width)}},
+                    {{"value", Const::make(c, width, i)}});
+
+                def->connect(constName + ".out", reduceParallelName + ".in.data." + to_string(i));
+                rightOutput += i;
+            }
+
+            def->connect(reduceParallelName + ".out", "self.out");
+            cout << "a" << endl;
+            mainModule->setDef(def);
+            cout << "b" << endl;
+            mainModule->print();
+            cout << "c" << endl;
+            reduceParallel_add->getModuleRef()->print();
+            cout << "d" << endl;
+            c->runPasses({"rungenerators", "verifyconnectivity-noclkrst",
+                        "wireclocks-coreir", "flatten", "flattentypes", "verifyconnectivity",
+                        "deletedeadinstances"},
+                {"aetherlinglib", "commonlib", "mantle", "coreir", "global"});
+            mainModule->print();
+            cout << "howdy" << endl;
                                     
             SimulatorState state(mainModule);
             state.exeCombinational();
@@ -244,8 +303,8 @@ namespace CoreIR {
             Module* mainModule = c->getGlobal()->newModuleDecl("mainReduceSequentialTest", mainModuleType);
             ModuleDef* def = mainModule->newModuleDef();
             
-            string reduceSequentialName = "reduce" + to_string(numInputs);
-            Instance* reduceSequential_add = def->addInstance(reduceSequentialName, "aetherlinglib.reduceSequential", reduceModArgs);
+            string reduceSequentialName = "reduce" + to_string(numInputs4);
+            Instance* reduceSequential_add = def->addInstance(reduceSequentialName, "aetherlinglib.reduceSequential", reduce4ModArgs);
             def->connect("self.in", reduceSequentialName + ".in");
             def->connect(reduceSequentialName + ".out", "self.out");
             def->connect(reduceSequentialName + ".valid", "self.valid");
@@ -264,7 +323,7 @@ namespace CoreIR {
             // on first clock, ready should be asserted, then deasserted for rest until processed all input
             // from start until all inputs have gone through, valid should be deasserted
             uint i;
-            for (i = 0; i < numInputs - 1; i++) {
+            for (i = 0; i < numInputs4 - 1; i++) {
                 state.setValue("self.in", BitVector(width, i));
                 rightOutput += i;
                 state.exeCombinational();

--- a/tests/simulator/aetherlingSim.cpp
+++ b/tests/simulator/aetherlingSim.cpp
@@ -203,7 +203,7 @@ namespace CoreIR {
             Type* mainModuleType = c->Record({
                     {"out", c->Bit()->Arr(width)}
                 });
-            Module* mainModule = c->getGlobal()->newModuleDecl("mainReduceParallelTest", mainModuleType);
+            Module* mainModule = c->getGlobal()->newModuleDecl("mainReduce4ParallelTest", mainModuleType);
             ModuleDef* def = mainModule->newModuleDef();
             
             string reduceParallelName = "reduce" + to_string(numInputs4);
@@ -251,7 +251,7 @@ namespace CoreIR {
             Type* mainModuleType = c->Record({
                     {"out", c->Bit()->Arr(width)}
                 });
-            Module* mainModule = c->getGlobal()->newModuleDecl("mainReduceParallelTest", mainModuleType);
+            Module* mainModule = c->getGlobal()->newModuleDecl("mainReduceParallel9Test", mainModuleType);
             ModuleDef* def = mainModule->newModuleDef();
             
             string reduceParallelName = "reduce" + to_string(numInputs9);

--- a/tests/simulator/aetherlingSim.cpp
+++ b/tests/simulator/aetherlingSim.cpp
@@ -226,19 +226,14 @@ namespace CoreIR {
             }
 
             def->connect(reduceParallelName + ".out", "self.out");
-            cout << "a" << endl;
             mainModule->setDef(def);
-            cout << "b" << endl;
             mainModule->print();
-            cout << "c" << endl;
             reduceParallel_add->getModuleRef()->print();
-            cout << "d" << endl;
             c->runPasses({"rungenerators", "verifyconnectivity-noclkrst",
                         "wireclocks-coreir", "flatten", "flattentypes", "verifyconnectivity",
                         "deletedeadinstances"},
                 {"aetherlinglib", "commonlib", "mantle", "coreir", "global"});
             mainModule->print();
-            cout << "howdy" << endl;
                                     
             SimulatorState state(mainModule);
             state.exeCombinational();
@@ -274,19 +269,14 @@ namespace CoreIR {
             }
 
             def->connect(reduceParallelName + ".out", "self.out");
-            cout << "a" << endl;
             mainModule->setDef(def);
-            cout << "b" << endl;
             mainModule->print();
-            cout << "c" << endl;
             reduceParallel_add->getModuleRef()->print();
-            cout << "d" << endl;
             c->runPasses({"rungenerators", "verifyconnectivity-noclkrst",
                         "wireclocks-coreir", "flatten", "flattentypes", "verifyconnectivity",
                         "deletedeadinstances"},
                 {"aetherlinglib", "commonlib", "mantle", "coreir", "global"});
             mainModule->print();
-            cout << "howdy" << endl;
                                     
             SimulatorState state(mainModule);
             state.exeCombinational();


### PR DESCRIPTION
Aetherling's reduce requires the user to provide the identity element for the reduce operator so that non-power 2 inputs can be put into a binary tree of reduce operators. The rest of the inputs to the tree are filled with the identity operator as this has no impact on the calculations.

Previously, there was a bug in the event that power 2 inputs were provided. In this case, the identity input was not connected to anything inside the circuit. I thought I had been testing this case to guarantee it was connected to something, but my constant for the number of inputs was wrong and so I was providing 9 inputs instead of 4. 

This pull request fixes the bug by sending the identity input to a term if it isn't needed. I've also added a test case so that there are test cases for both power 2 and non-power 2 inputs (both 4 and 9 inputs).