### PR TITLE
Disables verilator lint error for primitives that have unused bits

### DIFF
--- a/include/coreir/definitions/coreVerilog.hpp
+++ b/include/coreir/definitions/coreVerilog.hpp
@@ -83,7 +83,7 @@ void CoreIRLoadVerilog_coreir(Context* c) {
       "output [width-1:0] out"
     }},
     {"slice",{
-      "input [width-1:0] in",
+      "/*verilator lint_off UNUSED */input [width-1:0] in/*verilator lint_on UNUSED */",
       "output [hi-lo-1:0] out"
     }},
     {"concat",{
@@ -108,7 +108,7 @@ void CoreIRLoadVerilog_coreir(Context* c) {
       "output out"
     }},
     {"const",{"output [width-1:0] out"}},
-    {"term",{"input [width-1:0] in"}},
+    {"term",{"/*verilator lint_off UNUSED */input [width-1:0] in/*verilator lint_on UNUSED */"}},
     {"tribuf",{
       "input [width-1:0] in",
       "input en",

--- a/include/coreir/definitions/corebitVerilog.hpp
+++ b/include/coreir/definitions/corebitVerilog.hpp
@@ -46,7 +46,7 @@ void CoreIRLoadVerilog_corebit(Context* c) {
       "output [1:0] out"
     }},
     {"const",{"output out"}},
-    {"term",{"input in"}},
+    {"term",{"/*verilator lint_off UNUSED */input in/*verilator lint_on UNUSED */"}},
     {"tribuf",{
       "input in",
       "input en",

--- a/tests/binary/gold/concat.v
+++ b/tests/binary/gold/concat.v
@@ -1,5 +1,5 @@
 module coreir_slice #(parameter hi=1, parameter lo=0, parameter width=1) (
-  input [width-1:0] in,
+  /*verilator lint_off UNUSED */input [width-1:0] in/*verilator lint_on UNUSED */,
   output [hi-lo-1:0] out
 );
   assign out = in[hi-1:lo];


### PR DESCRIPTION
The default generated coreir primitives will cause verilator to error out with `WARNING-UNUSED`.

Example
```
%Warning-UNUSED: RegFile.v:2: Signal is not used: in
%Warning-UNUSED: Use "/* verilator lint_off UNUSED */" and lint_on around source to disable this message.
%Warning-UNUSED: RegFile.v:58: Signal is not used: in
%Warning-UNUSED: RegFile.v:9: Bits of signal are not used: in[1]
%Error: Exiting due to 3 warning(s)
```

The main issue are that for coreir `term`, the input `in` is unused, and for coreir `slice` some bits of the input are unused.

Rather than resort to `-Wno-fatal`, which might cause other warnings to slip by, this change adds the required comments to disable lint warnings related to just these primitives.

This was the simplest workaround for the issue, some improvements might be:
* Put the comment around the primitive module instead of inline in the argument. This requires special casing the logic for generating the verilog module definitions (need to look for these special primitives and insert the lint comment). Another option is to add a metadata field to the primitives that should include this directive (e.g. `"verilator_lint_off_unused"`). This is really a minor issue, but might make
the generated code slightly more readable.
* Add a mode to enable this (e.g. a flag `--verilator-lint-off-unused`). This would clean up the verilog in the case that verilator isn't being used. The comments shouldn't affect any functionality, but might be confusing to look at if it's always generated by default. Again a minor issue, but might be nice for QoL of the user