### PR TITLE
Add ModuleDefCanSelect to c-api

### DIFF
--- a/include/coreir-c/coreir.h
+++ b/include/coreir-c/coreir.h
@@ -88,6 +88,7 @@ extern COREWireable* COREConnectionGetFirst(COREConnection* c);
 extern COREWireable* COREConnectionGetSecond(COREConnection* c);
 extern COREWireable** COREWireableGetConnectedWireables(COREWireable* wireable, int* numWireables);
 extern COREWireable* COREModuleDefSelect(COREModuleDef* m, char* name);
+extern bool COREModuleDefCanSelect(COREModuleDef* m, char* name);
 extern COREModuleDef* COREWireableGetContainer(COREWireable* w);
 extern COREModule* COREModuleDefGetModule(COREModuleDef* m);
 extern const char** COREWireableGetSelectPath(COREWireable* w, int* num_selects);

--- a/src/coreir-c/coreir-c.cpp
+++ b/src/coreir-c/coreir-c.cpp
@@ -213,7 +213,7 @@ extern "C" {
   const char* COREModuleGetName(COREModule* module) {
     return rcast<Module*>(module)->getName().c_str();
   }
-  
+
   const char* COREGeneratorGetName(COREGenerator* gen) {
       return rcast<Generator*>(gen)->getName().c_str();
   }
@@ -352,6 +352,10 @@ extern "C" {
 
   COREWireable* COREModuleDefSelect(COREModuleDef* m, char* name) {
     return rcast<COREWireable*>(rcast<ModuleDef*>(m)->sel(string(name)));
+  }
+
+  bool COREModuleDefCanSelect(COREModuleDef* m, char* name) {
+    return rcast<COREWireable*>(rcast<ModuleDef*>(m)->canSel(string(name)));
   }
 
   COREModuleDef* COREWireableGetContainer(COREWireable* w) {


### PR DESCRIPTION
Enables a pycoreir check that raises an exception on selection errors instead of triggering a segfault in coreir.

See https://github.com/leonardt/pycoreir/commit/409c5e05c2238888348af27f8feaf2215985b224