### PR TITLE
Add options to statically build libcoreir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8)
 
 project(coreir)
+option(STATIC "Statically link everything" OFF)
+
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     # require at least gcc 4.8
@@ -11,7 +13,11 @@ else()
     message(WARNING "You are using an untested compiler")
 endif()
 
-set(CMAKE_CXX_FLAGS "-std=c++11 -Wall -fPIC -Werror")
+if (STATIC)
+    set(STATIC_FLAGS "-static-libgcc -static-libstdc++")
+endif()
+
+set(CMAKE_CXX_FLAGS "-std=c++11 -Wall -fPIC -Werror ${STATIC_FLAGS}")
 
 set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin)
 set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR}/lib)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,7 +9,12 @@ file(GLOB SRC_FILES
 set(CMAKE_MACOSX_RPATH 1)
 set(CMAKE_INSTALL_RPATH "${LIBRARY_OUTPUT_PATH}")
 
-add_library(coreir SHARED ${SRC_FILES})
+if (STATIC)
+    add_library(coreir STATIC ${SRC_FILES})
+else()
+    add_library(coreir SHARED ${SRC_FILES})
+endif()
+
 target_include_directories(coreir PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 target_link_libraries(coreir dl)
 


### PR DESCRIPTION
Add an option to build shared libraries that statically linked against `libcoreir`. It's off by default. See https://github.com/leonardt/pycoreir/pull/82.