### PR TITLE
Include verilog ast

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ bit_vector.h
 a.out.dSYM/
 
 conv_3_1.o
+include/verilogAST.hpp

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,6 @@ script:
 - make -j2 installtest
 - cd build && sudo make -j2 uninstall && cd ..
 - export LD_LIBRARY_PATH=`pwd`/lib:$LD_LIBRARY_PATH
-# Install verilogAST headers/library for old style tests
-- cd build/verilogAST-build && sudo make install && cd ../..
 - make -j2 test
 - cd build && ctest -V && cd ..
 compiler:

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,8 @@ script:
 - make -j2 installtest
 - cd build && sudo make -j2 uninstall && cd ..
 - export LD_LIBRARY_PATH=`pwd`/lib:$LD_LIBRARY_PATH
+# Install verilogAST headers/library for old style tests
+- cd build/verilogAST-build && sudo make install && cd ../..
 - make -j2 test
 - cd build && ctest -V && cd ..
 compiler:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,18 +46,18 @@ add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/verilogAST-src
                  EXCLUDE_FROM_ALL)
 include_directories(${CMAKE_CURRENT_BINARY_DIR}/verilogAST-src/include)
 
+set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin)
+set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR}/lib)
+set(INCLUDE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/include)
+
+add_subdirectory(${CMAKE_SOURCE_DIR}/src)
+
 add_custom_command(
   TARGET coreir
   POST_BUILD
   COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_BINARY_DIR}/lib/libverilogAST.${CMAKE_SHARED_LIBRARY_SUFFIX}" "${CMAKE_SOURCE_DIR}/lib/"
   COMMENT "Copying to lib/"
 )
-
-set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin)
-set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR}/lib)
-set(INCLUDE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/include)
-
-add_subdirectory(${CMAKE_SOURCE_DIR}/src)
 
 install(
     DIRECTORY ${CMAKE_SOURCE_DIR}/include/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,13 @@ add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/verilogAST-src
                  EXCLUDE_FROM_ALL)
 include_directories(${CMAKE_CURRENT_BINARY_DIR}/verilogAST-src/include)
 
