### PR TITLE
Vfix conn

### DIFF
--- a/src/passes/analysis/vmodule.cpp
+++ b/src/passes/analysis/vmodule.cpp
@@ -182,7 +182,8 @@ string VModule::toInstanceString(Instance* inst) {
   string mname;
   map<string,VWire> iports;
   Values args;
-  if (mref->isGenerated()) {
+  bool isVerilogGen = mref->isGenerated() && mref->getGenerator()->getMetaData().count("verilog") > 0;
+  if (isVerilogGen) {
     args = mref->getGenArgs();
     Type2Ports(mref->getGenerator()->getTypeGen()->getType(args),iports);
     mname = modname; 


### PR DESCRIPTION
Issue was related to the fact that "flattentypes" pass does not invalidate the typegen function used to create the generated module. #630 

Fix was to only use the 'typegen' for generated modules with generator verilog definitions.