### PR TITLE
Make mem module Yosys friendly

### DIFF
--- a/include/coreir/definitions/coreVerilog.hpp
+++ b/include/coreir/definitions/coreVerilog.hpp
@@ -134,7 +134,7 @@ void CoreIRLoadVerilog_coreir(Context* c) {
       "input [width-1:0] wdata",
       "input [$clog2(depth)-1:0] waddr",
       "input wen",
-      "output [width-1:0] rdata",
+      "output reg [width-1:0] rdata",
       "input [$clog2(depth)-1:0] raddr"
     }}
   });
@@ -235,16 +235,16 @@ void CoreIRLoadVerilog_coreir(Context* c) {
     "    if (wen) begin\n"
     "      data[waddr] <= wdata;\n"
     "    end\n"
-    "  end\n"
-    "  assign rdata = data[raddr];";
+    "    rdata <= data[raddr];\n"
+    "  end";
     vjson["verilator_debug_definition"] = ""
     "  reg [width-1:0] data[depth-1:0] /*verilator public*/;\n"
     "  always @(posedge clk) begin\n"
     "    if (wen) begin\n"
     "      data[waddr] <= wdata;\n"
     "    end\n"
-    "  end\n"
-    "  assign rdata = data[raddr];";
+    "    rdata <= data[raddr];\n"
+    "  end";
     core->getGenerator("mem")->getMetaData()["verilog"] = vjson;
   } 
 }


### PR DESCRIPTION
Yosys doesn't infer ice40 BRAM (SB_RAM40_4K) with the current generated mem module.

This PR adapts the mem module for the expected Verilog code.
https://www.reddit.com/r/yosys/comments/5aqzyr/can_i_write_behavioral_verilog_that_infers_ice40/d9imje6

Tested with Yosys c258b99040c8414952a3aceae874dc47563540dc.

    import magma
    import mantle
    import os

    mem = mantle.DefineMemory(height=256, width=16)
    magma.compile('build/test', mem, output='coreir-verilog')

    os.system('yosys -q -p "synth_ice40 -top RAM256x16 -blif build/test.blif" build/test.v')

    if os.system('grep -q SB_RAM40_4K build/test.blif') == 0:
      print("Yosys inferred SB_RAM40_4K")

Diff from generated Verilogs

    --- build/test.v
    +++ build/test_adapted.v
    @@ -3,7 +3,7 @@
       input [width-1:0] wdata,
       input [$clog2(depth)-1:0] waddr,
       input wen,
    -  output [width-1:0] rdata,
    +  output reg [width-1:0] rdata,
       input [$clog2(depth)-1:0] raddr
     );
       reg [width-1:0] data[depth-1:0];
    @@ -11,8 +11,8 @@
         if (wen) begin
           data[waddr] <= wdata;
         end
    +    rdata <= data[raddr];
       end
    -  assign rdata = data[raddr];

     endmodule  // coreir_mem