### PR TITLE
removed the bitwidth prefix for the verilog constant

### DIFF
--- a/include/coreir/definitions/corebitVerilog.hpp
+++ b/include/coreir/definitions/corebitVerilog.hpp
@@ -16,7 +16,7 @@ void CoreIRLoadVerilog_corebit(Context* c) {
     {"other",{
       {"mux","sel ? in1 : in0"},
       {"concat","{in0, in1}"},
-      {"const","1b'value"},
+      {"const","value"},
       {"term",""},
       {"tribuf","en ? in : 1'bz"},
       {"ibuf","in"},


### PR DESCRIPTION
This fixes bad verilog syntax when using bit constants.

This was changed a few months ago, but I do not recall why it was changed originally. I think it had something to do with the verilog inlining logic.

