### PR TITLE
Add "verilator_debug" mode in verilog pass

### DIFF
--- a/include/coreir/passes/analysis/vmodule.h
+++ b/include/coreir/passes/analysis/vmodule.h
@@ -41,6 +41,7 @@ struct VModules {
   map<Module*,VModule*> mod2VMod;
   vector<VModule*> vmods;
   bool _inline = false;
+  bool _verilator_debug = false;
   //Only used for genetaors that have verilog
   map<Generator*,VModule*> gen2VMod;
 
@@ -199,7 +200,13 @@ struct VInstance : VObject {
   }
 
 
-  string VWireDec(VWire w) { return "  wire " + w.dimstr() + " " + w.getName() + ";"; }
+  string VWireDec(VWire w) { 
+    string s = "  wire " + w.dimstr() + " " + w.getName();
+    if (this->vmods->_verilator_debug) {
+      s +=  "/*verilator public*/";
+    }
+    return s + ";";
+  }
   
   virtual void materialize(CoreIRVModule* vmod) override {
     Module* mref = inst->getModuleRef();

--- a/src/passes/analysis/verilog.cpp
+++ b/src/passes/analysis/verilog.cpp
@@ -27,10 +27,14 @@ void Passes::Verilog::initialize(int argc, char** argv) {
   cxxopts::Options options("verilog", "translates coreir graph to verilog and optionally inlines primitives");
   options.add_options()
     ("i,inline","Inline verilog modules if possible")
+    ("vdbg,verilator_debug","Mark IO and intermediate wires as /*verilator_public*/")
   ;
   auto opts = options.parse(argc,argv);
   if (opts.count("i")) {
     this->vmods._inline = true;
+  }
+  if (opts.count("vdbg")) {
+    this->vmods._verilator_debug = true;
   }
 }
 

--- a/src/passes/analysis/vmodule.cpp
+++ b/src/passes/analysis/vmodule.cpp
@@ -148,7 +148,11 @@ string VModule::toString() const {
   else {
     for (auto pmap : ports) {
       auto port = pmap.second;
-      pdecs.push_back(port.dirstr() + " " + port.dimstr() + " " + port.getName());
+      string pdec = port.dirstr() + " " + port.dimstr() + " " + port.getName();
+      if (this->vmods->_verilator_debug) {
+          pdec += "/*verilator public*/";
+      }
+      pdecs.push_back(pdec);
     }
   }
   


### PR DESCRIPTION
Invoke with `--verilator_debug` or `--vdb`.

Inserts the `/*verilator public*/` comment on intermediate signals (`wire`
statements) and IO ports.  This enables nested signals to be peek/poked
by the C++ driver.

Future support will enable selectively setting public signals rather
than having them all be public, which allows verilator to optimize out
(flatten) where possible.