### PR TITLE
Link lcoreirsim for coreirsim-c.so

### DIFF
--- a/src/coreir-c/Makefile
+++ b/src/coreir-c/Makefile
@@ -30,7 +30,7 @@ build/coreir-c.dylib: $(COBJS)
 	cp $@ $(HOME)/lib/libcoreir-c.dylib
 
 build/coreirsim-c.so: $(CSIMOBJS)
-	$(CXX) -shared $(LPATH) -o $@ $^ -lcoreir
+	$(CXX) -shared $(LPATH) -o $@ $^ -lcoreirsim
 	cp $@ $(HOME)/lib/libcoreirsim-c.so
 
 build/coreirsim-c.dylib: $(CSIMOBJS)


### PR DESCRIPTION
Updates the `build/coreirsim-c.so` rule to link the simulator library (`lcoreirsim`) instead of `lcoreir`. This is what the `.dylib` rule does, so I suspect this got missed when the rules were copy/pasted/updated for the simulator. This was caught by the pycoreir travis https://travis-ci.org/leonardt/pycoreir/builds/501631381