### PR TITLE
Use max(clog2(depth), 1) for memory address width calculation

### DIFF
--- a/src/ir/headers/core.hpp
+++ b/src/ir/headers/core.hpp
@@ -1,3 +1,4 @@
+#include <algorithm>  // std::max
 //This file is just included in context.cpp
 
 void core_convert(Context* c, Namespace* core) {
@@ -176,7 +177,7 @@ void core_state(Context* c, Namespace* core) {
   auto memFun = [](Context* c, Values genargs) {
     int width = genargs.at("width")->get<int>();
     int depth = genargs.at("depth")->get<int>();
-    int awidth = ceil(std::log2(depth));
+    int awidth = std::max((int) ceil(std::log2(depth)), 1);
     return c->Record({
       {"clk",c->Named("coreir.clkIn")},
       {"wdata",c->BitIn()->Arr(width)},

--- a/src/ir/headers/memories.hpp
+++ b/src/ir/headers/memories.hpp
@@ -1,3 +1,4 @@
+#include <algorithm>  // std::max
 //This file is just included in context.cpp
 
 bool isPowerOfTwo(const uint n) {
@@ -31,7 +32,7 @@ Namespace* CoreIRLoadHeader_memory(Context* c) {
 
   lbMem->setGeneratorDefFromFun([](Context* c, Values genargs, ModuleDef* def) {
     uint depth = genargs.at("depth")->get<int>();
-    uint addrWidth = (uint) ceil(log2(depth));
+    uint addrWidth = std::max((int) ceil(log2(depth)), 1);
 
     Values awParams({{"width",Const::make(c,addrWidth)}});
     Values aw1Params({{"width",Const::make(c,addrWidth+1)}});
@@ -260,7 +261,7 @@ Namespace* CoreIRLoadHeader_memory(Context* c) {
   memory->newTypeGen("RomType",MemGenParams,[](Context* c, Values genargs) {
     uint width = genargs.at("width")->get<int>();
     uint depth = genargs.at("depth")->get<int>();
-    uint awidth = (uint) ceil(log2(depth));
+    uint awidth = std::max((int) ceil(log2(depth)), 1);
     return c->Record({
       {"clk", c->Named("coreir.clkIn")},
       {"rdata", c->Bit()->Arr(width)},
@@ -275,7 +276,7 @@ Namespace* CoreIRLoadHeader_memory(Context* c) {
   rom->setGeneratorDefFromFun([](Context* c, Values genargs, ModuleDef* def) {
     uint width = genargs.at("width")->get<int>();
     uint depth = genargs.at("depth")->get<int>();
-    uint awidth = (uint) ceil(log2(depth));
+    uint awidth = std::max((int) ceil(log2(depth)), 1);
 
     Values memargs = genargs;
     memargs.insert({"has_init",Const::make(c,true)});


### PR DESCRIPTION
This resolves an issue with the edge case when `depth == 1`. In this case, `clog2(1) == 0` but you do want a width of 1. The proposed resolution is to use `max(clog2(1), 1)`.

Fixes https://github.com/phanrahan/mantle/issues/115