### PR TITLE
Add verilog debug for stateful coreir primitives

### DIFF
--- a/include/coreir/definitions/coreVerilog.hpp
+++ b/include/coreir/definitions/coreVerilog.hpp
@@ -186,8 +186,7 @@ void CoreIRLoadVerilog_coreir(Context* c) {
     "    else outReg <= in;\n"
     "  end\n"
     "  assign out = outReg;";
-    core->getGenerator("reg_arst")->getMetaData()["verilog"] = vjson;
-    vjson["definition"] = ""
+    vjson["debug_definition"] = ""
     "  reg [width-1:0] outReg/*verilator public*/;\n"
     "  wire real_rst;\n"
     "  assign real_rst = arst_posedge ? arst : ~arst;\n"
@@ -198,7 +197,7 @@ void CoreIRLoadVerilog_coreir(Context* c) {
     "    else outReg <= in;\n"
     "  end\n"
     "  assign out = outReg;";
-    core->getGenerator("reg_arst")->getMetaData()["verilog_debug"] = vjson;
+    core->getGenerator("reg_arst")->getMetaData()["verilog"] = vjson;
   }
   {
     //reg
@@ -214,8 +213,7 @@ void CoreIRLoadVerilog_coreir(Context* c) {
     "    outReg <= in;\n"
     "  end\n"
     "  assign out = outReg;";
-    core->getGenerator("reg")->getMetaData()["verilog"] = vjson;
-    vjson["definition"] = ""
+    vjson["debug_definition"] = ""
     "  reg [width-1:0] outReg/*verilator public*/=init;\n"
     "  wire real_clk;\n"
     "  assign real_clk = clk_posedge ? clk : ~clk;\n"
@@ -223,7 +221,7 @@ void CoreIRLoadVerilog_coreir(Context* c) {
     "    outReg <= in;\n"
     "  end\n"
     "  assign out = outReg;";
-    core->getGenerator("reg")->getMetaData()["verilog_debug"] = vjson;
+    core->getGenerator("reg")->getMetaData()["verilog"] = vjson;
   }
 
   {
@@ -239,8 +237,7 @@ void CoreIRLoadVerilog_coreir(Context* c) {
     "    end\n"
     "  end\n"
     "  assign rdata = data[raddr];";
-    core->getGenerator("mem")->getMetaData()["verilog"] = vjson;
-    vjson["definition"] = ""
+    vjson["debug_definition"] = ""
     "  reg [width-1:0] data[depth-1:0] /*verilator public*/;\n"
     "  always @(posedge clk) begin\n"
     "    if (wen) begin\n"
@@ -248,6 +245,6 @@ void CoreIRLoadVerilog_coreir(Context* c) {
     "    end\n"
     "  end\n"
     "  assign rdata = data[raddr];";
-    core->getGenerator("mem")->getMetaData()["verilog_debug"] = vjson;
+    core->getGenerator("mem")->getMetaData()["verilog"] = vjson;
   } 
 }

--- a/include/coreir/definitions/coreVerilog.hpp
+++ b/include/coreir/definitions/coreVerilog.hpp
@@ -187,6 +187,18 @@ void CoreIRLoadVerilog_coreir(Context* c) {
     "  end\n"
     "  assign out = outReg;";
     core->getGenerator("reg_arst")->getMetaData()["verilog"] = vjson;
+    vjson["definition"] = ""
+    "  reg [width-1:0] outReg/*verilator public*/;\n"
+    "  wire real_rst;\n"
+    "  assign real_rst = arst_posedge ? arst : ~arst;\n"
+    "  wire real_clk;\n"
+    "  assign real_clk = clk_posedge ? clk : ~clk;\n"
+    "  always @(posedge real_clk, posedge real_rst) begin\n"
+    "    if (real_rst) outReg <= init;\n"
+    "    else outReg <= in;\n"
+    "  end\n"
+    "  assign out = outReg;";
+    core->getGenerator("reg_arst")->getMetaData()["verilog_debug"] = vjson;
   }
   {
     //reg
@@ -203,6 +215,15 @@ void CoreIRLoadVerilog_coreir(Context* c) {
     "  end\n"
     "  assign out = outReg;";
     core->getGenerator("reg")->getMetaData()["verilog"] = vjson;
+    vjson["definition"] = ""
+    "  reg [width-1:0] outReg/*verilator public*/=init;\n"
+    "  wire real_clk;\n"
+    "  assign real_clk = clk_posedge ? clk : ~clk;\n"
+    "  always @(posedge real_clk) begin\n"
+    "    outReg <= in;\n"
+    "  end\n"
+    "  assign out = outReg;";
+    core->getGenerator("reg")->getMetaData()["verilog_debug"] = vjson;
   }
 
   {
@@ -219,5 +240,14 @@ void CoreIRLoadVerilog_coreir(Context* c) {
     "  end\n"
     "  assign rdata = data[raddr];";
     core->getGenerator("mem")->getMetaData()["verilog"] = vjson;
+    vjson["definition"] = ""
+    "  reg [width-1:0] data[depth-1:0] /*verilator public*/;\n"
+    "  always @(posedge clk) begin\n"
+    "    if (wen) begin\n"
+    "      data[waddr] <= wdata;\n"
+    "    end\n"
+    "  end\n"
+    "  assign rdata = data[raddr];";
+    core->getGenerator("mem")->getMetaData()["verilog_debug"] = vjson;
   } 
 }

--- a/include/coreir/definitions/coreVerilog.hpp
+++ b/include/coreir/definitions/coreVerilog.hpp
@@ -186,7 +186,7 @@ void CoreIRLoadVerilog_coreir(Context* c) {
     "    else outReg <= in;\n"
     "  end\n"
     "  assign out = outReg;";
-    vjson["debug_definition"] = ""
+    vjson["verilator_debug_definition"] = ""
     "  reg [width-1:0] outReg/*verilator public*/;\n"
     "  wire real_rst;\n"
     "  assign real_rst = arst_posedge ? arst : ~arst;\n"
@@ -213,7 +213,7 @@ void CoreIRLoadVerilog_coreir(Context* c) {
     "    outReg <= in;\n"
     "  end\n"
     "  assign out = outReg;";
-    vjson["debug_definition"] = ""
+    vjson["verilator_debug_definition"] = ""
     "  reg [width-1:0] outReg/*verilator public*/=init;\n"
     "  wire real_clk;\n"
     "  assign real_clk = clk_posedge ? clk : ~clk;\n"
@@ -237,7 +237,7 @@ void CoreIRLoadVerilog_coreir(Context* c) {
     "    end\n"
     "  end\n"
     "  assign rdata = data[raddr];";
-    vjson["debug_definition"] = ""
+    vjson["verilator_debug_definition"] = ""
     "  reg [width-1:0] data[depth-1:0] /*verilator public*/;\n"
     "  always @(posedge clk) begin\n"
     "    if (wen) begin\n"

--- a/include/coreir/definitions/corebitVerilog.hpp
+++ b/include/coreir/definitions/corebitVerilog.hpp
@@ -113,6 +113,13 @@ void CoreIRLoadVerilog_corebit(Context* c) {
     "end\n"
     "assign out = outReg;";
     bit->getModule("reg")->getMetaData()["verilog"] = vjson;
+    vjson["definition"] = ""
+    "reg outReg/*verilator public*/ = init;\n"
+    "always @(posedge clk) begin\n"
+    "  outReg <= in;\n"
+    "end\n"
+    "assign out = outReg;";
+    bit->getModule("reg")->getMetaData()["verilog_debug"] = vjson;
   }
   {
     //reg_arst
@@ -132,5 +139,17 @@ void CoreIRLoadVerilog_corebit(Context* c) {
     "end\n"
     "assign out = outReg;";
     bit->getModule("reg_arst")->getMetaData()["verilog"] = vjson;
+    vjson["definition"] = ""
+    "reg outReg/*verilator public*/;\n"
+    "wire real_rst;\n"
+    "assign real_rst = arst_posedge ? arst : ~arst;\n"
+    "wire real_clk;\n"
+    "assign real_clk = clk_posedge ? clk : ~clk;\n"
+    "always @(posedge real_clk, posedge real_rst) begin\n"
+    "  if (real_rst) outReg <= init;\n"
+    "  else outReg <= in;\n"
+    "end\n"
+    "assign out = outReg;";
+    bit->getModule("reg_arst")->getMetaData()["verilog_debug"] = vjson;
   }
 }

--- a/include/coreir/definitions/corebitVerilog.hpp
+++ b/include/coreir/definitions/corebitVerilog.hpp
@@ -112,14 +112,13 @@ void CoreIRLoadVerilog_corebit(Context* c) {
     "  outReg <= in;\n"
     "end\n"
     "assign out = outReg;";
-    bit->getModule("reg")->getMetaData()["verilog"] = vjson;
-    vjson["definition"] = ""
+    vjson["debug_definition"] = ""
     "reg outReg/*verilator public*/ = init;\n"
     "always @(posedge clk) begin\n"
     "  outReg <= in;\n"
     "end\n"
     "assign out = outReg;";
-    bit->getModule("reg")->getMetaData()["verilog_debug"] = vjson;
+    bit->getModule("reg")->getMetaData()["verilog"] = vjson;
   }
   {
     //reg_arst
@@ -138,8 +137,7 @@ void CoreIRLoadVerilog_corebit(Context* c) {
     "  else outReg <= in;\n"
     "end\n"
     "assign out = outReg;";
-    bit->getModule("reg_arst")->getMetaData()["verilog"] = vjson;
-    vjson["definition"] = ""
+    vjson["debug_definition"] = ""
     "reg outReg/*verilator public*/;\n"
     "wire real_rst;\n"
     "assign real_rst = arst_posedge ? arst : ~arst;\n"
@@ -150,6 +148,6 @@ void CoreIRLoadVerilog_corebit(Context* c) {
     "  else outReg <= in;\n"
     "end\n"
     "assign out = outReg;";
-    bit->getModule("reg_arst")->getMetaData()["verilog_debug"] = vjson;
+    bit->getModule("reg_arst")->getMetaData()["verilog"] = vjson;
   }
 }

--- a/include/coreir/definitions/corebitVerilog.hpp
+++ b/include/coreir/definitions/corebitVerilog.hpp
@@ -112,7 +112,7 @@ void CoreIRLoadVerilog_corebit(Context* c) {
     "  outReg <= in;\n"
     "end\n"
     "assign out = outReg;";
-    vjson["debug_definition"] = ""
+    vjson["verilator_debug_definition"] = ""
     "reg outReg/*verilator public*/ = init;\n"
     "always @(posedge clk) begin\n"
     "  outReg <= in;\n"
@@ -137,7 +137,7 @@ void CoreIRLoadVerilog_corebit(Context* c) {
     "  else outReg <= in;\n"
     "end\n"
     "assign out = outReg;";
-    vjson["debug_definition"] = ""
+    vjson["verilator_debug_definition"] = ""
     "reg outReg/*verilator public*/;\n"
     "wire real_rst;\n"
     "assign real_rst = arst_posedge ? arst : ~arst;\n"

--- a/include/coreir/passes/analysis/vmodule.h
+++ b/include/coreir/passes/analysis/vmodule.h
@@ -303,8 +303,8 @@ struct VerilogVModule : VModule {
       this->modname = jver["prefix"].get<std::string>() + name;
     }
     if (jver.count("definition")) {
-      if (this->vmods->_verilator_debug && jver.count("debug_definition") > 0) {
-        stmts.push_back(jver["debug_definition"].get<std::string>());
+      if (this->vmods->_verilator_debug && jver.count("verilator_debug_definition") > 0) {
+        stmts.push_back(jver["verilator_debug_definition"].get<std::string>());
       } else {
         stmts.push_back(jver["definition"].get<std::string>());
       }

--- a/include/coreir/passes/analysis/vmodule.h
+++ b/include/coreir/passes/analysis/vmodule.h
@@ -275,11 +275,7 @@ struct VerilogVModule : VModule {
   VerilogVModule(VModules* vmods) : VModule(vmods) {}
   void addJson(json& jmeta,string name) {
     assert(jmeta.count("verilog") > 0);
-    if (this->vmods->_verilator_debug && jmeta.count("verilog_debug") > 0) {
-        jver = jmeta["verilog_debug"];
-    } else {
-        jver = jmeta["verilog"];
-    }
+    jver = jmeta["verilog"];
     if (jver.count("verilog_string")) {
       this->modname = name;
       this->verilog_string = jver["verilog_string"].get<std::string>();
@@ -307,7 +303,11 @@ struct VerilogVModule : VModule {
       this->modname = jver["prefix"].get<std::string>() + name;
     }
     if (jver.count("definition")) {
-      stmts.push_back(jver["definition"].get<std::string>());
+      if (this->vmods->_verilator_debug && jmeta.count("debug_definition") > 0) {
+        stmts.push_back(jver["debug_definition"].get<std::string>());
+      } else {
+        stmts.push_back(jver["definition"].get<std::string>());
+      }
     }
     if (jver.count("interface")) {
       interface = (jver["interface"].get<std::vector<std::string>>());

--- a/include/coreir/passes/analysis/vmodule.h
+++ b/include/coreir/passes/analysis/vmodule.h
@@ -275,7 +275,11 @@ struct VerilogVModule : VModule {
   VerilogVModule(VModules* vmods) : VModule(vmods) {}
   void addJson(json& jmeta,string name) {
     assert(jmeta.count("verilog") > 0);
-    jver = jmeta["verilog"];
+    if (this->vmods->_verilator_debug && jmeta.count("verilog_debug") > 0) {
+        jver = jmeta["verilog_debug"];
+    } else {
+        jver = jmeta["verilog"];
+    }
     if (jver.count("verilog_string")) {
       this->modname = name;
       this->verilog_string = jver["verilog_string"].get<std::string>();

--- a/include/coreir/passes/analysis/vmodule.h
+++ b/include/coreir/passes/analysis/vmodule.h
@@ -303,7 +303,7 @@ struct VerilogVModule : VModule {
       this->modname = jver["prefix"].get<std::string>() + name;
     }
     if (jver.count("definition")) {
-      if (this->vmods->_verilator_debug && jmeta.count("debug_definition") > 0) {
+      if (this->vmods->_verilator_debug && jver.count("debug_definition") > 0) {
         stmts.push_back(jver["debug_definition"].get<std::string>());
       } else {
         stmts.push_back(jver["definition"].get<std::string>());

--- a/src/passes/analysis/vmodule.cpp
+++ b/src/passes/analysis/vmodule.cpp
@@ -144,6 +144,11 @@ string VModule::toString() const {
   vector<string> pdecs;
   if (interface.size()>0) {
     pdecs = interface;
+    if (this->vmods->_verilator_debug) {
+      for (auto& pdec : pdecs) {
+        pdec += "/*verilator public*/";
+      }
+    }
   }
   else {
     for (auto pmap : ports) {


### PR DESCRIPTION
Adds a `vjson` field `"verilog_debug"` which contains the definition of various coreir primtives including the `/*verilator public*/` annotations. I'm not sure if there's a more elegant way to do this, but it got the job done. The idea is that by default, we don't want these annotations because they force verilator to not inline signals, which can hurt performance.