### PR TITLE
Add verilator_debug to binary interface, use valid arg specifier

### DIFF
--- a/src/binary/coreir.cpp
+++ b/src/binary/coreir.cpp
@@ -42,6 +42,7 @@ int main(int argc, char *argv[]) {
     ("t,top","top: <namespace>.<modulename>",cxxopts::value<std::string>())
     ("a,all","run on all namespaces")
     ("z,inline","inlines verilog primitives")
+    ("y,verilator_debug","mark signals with /*veriltor public*/")
     ("s,split","splits output files by name (expects '-o <path>/*.<ext>')")
     ;
   
@@ -186,6 +187,9 @@ int main(int argc, char *argv[]) {
     string vstr = "verilog";
     if (opts.count("z")) {
       vstr += " -i";
+    }
+    if (opts.count("y")) {
+      vstr += " -y";
     }
     modified |= c->runPasses({"rungenerators","removebulkconnections","flattentypes",vstr},namespaces);
     cout << "Running vpasses" << endl;

--- a/src/passes/analysis/verilog.cpp
+++ b/src/passes/analysis/verilog.cpp
@@ -27,13 +27,13 @@ void Passes::Verilog::initialize(int argc, char** argv) {
   cxxopts::Options options("verilog", "translates coreir graph to verilog and optionally inlines primitives");
   options.add_options()
     ("i,inline","Inline verilog modules if possible")
-    ("vdbg,verilator_debug","Mark IO and intermediate wires as /*verilator_public*/")
+    ("y,verilator_debug","Mark IO and intermediate wires as /*verilator_public*/")
   ;
   auto opts = options.parse(argc,argv);
   if (opts.count("i")) {
     this->vmods._inline = true;
   }
-  if (opts.count("vdbg")) {
+  if (opts.count("y")) {
     this->vmods._verilator_debug = true;
   }
 }


### PR DESCRIPTION
This fixes an issue where the verilator_debug option was not exposed via
the binary's interface. Also another bug where the argument specifier
was not valid.