### PR TITLE
Skip writing verilator_public for External Module

### DIFF
--- a/src/passes/analysis/vmodule.cpp
+++ b/src/passes/analysis/vmodule.cpp
@@ -144,7 +144,7 @@ string VModule::toString() const {
   vector<string> pdecs;
   if (interface.size()>0) {
     pdecs = interface;
-    if (this->vmods->_verilator_debug) {
+    if (!this->isExternal && this->vmods->_verilator_debug) {
       for (auto& pdec : pdecs) {
         pdec += "/*verilator public*/";
       }
@@ -154,7 +154,7 @@ string VModule::toString() const {
     for (auto pmap : ports) {
       auto port = pmap.second;
       string pdec = port.dirstr() + " " + port.dimstr() + " " + port.getName();
-      if (this->vmods->_verilator_debug) {
+      if (!this->isExternal && this->vmods->_verilator_debug) {
           pdec += "/*verilator public*/";
       }
       pdecs.push_back(pdec);


### PR DESCRIPTION
Yosys can't compile generated Verilog with verilator_debug due to syntax error,

    build/top.v:3: ERROR: syntax error, unexpected ','

because of nested C-style comments for External Modules.

    /* External Modules
    module SB_RAM40_4K (
      input [15:0] MASK/*verilator public*/,