### PR TITLE
Update release makefile to properly install libcoreirsim

### DIFF
--- a/release/Makefile
+++ b/release/Makefile
@@ -11,8 +11,7 @@ endif
 .PHONY: install
 install:
 	install bin/coreir $(prefix)/bin
-	install lib/libcoreir.$(TARGET) $(prefix)/lib
-	install lib/libcoreir-* $(prefix)/lib
+	install lib/libcoreir* $(prefix)/lib
 	install -d $(prefix)/include/coreir-c
 	install -d $(prefix)/include/coreir/ir/casting
 	install -d $(prefix)/include/coreir/libs


### PR DESCRIPTION
`install lib/libcoreir-*` misses the simulator libraries because they're named `lib/libcoreirsim*`. This updates the release Makefile to match the top level makefile (https://github.com/rdaly525/coreir/blob/master/Makefile#L58)