### PR TITLE
CoreIR Changes/Fixes for Integration with CGRA-ME

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ TARGET = dylib
 prefix?=/usr/local
 endif
 
+COREDEBUG = True
 
 COREIRCONFIG ?= g++
 CXX ?= g++
@@ -27,7 +28,7 @@ CFLAGS = -Wall -fPIC
 CXXFLAGS = -std=c++11 -Wall -fPIC -Werror
 
 ifdef COREDEBUG
-CXXFLAGS += -O0 -g3 -D_GLIBCXX_DEBUG
+CXXFLAGS += -O0 -g3
 endif
 
 export CXX

--- a/include/coreir/passes/analysis/vmodule.h
+++ b/include/coreir/passes/analysis/vmodule.h
@@ -82,12 +82,12 @@ class VModule {
     VModule(Module* m) : VModule(m->getName(),m->getType()) {
       if (m->isGenerated()) this->modname = m->getLongName();
       this->addParams(params,m->getModParams());
-      this->addDefaults(paramDefaults,m->getDefaultModArgs());
+      this->addDefaults(&paramDefaults,m->getDefaultModArgs());
       this->checkJson(m->getMetaData());
     }
     VModule(Generator* g) : modname(g->getName()), gen(g) {
       this->addParams(params,g->getGenParams());
-      this->addDefaults(paramDefaults,g->getDefaultGenArgs());
+      this->addDefaults(&paramDefaults,g->getDefaultGenArgs());
       this->checkJson(g->getMetaData());
     }
     void checkJson(json jmeta) {
@@ -140,10 +140,10 @@ class VModule {
         sps.insert(p.first); 
       }
     }
-    void addDefaults(SMap sm, Values ds) { 
+    void addDefaults(SMap* sm, Values ds) {
       for (auto dpair : ds) {
         ASSERT(params.count(dpair.first),modname + " NYI Cannot Add default! " + dpair.first);
-        sm[dpair.first] = toConstString(dpair.second);
+        (*sm)[dpair.first] = toConstString(dpair.second);
       }
     }
     std::string toConstString(Value* v) {

--- a/src/ir/module.cpp
+++ b/src/ir/module.cpp
@@ -22,7 +22,9 @@ Module::Module(Namespace* ns,std::string name, Type* type,Params modparams) : Gl
 Module::Module(Namespace* ns,std::string name, Type* type,Params modparams, Generator* g, Values genargs) : GlobalValue(GVK_Module,ns,name), Args(modparams), modparams(modparams), g(g), genargs(genargs) {
   ASSERT(isa<RecordType>(type), "Module type needs to be a record!\n"+type->toString());
   this->type = cast<RecordType>(type);
-  ASSERT(g && genargs.size(),"Missing genargs!");
+  //ASSERT(g && genargs.size(),"Missing genargs!");
+  ASSERT(g, "Missing generator!");
+  ASSERT(genargs.size() == g->getTypeGen()->getParams().size(), "generator argument size does not match parameter list size!");
   this->longname = name + getContext()->getUnique(); //TODO do a better name
 }
 

--- a/src/ir/moduledef_validate.cpp
+++ b/src/ir/moduledef_validate.cpp
@@ -20,15 +20,41 @@ bool ModuleDef::checkTypes(Wireable* a, Wireable* b) {
   //TODO This might not be valid if:
   //  2 outputs are connected to the same input
 
-  //cout << "Got types" << endl;
-  
   if (ta == c->Flip(tb) ) {
-    //cout << "ta flipped" << endl;
     return false;
   }
 
-  //cout << "Flipped types" << endl;
-  
+
+// Potential fix for Inout Connections
+//  cout << "Finding BitInOut Connection in ModuleDef" << std::endl;
+//  if ((ta->getKind() == ta->TypeKind::TK_BitInOut) | (tb->getKind() == tb->TypeKind::TK_BitInOut)) 
+//  {
+//    cout << "Found BitInOut Connection" << std::endl;
+//    return false;   
+//  }
+//  
+//  if ((ta->getKind() == ta->TypeKind::TK_Array) && (tb->getKind() == ta->TypeKind::TK_Array))
+//  {
+//    if (ta->getLen() == tb->getLen()) // Arrays must be same length
+//    {
+//      if (ta->elemType == c->Flip(tb->elemType)) // Arrays must have flipped elements
+//      {   
+//        cout << "Arrays with same length, flipped elements" << endl;
+//        return false;
+//      }
+//        
+//      if ((ta->elemType->getKind() == ta->TypeKind::TK_BitInOut) && ((tb->elemType->getKind() == tb->TypeKind::TK_BitIn) | (tb->elemType->getKind() == tb->TypeKind::TK_Bit)))
+//      {
+//        cout << "1 BitInOut Array, 1 " << tb->toString() << endl; 
+//        return false;
+//      }
+//      if ((tb->elemType->getKind() == tb->TypeKind::TK_BitInOut) && ((ta->elemType->getKind() == ta->TypeKind::TK_BitIn) | (ta->elemType->getKind() == ta->TypeKind::TK_Bit)))
+//      {
+//        cout << "2 BitInOut Array, 1 " << ta->toString() << endl; 
+//        return false;
+//      }
+//    }
+//  }
   Error e;
   e.message(a->getContainer()->getName() + ": Cannot wire together");
   e.message("  " + a->toString() + " : " + a->getType()->toString());

--- a/src/passes/analysis/verifyinputconnections.cpp
+++ b/src/passes/analysis/verifyinputconnections.cpp
@@ -11,13 +11,15 @@ bool checkTypes(Wireable* a, Wireable* b) {
   Context* c = a->getContext();
   Type* ta = a->getType();
   Type* tb = b->getType();
+
+
   //TODO This might not be valid if:
   //  2 outputs are connected to the same input
   //  an inout is connected to an input (good!)
   //  an inout is connected to an output (bad!)
-  
+
   if (ta == c->Flip(tb) ) return false;
-  
+
   Error e;
   e.message("Cannot wire together");
   e.message("  " + a->toString() + " : " + a->getType()->toString());

--- a/src/passes/transform/removebulkconnections.cpp
+++ b/src/passes/transform/removebulkconnections.cpp
@@ -6,7 +6,7 @@ using namespace CoreIR;
 
 namespace {
 inline bool isBit(Type* t) {
-  return isa<BitType>(t) || isa<BitInType>(t) || isa<NamedType>(t);
+  return isa<BitType>(t) || isa<BitInType>(t) || isa<NamedType>(t) || isa<BitInOutType>(t);
 }
 bool isBitOrArrOfBits(Type* t) {
   if (isBit(t)) return true;


### PR DESCRIPTION
Makes changes to the CoreIR library so that it works with CGRA-ME.

Main changes:
- `RemoveBulkConnections`: Fixed a bug where Inouts were not recognized as bit connections
- `addDefaultGenArgs`: Fixed a bug where the default parameters were not being propagated to the Verilog writer.

To do:
- Enable Verilog generation of Inout connections using CoreIR