### PR TITLE
Fixes bug in verilog logic for handling self

### DIFF
--- a/src/passes/analysis/verilog.cpp
+++ b/src/passes/analysis/verilog.cpp
@@ -308,16 +308,16 @@ build_connection_map(std::set<Connection, ConnectionCompFast> connections,
 std::string convert_to_verilog_connection(Wireable *value) {
   SelectPath select_path = value->getSelectPath();
   if (select_path.front() == "self") {
-      select_path.pop_front();
+    select_path.pop_front();
   }
   std::string connection_name = "";
   for (auto item : select_path) {
-      if (isNumber(item)) {
-          item = "[" + item + "]";
-      } else if (connection_name != "") {
-          connection_name += "_";
-      }
-      connection_name += item;
+    if (isNumber(item)) {
+      item = "[" + item + "]";
+    } else if (connection_name != "") {
+      connection_name += "_";
+    }
+    connection_name += item;
   }
   return connection_name;
 }
@@ -340,7 +340,8 @@ void assign_module_outputs(
       std::vector<std::unique_ptr<vAST::Expression>> args;
       args.resize(entries.size());
       for (auto entry : entries) {
-        std::string connection_name = convert_to_verilog_connection(entry.source);
+        std::string connection_name =
+            convert_to_verilog_connection(entry.source);
         args[entry.index] =
             (std::make_unique<vAST::Identifier>(connection_name));
       }
@@ -407,7 +408,8 @@ compile_module_body(RecordType *module_type,
         std::vector<std::unique_ptr<vAST::Expression>> args;
         args.resize(entries.size());
         for (auto entry : entries) {
-          std::string connection_name = convert_to_verilog_connection(entry.source);
+          std::string connection_name =
+              convert_to_verilog_connection(entry.source);
           args[entry.index] =
               std::make_unique<vAST::Identifier>(connection_name);
         }

--- a/src/passes/analysis/verilog.cpp
+++ b/src/passes/analysis/verilog.cpp
@@ -304,11 +304,21 @@ build_connection_map(std::set<Connection, ConnectionCompFast> connections,
   return connection_map;
 }
 
-// Remove `self.` prefix from select strings, replace "." with "_"
-std::string convert_to_verilog_connection(std::string connection_name) {
-  connection_name =
-      std::regex_replace(connection_name, std::regex("self."), "");
-  std::replace(connection_name.begin(), connection_name.end(), '.', '_');
+// Join select path fields by "_" (ignoring intial self if present)
+std::string convert_to_verilog_connection(Wireable *value) {
+  SelectPath select_path = value->getSelectPath();
+  if (select_path.front() == "self") {
+      select_path.pop_front();
+  }
+  std::string connection_name = "";
+  for (auto item : select_path) {
+      if (isNumber(item)) {
+          item = "[" + item + "]";
+      } else if (connection_name != "") {
+          connection_name += "_";
+      }
+      connection_name += item;
+  }
   return connection_name;
 }
 
@@ -330,10 +340,7 @@ void assign_module_outputs(
       std::vector<std::unique_ptr<vAST::Expression>> args;
       args.resize(entries.size());
       for (auto entry : entries) {
-        std::string connection_name = entry.source->toString();
-        connection_name =
-            std::regex_replace(connection_name, std::regex("self."), "");
-        std::replace(connection_name.begin(), connection_name.end(), '.', '_');
+        std::string connection_name = convert_to_verilog_connection(entry.source);
         args[entry.index] =
             (std::make_unique<vAST::Identifier>(connection_name));
       }
@@ -343,8 +350,8 @@ void assign_module_outputs(
           std::make_unique<vAST::Identifier>(port.first), std::move(concat)));
     } else {
       // Regular (possibly bulk) connection
-      std::string connection_name = entries[0].source->toString();
-      connection_name = convert_to_verilog_connection(connection_name);
+      std::string connection_name =
+          convert_to_verilog_connection(entries[0].source);
       body.push_back(std::make_unique<vAST::ContinuousAssign>(
           std::make_unique<vAST::Identifier>(port.first),
           std::make_unique<vAST::Identifier>(connection_name)));
@@ -400,11 +407,7 @@ compile_module_body(RecordType *module_type,
         std::vector<std::unique_ptr<vAST::Expression>> args;
         args.resize(entries.size());
         for (auto entry : entries) {
-          std::string connection_name = entry.source->toString();
-          connection_name =
-              std::regex_replace(connection_name, std::regex("self."), "");
-          std::replace(connection_name.begin(), connection_name.end(), '.',
-                       '_');
+          std::string connection_name = convert_to_verilog_connection(entry.source);
           args[entry.index] =
               std::make_unique<vAST::Identifier>(connection_name);
         }
@@ -414,8 +417,8 @@ compile_module_body(RecordType *module_type,
             std::make_pair(port.first, std::move(concat)));
         // Otherwise we just use the entry in the connection map
       } else {
-        std::string connection_name = entries[0].source->toString();
-        connection_name = convert_to_verilog_connection(connection_name);
+        std::string connection_name =
+            convert_to_verilog_connection(entries[0].source);
         verilog_connections.insert(std::make_pair(
             port.first, std::make_unique<vAST::Identifier>(connection_name)));
       }

--- a/tests/gtest/array_select.json
+++ b/tests/gtest/array_select.json
@@ -15,7 +15,7 @@
       },
       "top":{
         "type":["Record",[
-          ["I",["Array",4,"BitIn"]],
+          ["self_I",["Array",4,"BitIn"]],
           ["O",["Array",4,"Bit"]]
         ]],
         "instances":{
@@ -27,18 +27,18 @@
           }
         },
         "connections":[
-          ["self.I.0","inst0.I.0"],
-          ["self.I.0","inst0.I.1"],
-          ["self.I.1","inst0.I.2"],
-          ["self.I.2","inst0.I.3"],
+          ["self.self_I.0","inst0.I.0"],
+          ["self.self_I.0","inst0.I.1"],
+          ["self.self_I.1","inst0.I.2"],
+          ["self.self_I.2","inst0.I.3"],
           ["inst0.O.0","inst1.I.0"],
           ["inst0.O.1","inst1.I.1"],
           ["inst0.O.1","inst1.I.2"],
-          ["self.I.1","inst1.I.3"],
+          ["self.self_I.1","inst1.I.3"],
           ["inst1.O.0","self.O.0"],
           ["inst1.O.0","self.O.1"],
-          ["self.I.0","self.O.2"],
-          ["self.I.1","self.O.3"]
+          ["self.self_I.0","self.O.2"],
+          ["self.self_I.1","self.O.3"]
         ]
       }
     }

--- a/tests/gtest/array_select_golden.v
+++ b/tests/gtest/array_select_golden.v
@@ -2,11 +2,11 @@
 module foo (input [3:0] I, output [3:0] O);
     assign O = I;
 endmodule
-module top (input [3:0] I, output [3:0] O);
+module top (output [3:0] O, input [3:0] self_I);
 wire [3:0] inst0_O;
 wire [3:0] inst1_O;
-foo inst0(.I({I[0],I[0],I[1],I[2]}), .O(inst0_O));
-foo inst1(.I({inst0_O[0],inst0_O[1],inst0_O[1],I[1]}), .O(inst1_O));
-assign O = {inst1_O[0],inst1_O[0],I[0],I[1]};
+foo inst0(.I({self_I[0],self_I[0],self_I[1],self_I[2]}), .O(inst0_O));
+foo inst1(.I({inst0_O[0],inst0_O[1],inst0_O[1],self_I[1]}), .O(inst1_O));
+assign O = {inst1_O[0],inst1_O[0],self_I[0],self_I[1]};
 endmodule
 


### PR DESCRIPTION
The existing code strips all references to `self` in names, however this
is bad in the case that `self` is actualy part of the name (e.g. a port
named `self_I`).  This updates the logic to only remove `self` when it
is the first element of a select path, rather than search/replacing the
entire select string.