+add_custom_command(
+  TARGET coreir
+  POST_BUILD
+  COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_BINARY_DIR}/lib/libverilogAST.${CMAKE_SHARED_LIBRARY_SUFFIX}" "${CMAKE_SOURCE_DIR}/lib/"
+  COMMENT "Copying to lib/"
+)
+
 set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin)
 set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR}/lib)
 set(INCLUDE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,10 +59,19 @@ add_custom_command(
   COMMENT "Copying to lib/"
 )
 
+add_custom_command(
+  TARGET coreir
+  POST_BUILD
+  COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_BINARY_DIR}/verilogAST-src/include/verilogAST.hpp" "${CMAKE_SOURCE_DIR}/include/"
+  COMMENT "Copying to include/"
+)
+
 install(
     DIRECTORY ${CMAKE_SOURCE_DIR}/include/
     DESTINATION include
-    FILES_MATCHING PATTERN "*.h"
+    FILES_MATCHING 
+        PATTERN "*.h"
+        PATTERN "*.hpp"
 )
 
 add_custom_target(uninstall

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,20 +52,6 @@ set(INCLUDE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/include)
 
 add_subdirectory(${CMAKE_SOURCE_DIR}/src)
 
-add_custom_command(
-  TARGET coreir
-  POST_BUILD
-  COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_BINARY_DIR}/lib/libverilogAST.${CMAKE_SHARED_LIBRARY_SUFFIX}" "${CMAKE_SOURCE_DIR}/lib/"
-  COMMENT "Copying to lib/"
-)
-
-add_custom_command(
-  TARGET coreir
-  POST_BUILD
-  COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_BINARY_DIR}/verilogAST-src/include/verilogAST.hpp" "${CMAKE_SOURCE_DIR}/include/"
-  COMMENT "Copying to include/"
-)
-
 install(
     DIRECTORY ${CMAKE_SOURCE_DIR}/include/
     DESTINATION include

--- a/CMakeLists.txt.in
+++ b/CMakeLists.txt.in
@@ -12,7 +12,7 @@ ExternalProject_Add(verilogAST
   BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/verilogAST-build"
   CONFIGURE_COMMAND ""
   BUILD_COMMAND     ""
-  INSTALL_COMMAND   "${CMAKE_COMMAND} -DCMAKE_INSTALL_PREFIX=${CMAKE_SOURCE_DIR} --build . --target install"
+  INSTALL_COMMAND   ${CMAKE_COMMAND} -DCMAKE_INSTALL_PREFIX=${CMAKE_SOURCE_DIR} --build . --target install
   TEST_COMMAND      ""
 )
 project(googletest-download NONE)

--- a/CMakeLists.txt.in
+++ b/CMakeLists.txt.in
@@ -12,7 +12,7 @@ ExternalProject_Add(verilogAST
   BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/verilogAST-build"
   CONFIGURE_COMMAND ""
   BUILD_COMMAND     ""
-  INSTALL_COMMAND   ${CMAKE_COMMAND} -DCMAKE_INSTALL_PREFIX=${CMAKE_SOURCE_DIR} --build . --target install
+  INSTALL_COMMAND   ""
   TEST_COMMAND      ""
 )
 project(googletest-download NONE)

--- a/CMakeLists.txt.in
+++ b/CMakeLists.txt.in
@@ -12,7 +12,7 @@ ExternalProject_Add(verilogAST
   BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/verilogAST-build"
   CONFIGURE_COMMAND ""
   BUILD_COMMAND     ""
-  INSTALL_COMMAND   ""
+  INSTALL_COMMAND   "${CMAKE_COMMAND} -DCMAKE_INSTALL_PREFIX=${CMAKE_SOURCE_DIR} --build . --target install"
   TEST_COMMAND      ""
 )
 project(googletest-download NONE)

--- a/release/Makefile
+++ b/release/Makefile
@@ -12,6 +12,7 @@ endif
 install:
 	install bin/coreir* $(prefix)/bin
 	install lib/libcoreir* $(prefix)/lib
+	install lib/libverilogAST* $(prefix)/lib
 	install -d $(prefix)/include/coreir-c
 	install -d $(prefix)/include/coreir/ir/casting
 	install -d $(prefix)/include/coreir/common
@@ -30,6 +31,7 @@ install:
 	install include/coreir/passes/analysis/* $(prefix)/include/coreir/passes/analysis
 	install include/coreir/passes/transform/* $(prefix)/include/coreir/passes/transform
 	install include/coreir/simulator/* $(prefix)/include/coreir/simulator
+	install include/verilogAST.hpp $(prefix)/include
 
 .PHONY: uninstall
 uninstall:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,6 +39,8 @@ add_custom_command(
   COMMENT "Copying libverilogAST"
 )
 
+install(FILES "${CMAKE_SOURCE_DIR}/lib/libverilogAST.dylib" DESTINATION lib)
+
 add_custom_command(
   TARGET coreir
   POST_BUILD

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,7 +21,7 @@ target_link_libraries(coreir verilogAST)
 
 #Install libcoreir
 install(
-    TARGETS coreir
+    TARGETS coreir verilogAST
     DESTINATION lib
 )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,7 +21,7 @@ target_link_libraries(coreir verilogAST)
 
 #Install libcoreir
 install(
-    TARGETS coreir verilogAST
+    TARGETS coreir
     DESTINATION lib
 )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,6 +32,20 @@ add_custom_command(
   COMMENT "Copying to lib/"
 )
 
+add_custom_command(
+  TARGET coreir
+  POST_BUILD
+  COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_BINARY_DIR}/lib/libverilogAST${CMAKE_SHARED_LIBRARY_SUFFIX}" "${CMAKE_SOURCE_DIR}/lib/"
+  COMMENT "Copying libverilogAST"
+)
+
+add_custom_command(
+  TARGET coreir
+  POST_BUILD
+  COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_BINARY_DIR}/verilogAST-src/include/verilogAST.hpp" "${CMAKE_SOURCE_DIR}/include/"
+  COMMENT "Copying verilogAST.hpp"
+)
+
 #Create coreir executable
 add_executable(coreir-bin ${CMAKE_CURRENT_SOURCE_DIR}/binary/coreir.cpp)
 target_link_libraries(coreir-bin PUBLIC coreir)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,7 +39,7 @@ add_custom_command(
   COMMENT "Copying libverilogAST"
 )
 
-install(FILES "${CMAKE_SOURCE_DIR}/lib/libverilogAST.dylib" DESTINATION lib)
+install(FILES "${CMAKE_SOURCE_DIR}/lib/libverilogAST.${CMAKE_SHARED_LIBRARY_SUFFIX}" DESTINATION lib)
 
 add_custom_command(
   TARGET coreir

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,8 +39,6 @@ add_custom_command(
   COMMENT "Copying libverilogAST"
 )
 
-install(FILES "${CMAKE_SOURCE_DIR}/lib/libverilogAST.dylib" DESTINATION lib)
-
 add_custom_command(
   TARGET coreir
   POST_BUILD

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,7 +39,7 @@ add_custom_command(
   COMMENT "Copying libverilogAST"
 )
 
-install(FILES "${CMAKE_SOURCE_DIR}/lib/libverilogAST.${CMAKE_SHARED_LIBRARY_SUFFIX}" DESTINATION lib)
+install(FILES "${CMAKE_SOURCE_DIR}/lib/libverilogAST${CMAKE_SHARED_LIBRARY_SUFFIX}" DESTINATION lib)
 
 add_custom_command(
   TARGET coreir


### PR DESCRIPTION
I've been battling with various release flows, but finally got one working. This isn't ideal, but it should get us off the ground. This basically bundles `libverilogAST` (shared library and header) with the coreir release, so when you install coreir, you get libverilogAST alongside it. This has the benefit of maintaining compatibility between the two libraries with each release. This has the downside in that it could clobber an existing libverilogAST used by some other software (I don't know of any other users as of now, so it's currently not an issue).

eventually, we should have libverilogAST installed into the system as a shared library and coreir installed separately, but this unblocks downstream tools and allows them to use the coreir release with pycoreir (so they don't have to build from source)