### PR TITLE
Strfix

### DIFF
--- a/src/ir/module.cpp
+++ b/src/ir/module.cpp
@@ -18,10 +18,11 @@ namespace {
 //This will make it a valid coreir string
 //Specifically for the case that toString on a type produces square brackets
 string sanatizeParamString(string name) {
-  //Strip out the '[' and ']' chars 
   string out = name;
+  //For type
   out.erase(std::remove(out.begin(),out.end(),'['),out.end());
   out.erase(std::remove(out.begin(),out.end(),']'),out.end());
+  out.erase(std::remove(out.begin(),out.end(),'.'),out.end());
   return out;
 }
 }

--- a/src/ir/module.cpp
+++ b/src/ir/module.cpp
@@ -13,12 +13,28 @@
 
 using namespace std;
 
+namespace {
+
+//This will make it a valid coreir string
+//Specifically for the case that toString on a type produces square brackets
+string sanatizeParamString(string name) {
+  //Strip out the '[' and ']' chars 
+  string out = name;
+  out.erase(std::remove(out.begin(),out.end(),'['),out.end());
+  out.erase(std::remove(out.begin(),out.end(),']'),out.end());
+  return out;
+}
+}
+
+
 namespace CoreIR {
 
   Module::Module(Namespace* ns,std::string name, Type* type,Params modparams) : GlobalValue(GVK_Module,ns,name), Args(modparams), modparams(modparams), longname((ns->getName()=="global" ? "" : ns->getName() + "_" )  + name) {
   ASSERT(isa<RecordType>(type), "Module type needs to be a record!\n"+type->toString());
   this->type = cast<RecordType>(type);
 }
+
+
 Module::Module(Namespace* ns,std::string name, Type* type,Params modparams, Generator* g, Values genargs) : GlobalValue(GVK_Module,ns,name), Args(modparams), modparams(modparams), g(g), genargs(genargs) {
   ASSERT(isa<RecordType>(type), "Module type needs to be a record!\n"+type->toString());
   this->type = cast<RecordType>(type);
@@ -30,7 +46,7 @@ Module::Module(Namespace* ns,std::string name, Type* type,Params modparams, Gene
     this->longname = name;
   }
   for (auto genarg : genargs) {
-    this->longname += "__" + genarg.first + genarg.second->toString() ;
+    this->longname += "__" + genarg.first + sanatizeParamString(genarg.second->toString()) ;
   }
 }
 


### PR DESCRIPTION
Fixes a verilog generation bug when using Types and Modules as generator parameters. It used to produce invalid syntax.