### PR TITLE
Include fwd_declare.h in dynamic_bit_vector.h for uint 

### DIFF
--- a/include/coreir/ir/dynamic_bit_vector.h
+++ b/include/coreir/ir/dynamic_bit_vector.h
@@ -6,6 +6,7 @@
 #include <iostream>
 #include <stdint.h>
 #include <type_traits>
+#include "coreir/ir/fwd_declare.h"
 
 // This is a comment
 


### PR DESCRIPTION
Fixes gcc-4.9 issue on macos