### PR TITLE
Connfix

### DIFF
--- a/include/coreir/ir/common.h
+++ b/include/coreir/ir/common.h
@@ -12,7 +12,7 @@ namespace CoreIR {
 //TODO Ugly hack to create a sorted connection. Should make my own connection class
 Connection connectionCtor(Wireable* a, Wireable* b);
 
-typedef std::set<Connection,ConnectionComp> Connections;
+typedef std::set<Connection,ConnectionCompFast> ConnectionsFast;
 
 //These are defined in helpers
 bool isNumber(std::string s);

--- a/include/coreir/ir/context.h
+++ b/include/coreir/ir/context.h
@@ -32,7 +32,7 @@ class Context {
   private :
     
     //Memory management
-    std::unordered_map<void*,Value*> valueList;
+    std::map<void*,Value*> valueList;
     std::vector<Values*> valuesList;
     std::vector<Value**> valuePtrArrays;
     std::vector<ValueType**> valueTypePtrArrays;

--- a/include/coreir/ir/fwd_declare.h
+++ b/include/coreir/ir/fwd_declare.h
@@ -139,16 +139,17 @@ typedef std::pair<Wireable*,Wireable*> Connection;
 typedef std::vector<std::pair<Wireable*,Wireable*>> LocalConnections;
 
 
-//Comparison classes for caches
-class ConnectionComp {
+//Comparison classes
+
+//This will do fast comparisons on Connections, but makes no guarentees on being the same between different runs of the program
+class ConnectionCompFast {
   public:
-    static bool SPComp(const SelectPath& l, const SelectPath& r);
     bool operator() (const Connection& l, const Connection& r) const;
 };
 
-class ConnectionStrComp {
+//This will do slow comparisons on Connections but makes guarentee on being consistent between different runs
+class ConnectionCompConsistent {
   public:
-    static bool SPComp(const SelectPath& l, const SelectPath& r);
     bool operator() (const Connection& l, const Connection& r) const;
 };
 

--- a/include/coreir/ir/fwd_declare.h
+++ b/include/coreir/ir/fwd_declare.h
@@ -6,8 +6,6 @@
 #include <deque>
 #include <map>
 #include <set>
-#include <unordered_map>
-#include <unordered_set>
 #include <memory>
 #include <cassert>
 #include <sstream>

--- a/include/coreir/ir/moduledef.h
+++ b/include/coreir/ir/moduledef.h
@@ -9,25 +9,15 @@
 
 namespace CoreIR {
 
-//struct ConnectionHasher {
-//  size_t operator()(const Connection& rp) const {
-//    size_t hash = 0;
-//    hash_combine(hash,rp.first);
-//    hash_combine(hash,rp.second);
-//    return hash;
-//  }
-//};
-
-
 class ModuleDef {
     friend class Wireable;
   protected:
     Module* module;
     Interface* interface; 
     std::map<std::string,Instance*> instances;
-    std::set<Connection,ConnectionComp> connections;
+    std::set<Connection,ConnectionCompFast> connections;
 
-    std::map<Connection,MetaData*,ConnectionComp> connMetaData;
+    std::map<Connection,MetaData*,ConnectionCompFast> connMetaData;
     
     // Instances Iterator Internal Fields/API
     Instance* instancesIterFirst = nullptr;
@@ -41,7 +31,8 @@ class ModuleDef {
     ModuleDef(Module* m);
     ~ModuleDef();
     const std::map<std::string,Instance*>& getInstances(void) const { return instances;}
-    const std::set<Connection,ConnectionComp>& getConnections(void) const { return connections; }
+    const std::set<Connection,ConnectionCompFast>& getConnections(void) const { return connections; }
+    const std::vector<Connection> getSortedConnections(void) const;
     bool hasInstances(void) { return !instances.empty();}
     void print(void);
     

--- a/include/coreir/ir/moduledef.h
+++ b/include/coreir/ir/moduledef.h
@@ -32,8 +32,8 @@ class ModuleDef {
     // Instances Iterator Internal Fields/API
     Instance* instancesIterFirst = nullptr;
     Instance* instancesIterLast = nullptr;
-    std::unordered_map<Instance*,Instance*> instancesIterNextMap;
-    std::unordered_map<Instance*,Instance*> instancesIterPrevMap;
+    std::map<Instance*,Instance*> instancesIterNextMap;
+    std::map<Instance*,Instance*> instancesIterPrevMap;
     void appendInstanceToIter(Instance* instance);
     void removeInstanceFromIter(Instance* instance);
     

--- a/include/coreir/ir/passmanager.h
+++ b/include/coreir/ir/passmanager.h
@@ -12,7 +12,7 @@ class PassManager {
   std::vector<Namespace*> nss; 
   
   //Data structure for storing passes
-  std::unordered_map<std::string,Pass*> passMap;
+  std::map<std::string,Pass*> passMap;
 
   //Name to isValid
   std::map<std::string,bool> analysisPasses;

--- a/include/coreir/ir/typecache.h
+++ b/include/coreir/ir/typecache.h
@@ -3,6 +3,7 @@
 
 #include "fwd_declare.h"
 
+//TODO need to add a comparison function for RecordParams in order to use map
 #include <unordered_map>
 
 namespace CoreIR {

--- a/include/coreir/ir/typecache.h
+++ b/include/coreir/ir/typecache.h
@@ -3,6 +3,8 @@
 
 #include "fwd_declare.h"
 
+#include <unordered_map>
+
 namespace CoreIR {
 
 struct RecordParamsHasher {
@@ -25,13 +27,13 @@ class TypeCache {
   BitInType* bitI;
   BitType* bitO;
   BitInOutType* bitIO;
-  std::unordered_map<Type*,std::unordered_map<int,ArrayType*>> ArrayCache;
+  std::map<Type*,std::map<int,ArrayType*>> ArrayCache;
   std::unordered_map<RecordParams,RecordType*,RecordParamsHasher> RecordCache;
   
   AnyType* anyType;
   BoolType* boolType;
   IntType* intType;
-  std::unordered_map<int,BitVectorType*> bitVectorCache;
+  std::map<int,BitVectorType*> bitVectorCache;
   StringType* stringType;
   CoreIRType* coreIRType;
   ModuleType* moduleType;

--- a/include/coreir/passes/analysis/vmodule.h
+++ b/include/coreir/passes/analysis/vmodule.h
@@ -167,8 +167,6 @@ struct CoreIRVModule : VModule {
 };
 
 
-
-
 //The following are for CoreIR VModules
 //This represents some chunk of lines of code
 struct VObject {
@@ -181,8 +179,6 @@ struct VObject {
   //fills out the body
   virtual void materialize(CoreIRVModule* vmod) = 0;
 };
-
-
 
 struct VInstance : VObject {
   string wireDecs;

--- a/include/coreir/passes/analysis/vmodule.h
+++ b/include/coreir/passes/analysis/vmodule.h
@@ -149,9 +149,9 @@ struct CoreIRVModule : VModule {
   Module* mod;
   //Backwards maps
   std::map<Instance*,VObject*> inst2VObj;
-  std::map<Connection,VObject*,ConnectionCompConsistent> conn2VObj;
   std::map<string,std::set<VObject*,VObjComp>> sortedVObj;
 
+  void addConnectionsInlined(ModuleDef* def);
   void addConnections(ModuleDef* def);
   void addInstance(Instance* inst);
   std::string inline_instance(ModuleDef* def, std::queue<Connection> &worklist,

--- a/include/coreir/passes/analysis/vmodule.h
+++ b/include/coreir/passes/analysis/vmodule.h
@@ -149,7 +149,7 @@ struct CoreIRVModule : VModule {
   Module* mod;
   //Backwards maps
   std::map<Instance*,VObject*> inst2VObj;
-  std::map<Connection,VObject*,ConnectionComp> conn2VObj;
+  std::map<Connection,VObject*,ConnectionCompConsistent> conn2VObj;
   std::map<string,std::set<VObject*,VObjComp>> sortedVObj;
 
   void addConnections(ModuleDef* def);

--- a/src/ir/common.cpp
+++ b/src/ir/common.cpp
@@ -77,8 +77,6 @@ string toString(Connection con) {
   Wireable* fstCon = order ? con.first : con.second;
   Wireable* sndCon = order ? con.second : con.first;
   return fstCon->toString() + " <=> " + sndCon->toString();
-
-  //return con.first->toString() + " <=> " + con.second->toString();
 }
 
 string toString(RecordParams rp) {

--- a/src/ir/common.cpp
+++ b/src/ir/common.cpp
@@ -18,42 +18,31 @@ bool isPower2(uint n) {
   return (n & (n-1))==0;
 }
 
-bool ConnectionComp::SPComp(const SelectPath& l, const SelectPath& r) {
-  if (l.size() != r.size()) {
-    return l.size() < r.size();
-  }
-  for (uint i=0; i<l.size(); ++i) {
-    if (l[i] != r[i]) return l[i] < r[i];
-  }
-  return false;
+bool SPComp(const SelectPath& l, const SelectPath& r) {
+  string ls = toString(l);
+  string lr = toString(r);
+  return ls < lr;
 }
 
-bool ConnectionComp::operator() (const Connection& l, const Connection& r) const {
+bool ConnectionCompFast::operator() (const Connection& l, const Connection& r) const {
   if (l.first != r.first) {
     return l.first < r.first;
   }
   return l.second < r.second;
 }
 
-bool ConnectionStrComp::SPComp(const SelectPath& l, const SelectPath& r) {
-  string ls = toString(l);
-  string lr = toString(r);
-  return ls < lr;
-}
-bool ConnectionStrComp::operator() (const Connection& l, const Connection& r) const {
+bool ConnectionCompConsistent::operator() (const Connection& l, const Connection& r) const {
   string ls = toString(l);
   string rs = toString(r);
   return ls < rs;
 }
 
+//Creates a connection with no consistency guarentee
 Connection connectionCtor(Wireable* a, Wireable* b) {
-  //if (ConnectionComp::SPComp(a->getSelectPath(),b->getSelectPath())) {
   if (a < b) {
-    //return Connection(a,b);
     return {a, b};
   }
   else {
-    //return Connection(b,a);
     return {b,a};
   }
 }
@@ -82,8 +71,9 @@ string toString(SelectPath path) {
   return join(path.begin(),path.end(),string("."));
 }
 
+//This will always be consistent
 string toString(Connection con) {
-  bool order = ConnectionStrComp::SPComp(con.first->getSelectPath(), con.second->getSelectPath());
+  bool order = SPComp(con.first->getSelectPath(), con.second->getSelectPath());
   Wireable* fstCon = order ? con.first : con.second;
   Wireable* sndCon = order ? con.second : con.first;
   return fstCon->toString() + " <=> " + sndCon->toString();

--- a/src/ir/common.cpp
+++ b/src/ir/common.cpp
@@ -30,7 +30,7 @@ bool ConnectionComp::SPComp(const SelectPath& l, const SelectPath& r) {
 
 bool ConnectionComp::operator() (const Connection& l, const Connection& r) const {
   if (l.first != r.first) {
-    return l.first < r.first
+    return l.first < r.first;
   }
   return l.second < r.second;
 }

--- a/src/ir/common.cpp
+++ b/src/ir/common.cpp
@@ -29,13 +29,10 @@ bool ConnectionComp::SPComp(const SelectPath& l, const SelectPath& r) {
 }
 
 bool ConnectionComp::operator() (const Connection& l, const Connection& r) const {
-  if (l.first < r.first) {
-    return true;
+  if (l.first != r.first) {
+    return l.first < r.first
   }
-  if (l.first == r.first) {
-    return l.second < r.second;
-  }
-  return false;
+  return l.second < r.second;
 }
 
 bool ConnectionStrComp::SPComp(const SelectPath& l, const SelectPath& r) {

--- a/src/ir/fileReader.cpp
+++ b/src/ir/fileReader.cpp
@@ -45,7 +45,7 @@ vector<string> getRef(string s) {
 }
 
 //This will verify that json contains ONLY list of possible things
-void checkJson(json j, unordered_set<string> optsRequired, unordered_set<string> optsOptional=unordered_set<string>()) {
+void checkJson(json j, set<string> optsRequired, set<string> optsOptional=set<string>()) {
   jsonmap jmap = j.get<jsonmap>();
   for (auto req : optsRequired) {
     ASSERTTHROW(jmap.count(req), "Missing " + req + " from\n " + toString(j));
@@ -81,7 +81,7 @@ bool loadFromFile(Context* c, string filename,Module** top) {
     checkJson(j,{"namespaces"},{"top"});
     for (auto jnsmap : j.at("namespaces").get<jsonmap>() ) {
       string nsname = jnsmap.first;
-      checkJson(jnsmap.second,unordered_set<string>(),{"namedtypes","typegens","modules","generators"});
+      checkJson(jnsmap.second,set<string>(),{"namedtypes","typegens","modules","generators"});
       Namespace* ns;
       if (c->hasNamespace(nsname) ) {
         ns = c->getNamespace(nsname);
@@ -255,7 +255,7 @@ bool loadFromFile(Context* c, string filename,Module** top) {
         for (auto jinstmap : jmod.at("instances").get<jsonmap>()) {
           string instname = jinstmap.first;
           json jinst = jinstmap.second;
-          checkJson(jinst,unordered_set<string>(),{"modref","genref","genargs","modargs","metadata",});
+          checkJson(jinst,set<string>(),{"modref","genref","genargs","modargs","metadata",});
           // This function can throw an error
           Instance* inst;
           if (jinst.count("modref")) {

--- a/src/ir/inline.cpp
+++ b/src/ir/inline.cpp
@@ -44,7 +44,7 @@ void connectSameLevel(ModuleDef* def, Wireable* wa, Wireable* wb) {
   auto waSelects = wa->getSelects();
   auto wbSelects = wb->getSelects();
   
-  unordered_set<string> both;
+  set<string> both;
   for (auto waSelmap : waSelects) {
     if (wbSelects.count(waSelmap.first)>0) {
       both.insert(waSelmap.first);
@@ -116,7 +116,7 @@ Instance* addPassthrough(Wireable* w,string instname) {
   //Add actual passthrough instance
   Instance* pt = def->addInstance(instname,c->getGenerator("_.passthrough"),{{"type",Const::make(c,wtype)}});
   
-  unordered_set<Wireable*> completed;
+  set<Wireable*> completed;
   PTTraverse(def,w,pt->sel("out"));
   
   //Connect the passthrough back to w

--- a/src/ir/moduledef.cpp
+++ b/src/ir/moduledef.cpp
@@ -23,6 +23,20 @@ ModuleDef::~ModuleDef() {
   for(auto inst : instances) delete inst.second;
 }
 
+//
+const std::vector<Connection> ModuleDef::getSortedConnections(void) const {
+  vector<Connection> sortedConns;
+  for (auto c : this->connections) {
+    sortedConns.push_back(c);
+  }
+
+  // Ensure that connections are serialized in select string sorted order
+  ConnectionCompConsistent c;
+  std::sort(begin(sortedConns), end(sortedConns), [c](const Connection& l, const Connection& r) {
+    return c(l, r);
+  });
+  return sortedConns;
+}
 
 void ModuleDef::print(void) {
   cout << "  Def:" << endl;

--- a/src/ir/types.cpp
+++ b/src/ir/types.cpp
@@ -139,7 +139,7 @@ void NamedType::print() const {
 
 //Stupid hashing wrapper for enum
 RecordType::RecordType(Context* c, RecordParams _record) : Type(TK_Record,DK_Null,c) {
-  unordered_set<uint> dirs; // Slight hack because it is not easy to hash enums
+  set<uint> dirs; // Slight hack because it is not easy to hash enums
   for(auto field : _record) {
     checkStringSyntax(field.first);
     record.emplace(field.first,field.second);

--- a/src/ir/wireable.cpp
+++ b/src/ir/wireable.cpp
@@ -181,7 +181,7 @@ std::map<SelectPath,Wireable*> Wireable::getAllParents() {
 
 LocalConnections Wireable::getLocalConnections() {
   //For the annoying case where connections connect bact to self
-  Connections uniqueCons;
+  ConnectionsFast uniqueCons;
   LocalConnections cons;
   std::function<void(Wireable*)> traverse;
   traverse = [&cons,&traverse,&uniqueCons](Wireable* curw) ->void {

--- a/src/passes/analysis/coreirjson.cpp
+++ b/src/passes/analysis/coreirjson.cpp
@@ -213,20 +213,10 @@ string Instances2Json(map<string,Instance*>& insts,int taboffset) {
   return jis.toMultiString();
 }
 
-string Connections2Json(Connections& cons,ModuleDef* def,int taboffset) {
+string Connections2Json(ModuleDef* def,int taboffset) {
   Array a(taboffset);
-  vector<Connection> sortedConns;
-  for (auto c : cons) {
-    sortedConns.push_back(c);
-  }
-
-  // Ensure that connections are serialized in select string sorted order
-  ConnectionStrComp c;
-  std::sort(begin(sortedConns), end(sortedConns), [c](const Connection& l, const Connection& r) {
-      return c(l, r);
-    });
-
-  for (auto con : sortedConns) {
+  
+  for (auto con : def->getSortedConnections()) {
     auto pa = con.first->getSelectPath();
     auto pb = con.second->getSelectPath();
     string sa = join(pa.begin(),pa.end(),string("."));
@@ -265,8 +255,7 @@ string Module2Json(Module* m, int taboffset) {
       j.add("instances",Instances2Json(insts, taboffset+2));
     }
     if (!def->getConnections().empty()) {
-      auto cons = def->getConnections();
-      j.add("connections",Connections2Json(cons,def,taboffset+2));
+      j.add("connections",Connections2Json(def,taboffset+2));
     }
   }
   if (m->hasMetaData()) {

--- a/src/passes/analysis/vmodule.cpp
+++ b/src/passes/analysis/vmodule.cpp
@@ -243,7 +243,7 @@ void CoreIRVModule::addConnections(ModuleDef* def) {
         // skip if module def input connected to output
         if (vmods->_inline) {
           if (!(left->getSelectPath()[0] == "self" && right->getSelectPath()[0] == "self")) {
-              if (Instance* right_parent = dynamic_cast<Instance*>(right->getTopParent())) {
+              if (Instance* right_parent = dyn_cast<Instance>(right->getTopParent())) {
                   right_conn_str = CoreIRVModule::inline_instance(def, worklist, right_parent);
               } else {
                   ASSERT(right->getSelectPath()[0] == "self", "Expected reference to self port");

--- a/src/passes/analysis/vmodule.cpp
+++ b/src/passes/analysis/vmodule.cpp
@@ -108,7 +108,7 @@ std::string CoreIRVModule::get_replace_str(std::string input_name, Instance* ins
   // concat syntax
   int count = 0;
 
-  for (auto conn : def->getConnections()) {
+  for (auto conn : def->getSortedConnections()) {
     SelectPath sp_first = conn.first->getSelectPath();
     SelectPath sp_second = conn.second->getSelectPath();
     SelectPath inst_sp = instance->getSelectPath();
@@ -195,7 +195,7 @@ std::string CoreIRVModule::inline_instance(ModuleDef* def, std::queue<Connection
     }
     if (right_conn_str == "") {
         // not inlined, so add it's connections to the worklist
-        for (auto conn : def->getConnections()) {
+        for (auto conn : def->getSortedConnections()) {
             SelectPath sp_first = conn.first->getSelectPath();
             SelectPath sp_second = conn.second->getSelectPath();
             SelectPath inst_sp = right_parent->getSelectPath();
@@ -241,12 +241,14 @@ void CoreIRVModule::addConnections(ModuleDef* def) {
         Wireable* right = left == conn.first ? conn.second : conn.first;
         string right_conn_str = "";
         // skip if module def input connected to output
-        if (!(left->getSelectPath()[0] == "self" && right->getSelectPath()[0] == "self")) {
-            if (Instance* right_parent = dynamic_cast<Instance*>(right->getTopParent())) {
-                right_conn_str = CoreIRVModule::inline_instance(def, worklist, right_parent);
-            } else {
-                ASSERT(right->getSelectPath()[0] == "self", "Expected reference to self port");
-            }
+        if (vmods->_inline) {
+          if (!(left->getSelectPath()[0] == "self" && right->getSelectPath()[0] == "self")) {
+              if (Instance* right_parent = dynamic_cast<Instance*>(right->getTopParent())) {
+                  right_conn_str = CoreIRVModule::inline_instance(def, worklist, right_parent);
+              } else {
+                  ASSERT(right->getSelectPath()[0] == "self", "Expected reference to self port");
+              }
+          }
         }
         if (right_conn_str == "") {
             VWire vright(right);

--- a/src/passes/analysis/vmodule.cpp
+++ b/src/passes/analysis/vmodule.cpp
@@ -50,7 +50,7 @@ static bool is_input_from_self(Wireable* wireable) {
 // Helper function to initialize work list with connections feeding the module
 // def outputs
 static void init_worklist(ModuleDef* def, std::queue<Connection> &worklist) {
-  for (auto conn : def->getConnections()) {
+  for (auto conn : def->getSortedConnections()) {
     if (is_input_from_self(conn.first) || is_input_from_self(conn.second)) {
       worklist.push(conn);
     }

--- a/tests/binary/gold/concat.v
+++ b/tests/binary/gold/concat.v
@@ -47,7 +47,15 @@ module concats (
     .out(s1__out)
   );
 
+  assign cc0__in0[3:0] = s0__out[3:0];
+
+  assign cc0__in1[11:0] = s1__out[11:0];
+
   assign out[15:0] = cc0__out[15:0];
+
+  assign s0__in[15:0] = in[15:0];
+
+  assign s1__in[15:0] = in[15:0];
 
 
 endmodule  // concats

--- a/tests/binary/gold/concat.v
+++ b/tests/binary/gold/concat.v
@@ -47,15 +47,7 @@ module concats (
     .out(s1__out)
   );
 
-  assign cc0__in0[3:0] = s0__out[3:0];
-
-  assign cc0__in1[11:0] = s1__out[11:0];
-
   assign out[15:0] = cc0__out[15:0];
-
-  assign s0__in[15:0] = in[15:0];
-
-  assign s1__in[15:0] = in[15:0];
 
 
 endmodule  // concats

--- a/tests/unit/blackbox_verilog.cpp
+++ b/tests/unit/blackbox_verilog.cpp
@@ -19,7 +19,7 @@ void testBlackboxVerilog() {
     "rungenerators",
     "removebulkconnections",
     "flattentypes",
-    "verilog"
+    "verilog --inline"
   };
   c->runPasses(passes, {});
   auto vpass = static_cast<Passes::Verilog*>(


### PR DESCRIPTION
This does the following:
Changes a few unordered_map/unordered_set to map/set
Rename Connection Comparison classes to be "Fast" or "Consistent".
Created an API to get sorted connections (Which should always be consistent)
Fixed a bug where verilog generation was always trying to inline. (It is possible that verilog inlining is still not deterministic)