### PR TITLE
Connmeta

### DIFF
--- a/doc/JsonSpec.md
+++ b/doc/JsonSpec.md
@@ -60,7 +60,7 @@ Instance = {
   "modargs"?:Values
 }
 
-Connection = [Wireable, Wireable]
+Connection = [Wireable, Wireable, MetaData?]
 
 //accesses instname.a.b If "instname" is "self" then this is the module's interface.
 //Note: a,b can be digits representing an index. 

--- a/include/coreir/ir/moduledef.h
+++ b/include/coreir/ir/moduledef.h
@@ -27,6 +27,7 @@ class ModuleDef {
     std::map<std::string,Instance*> instances;
     std::set<Connection,ConnectionComp> connections;
 
+    std::map<Connection,MetaData*,ConnectionComp> connMetaData;
     
     // Instances Iterator Internal Fields/API
     Instance* instancesIterFirst = nullptr;
@@ -95,6 +96,13 @@ class ModuleDef {
     
     //This will disconnect everything the wireable is connected to
     void disconnect(Wireable* w);
+
+    //API for adding metadata to Connetions
+    json& getMetaData(Wireable* a, Wireable* b);
+    bool hasMetaData(Wireable* a, Wireable* b);
+
+
+
 
     //API for deleting an instance
     //This will also delete all connections from all connected things

--- a/src/ir/fileReader.cpp
+++ b/src/ir/fileReader.cpp
@@ -289,9 +289,14 @@ bool loadFromFile(Context* c, string filename,Module** top) {
 
       //Connections
       if (jmod.count("connections")) {
-        for (auto jcon : jmod.at("connections").get<vector<vector<string>>>()) {
-          ASSERTTHROW(jcon.size()==2,"Connection invalid");
-          mdef->connect(jcon[0],jcon[1]);
+        for (auto jcon : jmod.at("connections").get<vector<jsonvector>>()) {
+          ASSERTTHROW(jcon.size()==2 || jcon.size()==3,"Connection invalid");
+          Wireable* a = mdef->sel(jcon[0].get<string>());
+          Wireable* b = mdef->sel(jcon[1].get<string>());
+          mdef->connect(a,b);
+          if (jcon.size()==3) {
+            mdef->getMetaData(a,b) = jcon[2];
+          }
         }
       }
       

--- a/src/ir/moduledef.cpp
+++ b/src/ir/moduledef.cpp
@@ -322,13 +322,13 @@ json& ModuleDef::getMetaData(Wireable* a, Wireable* b) {
   Connection conn = connectionCtor(a,b);
   ASSERT(connections.count(conn),"Cannot access metadata to something not connected: " + toString(conn));
   if (connMetaData.count(conn) == 0) {
-    connMetaData.emplace(conn,new MetaData())
+    connMetaData.emplace(conn,new MetaData());
   }
   return connMetaData[conn]->getMetaData();
 
 }
 
-bool hasMetaData(Wireable* a, Wireable* b) {
+bool ModuleDef::hasMetaData(Wireable* a, Wireable* b) {
   Connection conn = connectionCtor(a,b);
   return connMetaData.count(conn) > 0;
 }

--- a/src/ir/moduledef.cpp
+++ b/src/ir/moduledef.cpp
@@ -318,6 +318,21 @@ void ModuleDef::disconnect(Connection fstCon) {
   connections.erase(con);
 }
 
+json& ModuleDef::getMetaData(Wireable* a, Wireable* b) {
+  Connection conn = connectionCtor(a,b);
+  ASSERT(connections.count(conn),"Cannot access metadata to something not connected: " + toString(conn));
+  if (connMetaData.count(conn) == 0) {
+    connMetaData.emplace(conn,new MetaData())
+  }
+  return connMetaData[conn]->getMetaData();
+
+}
+
+bool hasMetaData(Wireable* a, Wireable* b) {
+  Connection conn = connectionCtor(a,b);
+  return connMetaData.count(conn) > 0;
+}
+
 
 void ModuleDef::removeInstance(Instance* inst) {
   removeInstance(inst->getInstname());

--- a/src/passes/analysis/coreirjson.cpp
+++ b/src/passes/analysis/coreirjson.cpp
@@ -213,7 +213,7 @@ string Instances2Json(map<string,Instance*>& insts,int taboffset) {
   return jis.toMultiString();
 }
 
-string Connections2Json(Connections& cons,int taboffset) {
+string Connections2Json(Connections& cons,ModuleDef* def,int taboffset) {
   Array a(taboffset);
   vector<Connection> sortedConns;
   for (auto c : cons) {
@@ -240,7 +240,11 @@ string Connections2Json(Connections& cons,int taboffset) {
       b.add(quote(sb));
       b.add(quote(sa));
     }
+    if (def->hasMetaData(con.first,con.second)) {
+      b.add(toString(def->getMetaData(con.first,con.second)));
+    }
     a.add(b.toString());
+
   }
   return a.toMultiString();
 }
@@ -262,7 +266,7 @@ string Module2Json(Module* m, int taboffset) {
     }
     if (!def->getConnections().empty()) {
       auto cons = def->getConnections();
-      j.add("connections",Connections2Json(cons,taboffset+2));
+      j.add("connections",Connections2Json(cons,def,taboffset+2));
     }
   }
   if (m->hasMetaData()) {


### PR DESCRIPTION
Adds api for adding metadata to connections

Unfortunately it was going to be an immense amount of changes to have a connections class inheret from MetaData, so I have a separate API from ModuleDef to add metadata to connections.

(I am still working on a test here, but I figure this can get you started)