### PR TITLE
Add c api methods for metadata

### DIFF
--- a/include/coreir-c/coreir.h
+++ b/include/coreir-c/coreir.h
@@ -19,7 +19,7 @@ void* CORENewMap(COREContext* c, void* keys, void* values, uint len, COREMapKind
 extern COREContext* CORENewContext();
 extern void COREDeleteContext(COREContext*);
 extern COREType* COREContextNamedType(COREContext* context, const char* namespace_, const char* type_name);
-  COREType* COREContextFlip(COREContext* context, COREType* type);
+extern COREType* COREContextFlip(COREContext* context, COREType* type);
 
 extern COREValueType* COREContextBool(COREContext* context);
 extern COREValueType* COREContextInt(COREContext* context);

--- a/include/coreir-c/coreir.h
+++ b/include/coreir-c/coreir.h
@@ -19,6 +19,7 @@ void* CORENewMap(COREContext* c, void* keys, void* values, uint len, COREMapKind
 extern COREContext* CORENewContext();
 extern void COREDeleteContext(COREContext*);
 extern COREType* COREContextNamedType(COREContext* context, const char* namespace_, const char* type_name);
+  COREType* COREContextFlip(COREContext* context, COREType* type);
 
 extern COREValueType* COREContextBool(COREContext* context);
 extern COREValueType* COREContextInt(COREContext* context);
@@ -94,6 +95,7 @@ extern const char** COREWireableGetSelectPath(COREWireable* w, int* num_selects)
 extern void COREPrintErrors(COREContext* c);
 extern const char* CORENamespaceGetName(CORENamespace* n);
 extern COREType* COREWireableGetType(COREWireable* wireable);
+void COREWireableAddMetaDataStr(COREWireable* wireable, char *key, char *value);
 
 // BEGIN : directedview
 extern const char** COREDirectedConnectionGetSrc(COREDirectedConnection* directed_connection);

--- a/src/coreir-c/coreir-c.cpp
+++ b/src/coreir-c/coreir-c.cpp
@@ -63,6 +63,9 @@ extern "C" {
   COREType* COREContextNamed(COREContext* context, const char* namespace_, const char* type_name) {
       return rcast<COREType*>(rcast<Context*>(context)->Named(std::string(namespace_)+"."+std::string(type_name)));
   }
+  COREType* COREContextFlip(COREContext* context, COREType* type) {
+      return rcast<COREType*>(rcast<Context*>(context)->Flip(rcast<Type*>(type)));
+  }
 
   COREValueType* COREContextBool(COREContext* context) {
       return rcast<COREValueType*>(rcast<Context*>(context)->Bool());
@@ -213,7 +216,7 @@ extern "C" {
   const char* COREModuleGetName(COREModule* module) {
     return rcast<Module*>(module)->getName().c_str();
   }
-  
+
   const char* COREGeneratorGetName(COREGenerator* gen) {
       return rcast<Generator*>(gen)->getName().c_str();
   }
@@ -314,6 +317,10 @@ extern "C" {
     }
     return rcast<COREConnection**>(arr);
   }
+
+  // void COREConnectionAddMetaDataStr(COREConnection* connection, char *key, char *value) {
+  //     rcast<Connection*>(connection)->getMetaData()[key] = value;
+  // }
 
   COREWireable* COREConnectionGetFirst(COREConnection* c) {
     return rcast<COREWireable*>(rcast<Connection*>(c)->first);
@@ -556,6 +563,10 @@ extern "C" {
           i++;
       }
       return rcast<COREDirectedConnection**>(ptr_arr);
+  }
+
+  void COREWireableAddMetaDataStr(COREWireable* wireable, char *key, char *value) {
+      rcast<Wireable*>(wireable)->getMetaData()[key] = value;
   }
 
   const char* COREInstanceGetInstname(COREWireable* instance) {


### PR DESCRIPTION
First pass support for passing simple string key, value pairs for metadata. This allows magma to pass the 'filename' and 'lineno' fields to coreir.

Basically
```
rcast<Wireable*>(wireable)->getMetaData()[key] = value;
```

If we can make the `Connections` type (currently a typedef to pair) a `MetaData`, we can also add support for filename/lineno passing for connections.

Actually, could we change `COREWireableAddMetaDataStr` to `COREMetaDataAddMetaDataStr`? (I think this should just work for any class that subclasses from MetaData).