### PR TITLE
Wrapped verilog fix

### DIFF
--- a/src/passes/analysis/vmodule.cpp
+++ b/src/passes/analysis/vmodule.cpp
@@ -314,13 +314,8 @@ void VModules::addModule(Module* m) {
     genHasVerilog = g->getMetaData().count("verilog") > 0;
   }
   bool modHasVerilog = m->getMetaData().count("verilog") > 0;
-  //Linking concerns:
-  //coreir Def and Verilog Def
-  //TODO should probably let the verilog def override the coreir def
-  if (hasDef) {
-    ASSERT(!genHasVerilog && !modHasVerilog,"NYI, Verilog def with coreir def");
-  }
-  //Two Verilog defs, should be an error
+  // Linking concerns:
+  //   Two Verilog defs, should be an error.
   ASSERT(!(modHasVerilog && genHasVerilog),"Linking issue!");
 
   bool isExtern = !hasDef && !genHasVerilog && !modHasVerilog;


### PR DESCRIPTION
This change in magma (https://github.com/phanrahan/magma/pull/367) makes verilog wrapping more robust by capturing the entire scope of a verilog file (including instanced verilog modules). That is, if a module written in verilog instances another module written in verilog, that dependency gets captured and passed through magma -> CoreIR.

This change in CoreIR supports that by (a) foregoing the verify connectivity pass for verilog modules, and (b) allowing there to be both Verilog and CoreIR definitions in a module (in which case we override CoreIR w/ verilog).