### PR TITLE
Use CMAKE_STATIC_LINKER_FLAGS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,10 +14,11 @@ else()
 endif()
 
 if (STATIC)
-    set(STATIC_FLAGS "-static-libgcc -static-libstdc++")
+    set(CMAKE_STATIC_LINKER_FLAGS "-static-libgcc -static-libstdc++")
 endif()
 
 set(CMAKE_CXX_FLAGS "-std=c++11 -Wall -fPIC -Werror ${STATIC_FLAGS}")
+
 
 set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin)
 set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR}/lib)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,8 +17,7 @@ if (STATIC)
     set(CMAKE_STATIC_LINKER_FLAGS "-static-libgcc -static-libstdc++")
 endif()
 
-set(CMAKE_CXX_FLAGS "-std=c++11 -Wall -fPIC -Werror ${STATIC_FLAGS}")
-
+set(CMAKE_CXX_FLAGS "-std=c++11 -Wall -fPIC -Werror")
 
 set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin)
 set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR}/lib)


### PR DESCRIPTION
Right now compiling the static build on MacOS with apple clang fails with:
```
    clang: error: argument unused during compilation: '-static-libgcc' [-Werror,-Wunused-comm
and-line-argument]
    clang: error: argument unused during compilation: '-static-libstdc++' [-Werror,-Wunused-c
ommand-line-argument]
    clang: error: argument unused during compilation: '-static-libgcc' [-Werror,-Wunused-comm
and-line-argument]
    clang: error: argument unused during compilation: '-static-libstdc++' [-Werror,-Wunused-c
```

It seems to be an issue with the fact that the static linking flags are set as part of `CMAKE_CXX_FLAGS` which are passed to the compile command. Clang ignores this flag during compilation (it's a link time flag) which leads to an error. The solution provided here is to set `CMAKE_STATIC_LINKER_FLAGS`, which will be passed to the link command, rather than using cxx flags.