### PR TITLE
Fix concat ordering

### DIFF
--- a/include/coreir/passes/analysis/verilog.h
+++ b/include/coreir/passes/analysis/verilog.h
@@ -1,10 +1,10 @@
 #ifndef COREIR_VERILOG_HPP_
 #define COREIR_VERILOG_HPP_
 
-#include <memory>
-#include <ostream>
 #include "coreir.h"
 #include "verilogAST.hpp"
+#include <memory>
+#include <ostream>
 
 namespace vAST = verilogAST;
 
@@ -12,44 +12,49 @@ namespace CoreIR {
 namespace Passes {
 
 class Verilog : public InstanceGraphPass {
-    bool _inline = false;
-    bool verilator_debug = true;
+  bool _inline = false;
+  bool verilator_debug = false;
 
-    // We store a vector of module name, module AST node pairs to support
-    // serializing to a single or multiple files
-    std::vector<std::pair<std::string, std::unique_ptr<vAST::AbstractModule>>>
-        modules;
+  // We store a vector of module name, module AST node pairs to support
+  // serializing to a single or multiple files
+  std::vector<std::pair<std::string, std::unique_ptr<vAST::AbstractModule>>>
+      modules;
 
-    // Externally defined modules (no moduleDef), for now we just emit comments
-    // listing them when compiling to a single file
-    std::vector<Module*> extern_modules;
+  // Externally defined modules (no moduleDef), for now we just emit comments
+  // listing them when compiling to a single file
+  std::vector<Module *> extern_modules;
 
-    // Set used to track generators that are compiled as parametrized verilog
-    // modules. These parametrized modules have been instanced to create coreir
-    // modules, but we only need to compile the verilog definition once
-    std::set<Generator*> verilog_generators_seen;
+  // Set used to track generators that are compiled as parametrized verilog
+  // modules. These parametrized modules have been instanced to create coreir
+  // modules, but we only need to compile the verilog definition once
+  std::set<Generator *> verilog_generators_seen;
 
-    void compileModule(Module* module);
+  void compileModule(Module *module);
 
-   public:
-    static std::string ID;
-    Verilog() : InstanceGraphPass(ID, "Compiles IR to Verilog files", true) {}
-    ~Verilog(){};
-    bool runOnInstanceGraphNode(InstanceGraphNode& node) override;
-    void initialize(int argc, char** argv) override;
-    void setAnalysisInfo() override {
-        onlyTop = true;
-        addDependency(
-            "verifyconnectivity --onlyinputs");  // Should change back to check
-                                                 // all connections
-        addDependency("verifyflattenedtypes");
-    }
+    std::vector<std::unique_ptr<vAST::AbstractPort>>
+    compilePorts(RecordType *record_type);
 
-    void writeToStream(std::ostream& os);
-    void writeToFiles(const std::string& dir,
-                      std::unique_ptr<std::string> product_file);
+  std::unique_ptr<vAST::AbstractModule>
+  compileStringBodyModule(json verilog_json, std::string name, Module *module);
+
+public:
+  static std::string ID;
+  Verilog() : InstanceGraphPass(ID, "Compiles IR to Verilog files", true) {}
+  ~Verilog(){};
+  bool runOnInstanceGraphNode(InstanceGraphNode &node) override;
+  void initialize(int argc, char **argv) override;
+  void setAnalysisInfo() override {
+    onlyTop = true;
+    addDependency("verifyconnectivity --onlyinputs"); // Should change back to
+                                                      // check all connections
+    addDependency("verifyflattenedtypes");
+  }
+
+  void writeToStream(std::ostream &os);
+  void writeToFiles(const std::string &dir,
+                    std::unique_ptr<std::string> product_file);
 };
 
-}  // namespace Passes
-}  // namespace CoreIR
+} // namespace Passes
+} // namespace CoreIR
 #endif

--- a/src/passes/analysis/verilog.cpp
+++ b/src/passes/analysis/verilog.cpp
@@ -343,6 +343,7 @@ void assign_module_outputs(
         args[entry.index] =
             (std::make_unique<vAST::Identifier>(connection_name));
       }
