### PR TITLE
Avoid using `join` as instance name in commonlib

### DIFF
--- a/src/libs/commonlib.cpp
+++ b/src/libs/commonlib.cpp
@@ -432,16 +432,16 @@ Namespace* CoreIRLoadLibrary_commonlib(Context* c) {
         def->connect("self.in.sel.0", "term_sel.in");
       }
       else if (N == 2) {
-        def->addInstance("join",mux2,{{"width",aWidth}});
-        def->connect("join.out","self.out");
+        def->addInstance("_join",mux2,{{"width",aWidth}});
+        def->connect("_join.out","self.out");
 
-        def->connect("self.in.data.0","join.in0");
-        def->connect("self.in.data.1","join.in1");
-        def->connect("self.in.sel.0", "join.sel");
+        def->connect("self.in.data.0","_join.in0");
+        def->connect("self.in.data.1","_join.in1");
+        def->connect("self.in.sel.0", "_join.sel");
       }
       else {
-        def->addInstance("join",mux2,{{"width",aWidth}});
-        def->connect("join.out","self.out");
+        def->addInstance("_join",mux2,{{"width",aWidth}});
+        def->connect("_join.out","self.out");
 
         //Connect half instances
         uint Nbits = num_bits(N-1); // 4 inputs has a max index of 3
@@ -464,11 +464,11 @@ Namespace* CoreIRLoadLibrary_commonlib(Context* c) {
           def->connect({"self","in","data",to_string(i+Nlargehalf)},{"muxN_1","in","data",to_string(i)});
         }
 
-        def->connect("muxN_0.out","join.in0");
-        def->connect("muxN_1.out","join.in1");
+        def->connect("muxN_0.out","_join.in0");
+        def->connect("muxN_1.out","_join.in1");
 
         // wire up selects
-        def->connect({"self","in","sel",to_string(Nbits-1)},{"join","sel"});
+        def->connect({"self","in","sel",to_string(Nbits-1)},{"_join","sel"});
         Values sliceArgs0 = {{"width", Const::make(c,Nbits)},
                              {"lo", Const::make(c,0)},
                              {"hi", Const::make(c,num_bits(Nlargehalf-1))}};
@@ -509,15 +509,15 @@ Namespace* CoreIRLoadLibrary_commonlib(Context* c) {
       def->connect("self.in.0","self.out");
     }
     else if (N == 2) {
-      def->addInstance("join",op2,{{"width",aWidth}});
-      def->connect("join.out","self.out");
+      def->addInstance("_join",op2,{{"width",aWidth}});
+      def->connect("_join.out","self.out");
 
-      def->connect("self.in.0","join.in0");
-      def->connect("self.in.1","join.in1");
+      def->connect("self.in.0","_join.in0");
+      def->connect("self.in.1","_join.in1");
     }
     else {
-      def->addInstance("join",op2,{{"width",aWidth}});
-      def->connect("join.out","self.out");
+      def->addInstance("_join",op2,{{"width",aWidth}});
+      def->connect("_join.out","self.out");
 
       //Connect half instances
       uint Nbits = num_bits(N-1); // 4 inputs has a max index of 3
@@ -536,8 +536,8 @@ Namespace* CoreIRLoadLibrary_commonlib(Context* c) {
       for (uint i=0; i<Nsmallhalf; ++i) {
         def->connect({"self","in",to_string(i+Nlargehalf)},{"opN_1","in",to_string(i)});
       }
-      def->connect("opN_0.out","join.in0");
-      def->connect("opN_1.out","join.in1");
+      def->connect("opN_0.out","_join.in0");
+      def->connect("opN_1.out","_join.in1");
     }
 
   });
@@ -562,15 +562,15 @@ Namespace* CoreIRLoadLibrary_commonlib(Context* c) {
       def->connect("self.in.0","self.out");
     }
     else if (N == 2) {
-      def->addInstance("join",op2);
-      def->connect("join.out","self.out");
+      def->addInstance("_join",op2);
+      def->connect("_join.out","self.out");
 
-      def->connect("self.in.0","join.in0");
-      def->connect("self.in.1","join.in1");
+      def->connect("self.in.0","_join.in0");
+      def->connect("self.in.1","_join.in1");
     }
     else {
-      def->addInstance("join",op2);
-      def->connect("join.out","self.out");
+      def->addInstance("_join",op2);
+      def->connect("_join.out","self.out");
 
       //Connect half instances
       uint Nbits = num_bits(N-1); // 4 inputs has a max index of 3
@@ -589,8 +589,8 @@ Namespace* CoreIRLoadLibrary_commonlib(Context* c) {
       for (uint i=0; i<Nsmallhalf; ++i) {
         def->connect({"self","in",to_string(i+Nlargehalf)},{"opN_1","in",to_string(i)});
       }
-      def->connect("opN_0.out","join.in0");
-      def->connect("opN_1.out","join.in1");
+      def->connect("opN_0.out","_join.in0");
+      def->connect("opN_1.out","_join.in1");
     }
 
   });


### PR DESCRIPTION
Verilator complains when generating verilog with
```
Unsupported: Verilog 1995 reserved word not implemented: join
```
Solution is to prefix the `join` instance name with an underscore (`_`)