### PR TITLE
Support SB_PLL40_CORE

### DIFF
--- a/include/coreir/passes/analysis/vmodule.h
+++ b/include/coreir/passes/analysis/vmodule.h
@@ -29,8 +29,10 @@ std::string toConstString(Value* v) {
     //return std::to_string(bv.bitLength()) + "'b" + bv.binary_string();
     return bv.hex_string();
   }
+  else if (auto sv = dyn_cast<ConstString>(v)) {
+    return std::string("\"") + sv->toString() + std::string("\"");
+  }
 
-  //TODO could add string
   assert(0);
 }
 }

--- a/src/libs/ice40.cpp
+++ b/src/libs/ice40.cpp
@@ -53,6 +53,19 @@ Namespace* CoreIRLoadLibrary_ice40(Context* c) {
     }
     ice40->newModuleDecl("SB_RAM40_4K", SB_RAM40_4KType, SB_RAM40_4KParams);
 
+    Type* SB_PLL40_COREType = c->Record({{"BYPASS",       c->BitIn()},
+                                         {"PLLOUTCORE",   c->Bit()},
+                                         {"PLLOUTGLOBAL", c->Named("coreir.clk")},
+                                         {"REFERENCECLK", c->Named("coreir.clkIn")},
+                                         {"RESETB",       c->BitIn()}});
+    Params SB_PLL40_COREParams({{"DIVF",          c->BitVector(7)},
+                                {"DIVQ",          c->BitVector(3)},
+                                {"DIVR",          c->BitVector(4)},
+                                {"FEEDBACK_PATH", c->String()},
+                                {"FILTER_RANGE",  c->BitVector(3)},
+                                {"PLLOUT_SELECT", c->String()}});
+    ice40->newModuleDecl("SB_PLL40_CORE", SB_PLL40_COREType, SB_PLL40_COREParams);
+
     return ice40;
 }
 


### PR DESCRIPTION
Some of the parameters of SB_PLL40_CORE are string, and it should be double-quated like

    SB_PLL40_CORE #(.DIVF(7'h26),.DIVQ(3'h4),.DIVR(4'h0),.FEEDBACK_PATH("SIMPLE"),.FILTER_RANGE(3'h1),.PLLOUT_SELECT("GENCLK")) SB_PLL40_CORE_inst0(