+      std::reverse(args.begin(), args.end());
       std::unique_ptr<vAST::Concat> concat =
           std::make_unique<vAST::Concat>(std::move(args));
       body.push_back(std::make_unique<vAST::ContinuousAssign>(
@@ -431,6 +432,7 @@ compile_module_body(RecordType *module_type,
           args[entry.index] =
               std::make_unique<vAST::Identifier>(connection_name);
         }
+        std::reverse(args.begin(), args.end());
         std::unique_ptr<vAST::Concat> concat =
             std::make_unique<vAST::Concat>(std::move(args));
         verilog_connections.insert(

--- a/src/passes/analysis/verilog.cpp
+++ b/src/passes/analysis/verilog.cpp
@@ -142,11 +142,16 @@ std::unique_ptr<vAST::AbstractModule> compile_string_module(json verilog_json) {
 // If the module `isGenerated`, the parameters to the module include
 // `getDefaultGenArgs` and `getGenParams`
 std::unique_ptr<vAST::AbstractModule>
-compile_string_body_module(json verilog_json, std::string name,
-                           Module *module) {
+Passes::Verilog::compileStringBodyModule(json verilog_json, std::string name,
+                                         Module *module) {
   std::vector<std::unique_ptr<vAST::AbstractPort>> ports;
   for (auto port_str :
        verilog_json["interface"].get<std::vector<std::string>>()) {
+    if (this->verilator_debug) {
+        // FIXME: Hack to get comment into port name, we need to design a way
+        // to attach comments to expressions
+        port_str += "/*verilator public*/";
+    }
     ports.push_back(std::make_unique<vAST::StringPort>(port_str));
   }
   vAST::Parameters parameters;
@@ -177,19 +182,31 @@ compile_string_body_module(json verilog_json, std::string name,
                     std::make_unique<vAST::NumericLiteral>("1")));
     }
   }
+  std::string definition;
+  if (this->verilator_debug &&
+      verilog_json.count("verilator_debug_definition")) {
+    definition = verilog_json["verilator_debug_definition"].get<std::string>();
+  } else {
+    definition = verilog_json["definition"].get<std::string>();
+  }
   return std::make_unique<vAST::StringBodyModule>(
-      name, std::move(ports), verilog_json["definition"].get<std::string>(),
-      std::move(parameters));
+      name, std::move(ports), definition, std::move(parameters));
 }
 
 // Compile a CoreIR record type corresponding to the interface of a module with
 // flattened types into a vector of vAST Ports
 std::vector<std::unique_ptr<vAST::AbstractPort>>
-compile_ports(RecordType *record_type) {
+Passes::Verilog::compilePorts(RecordType *record_type) {
   std::vector<std::unique_ptr<vAST::AbstractPort>> ports;
   for (auto entry : record_type->getRecord()) {
+    std::string name_str = entry.first;
+    if (this->verilator_debug) {
+        // FIXME: Hack to get comment into port name, we need to design a way
+        // to attach comments to expressions
+        name_str += "/*verilator public*/";
+    }
     std::unique_ptr<vAST::Identifier> name =
-        std::make_unique<vAST::Identifier>(entry.first);
+        std::make_unique<vAST::Identifier>(name_str);
 
     Type *type = entry.second;
 
@@ -360,16 +377,20 @@ void assign_module_outputs(
 }
 
 // assign inout ports
-void assign_inouts(std::vector<Connection> connections,
+void assign_inouts(
+    std::vector<Connection> connections,
     std::vector<std::variant<std::unique_ptr<vAST::StructuralStatement>,
                              std::unique_ptr<vAST::Declaration>>> &body) {
-    for (auto connection : connections) {
-        if (connection.first->getType()->isInOut() || connection.second->getType()->isInOut()) {
-            body.push_back(std::make_unique<vAST::ContinuousAssign>(
-                std::make_unique<vAST::Identifier>(convert_to_verilog_connection(connection.first)),
-                std::make_unique<vAST::Identifier>(convert_to_verilog_connection(connection.second))));
-        };
+  for (auto connection : connections) {
+    if (connection.first->getType()->isInOut() ||
+        connection.second->getType()->isInOut()) {
+      body.push_back(std::make_unique<vAST::ContinuousAssign>(
+          std::make_unique<vAST::Identifier>(
+              convert_to_verilog_connection(connection.first)),
+          std::make_unique<vAST::Identifier>(
+              convert_to_verilog_connection(connection.second))));
     };
+  };
 }
 
 // Traverses the instance map and creates a vector of module instantiations
@@ -398,8 +419,7 @@ compile_module_body(RecordType *module_type,
         module_name = instance_module->getLongName();
       }
     } else if (instance_module->getMetaData().count("verilog") > 0) {
-      json verilog_json =
-          instance_module->getMetaData()["verilog"];
+      json verilog_json = instance_module->getMetaData()["verilog"];
       module_name = make_name(module_name, verilog_json);
     }
     vAST::Parameters instance_parameters;
@@ -509,7 +529,7 @@ void Passes::Verilog::compileModule(Module *module) {
     } else {
       std::string name = make_name(module->getName(), verilog_json);
       modules.push_back(std::make_pair(
-          name, compile_string_body_module(verilog_json, name, module)));
+          name, compileStringBodyModule(verilog_json, name, module)));
     }
     return;
   }
@@ -521,7 +541,7 @@ void Passes::Verilog::compileModule(Module *module) {
     std::string name = make_name(module->getName(), verilog_json);
 
     modules.push_back(std::make_pair(
-        name, compile_string_body_module(verilog_json, name, module)));
+        name, compileStringBodyModule(verilog_json, name, module)));
 
     // We only need to compile the verilog generator once, even though
     // there may be multiple instances of the generator represented as
@@ -535,14 +555,14 @@ void Passes::Verilog::compileModule(Module *module) {
     return;
   }
   std::vector<std::unique_ptr<vAST::AbstractPort>> ports =
-      compile_ports(cast<RecordType>(module->getType()));
+      compilePorts(cast<RecordType>(module->getType()));
 
   ModuleDef *definition = module->getDef();
   std::vector<std::variant<std::unique_ptr<vAST::StructuralStatement>,
                            std::unique_ptr<vAST::Declaration>>>
-      body =
-          compile_module_body(module->getType(), definition->getSortedConnections(),
-                              definition->getInstances());
+      body = compile_module_body(module->getType(),
+                                 definition->getSortedConnections(),
+                                 definition->getInstances());
 
   vAST::Parameters parameters = compile_params(module);
 

--- a/tests/gtest/array_select_golden.v
+++ b/tests/gtest/array_select_golden.v
@@ -5,8 +5,8 @@ endmodule
 module top (output [3:0] O, input [3:0] self_I);
 wire [3:0] inst0_O;
 wire [3:0] inst1_O;
-foo inst0(.I({self_I[0],self_I[0],self_I[1],self_I[2]}), .O(inst0_O));
-foo inst1(.I({inst0_O[0],inst0_O[1],inst0_O[1],self_I[1]}), .O(inst1_O));
-assign O = {inst1_O[0],inst1_O[0],self_I[0],self_I[1]};
+foo inst0(.I({self_I[2],self_I[1],self_I[0],self_I[0]}), .O(inst0_O));
+foo inst1(.I({self_I[1],inst0_O[1],inst0_O[1],inst0_O[0]}), .O(inst1_O));
+assign O = {self_I[1],self_I[0],inst1_O[0],inst1_O[0]};
 endmodule
 


### PR DESCRIPTION
Depends on #778, #776 and #777

Verilog's concat ordering is reversed, this was missed in the manual inspection of the verilog output. You can inspect the input ordering here https://github.com/rdaly525/coreir/blob/patch-concat-order/tests/gtest/array_select.json#L30-L41 and verify the new verilog matches (should be MSB in first position)