### PR TITLE
[install] update link for release download

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,6 +1,6 @@
 
 ## Quick Install (Linux Only):
-    wget https://github.com/rdaly525/coreir/releases/download/v0.0.3/coreir.tar.gz
+    wget https://github.com/rdaly525/coreir/releases/download/v0.0.29/coreir.tar.gz
     tar -zxf coreir.tar.gz
     cd release
     sudo make install


### PR DESCRIPTION
Ideally we could have a link for the "latest" version, but for now let's keep this up to date so users don't download an older version.