### PR TITLE
Add osx build/release to travis flow

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ before_install:
 # End install conda
 - |
   if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-    export DYLD_LIBRARY_PATH=/usr/local/lib:$DYLD_LIBRARY_PATH
+    export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:/usr/local/lib
   else
     export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,6 @@ matrix:
     - CXX=g++-7
   - os: osx
     osx_image: xcode10.2
-    addons:
-      homebrew:
-        packages:
-          - cmake
 before_install:
 # install conda for py 3.7
 - |
@@ -40,9 +36,11 @@ before_install:
 # End install conda
 - |
   if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-    export DYLD_LIBRARY_PATH=/usr/local/lib:$DYLD_LIBRARY_PATH
+    # avoid strange libjpeg error (see https://github.com/sgrif/pq-sys/issues/1
+    # for some more info)
+    export DYLD_LIBRARY_PATH=/System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/:/usr/local/lib:$DYLD_LIBRARY_PATH
   else
-    export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
+    export LD_LIBRARY_PATH=`pwd`/lib:$LD_LIBRARY_PATH
   fi
 - cd build
 - cmake ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,12 @@ before_install:
 - source activate test-env
 - conda install pip
 # End install conda
+- |
+  if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+    export DYLD_LIBRARY_PATH=/usr/local/lib:$DYLD_LIBRARY_PATH
+  else
+    export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
+  fi
 - cd build
 - cmake ..
 - make -j2
@@ -47,9 +53,9 @@ script:
 - cd build && sudo make -j2 uninstall && cd ..
 - |
   if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-    export LD_LIBRARY_PATH=`pwd`/lib:$LD_LIBRARY_PATH
-  else
     export DYLD_LIBRARY_PATH=`pwd`/lib:$DYLD_LIBRARY_PATH
+  else
+    export LD_LIBRARY_PATH=`pwd`/lib:$LD_LIBRARY_PATH
   fi
 - make -j2 test
 - cd build && ctest -V && cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,6 @@ before_install:
 - source activate test-env
 - conda install pip
 # End install conda
-- export CXX="g++-7";
 - cd build
 - cmake ..
 - make -j2

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,15 +56,9 @@ script:
 - ls bin/
 - pytest tests/binary
 - make -j2 installtest
-- cd build && sudo make -j2 uninstall && cd ..
-- |
-  if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-    export DYLD_LIBRARY_PATH=`pwd`/lib:$DYLD_LIBRARY_PATH
-  else
-    export LD_LIBRARY_PATH=`pwd`/lib:$LD_LIBRARY_PATH
-  fi
 - make -j2 test
 - cd build && ctest -V && cd ..
+- cd build && sudo make -j2 uninstall && cd ..
 before_deploy:
 - ./tools/scripts/release.sh
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,29 @@
 dist: trusty
 language: c++
-compiler:
-  - clang
-  - gcc
-sudo: true
-addons:
-  apt:
-    sources:
-    - ubuntu-toolchain-r-test
-    packages:
-    - g++-7
-    - verilator
+matrix:
+  include:
+  - os: linux
+    addons:
+      apt:
+        sources:
+        - ubuntu-toolchain-r-test
+        packages:
+        - g++-7
+        - verilator
+    env:
+    - CC=gcc-7
+    - CXX=g++-7
+  - os: osx
+    osx_image: xcode10.2
 before_install:
 # install conda for py 3.7
-- wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+- |
+  if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+    wget https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh
+  else
+    # install conda for py 3.7
+    wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+  fi
 - chmod +x miniconda.sh
 - ./miniconda.sh -b -p $TRAVIS_BUILD_DIR/miniconda
 - export PATH=$TRAVIS_BUILD_DIR/miniconda/bin:$PATH
@@ -25,7 +35,6 @@ before_install:
 - conda install pip
 # End install conda
 - export CXX="g++-7";
-- export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 - cd build
 - cmake ..
 - make -j2
@@ -37,20 +46,21 @@ script:
 - pytest tests/binary
 - make -j2 installtest
 - cd build && sudo make -j2 uninstall && cd ..
-- export LD_LIBRARY_PATH=`pwd`/lib:$LD_LIBRARY_PATH
+- |
+  if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+    export LD_LIBRARY_PATH=`pwd`/lib:$LD_LIBRARY_PATH
+  else
+    export DYLD_LIBRARY_PATH=`pwd`/lib:$DYLD_LIBRARY_PATH
+  fi
 - make -j2 test
 - cd build && ctest -V && cd ..
-compiler:
-- gcc
-os:
-- linux
 before_deploy:
 - ./tools/scripts/release.sh
 deploy:
   provider: releases
   api_key:
     secure: ov1UJzIPDhQpIFlItxEI1d+1YZmW2UU83cXZTLm+Wl4m+Uanab1r3s9UakGW8OqwTDmKu1JHba876lC1YWcO6K9o6iAx8YVqTFKh89kOGs1V2vfkgMHVkV+x+AcxwUJJDOv0J2KCntLU6O7babm5peLMkctqsyfiOHK4muedKxpMLG6ZFyKit42yqXp2uLKJF7SvLtSBV7hSFST8fnt05Whxu4m8YP5qAQEKLkfo77dPS4/RXjo02ac5mTVEXklB8xvNvuPDNq1rWS/+0H83XMO3dJcDKYD6hOV48/pE17Imli6SEVMUwXsTAoGHRocfKXQRZS36mMD139YhDydZTckmlDVMN1P/+yKzsGg58cX9Z6AAp0fu2i/5myqbqH/m14JBlyZrvL8KuDL1uJvzwr6mbrlQGphOAOoGLNN3ziPAmJRdw4y73UCJjaK5I875O+YtCDmgadtlZp3QfTCUj9u/WsS8lFKv72tggWLf2gri3krfUQaFxHni2gMJY2DMeqFXh6g5/QY+naCoYQ2tFt6ORZZiB7K3iLe7hSh3BPq7/gvC/BV+pjaQMvH3YA8K9jDhn+SObhykR1yB2EAi8JpjOm2HfSHK2wvjPlwzsQQ2/0K9j8SwzChMJ+4s9gbPGOjiYatAMXIl61OlT8KkTrDfJp+lOMasLBaQDMYthfs=
-  file: coreir.tar.gz
+  file: coreir-${TRAVIS_OS_NAME}
   skip_cleanup: true
   on:
     repo: rdaly525/coreir

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,10 @@ matrix:
     - CXX=g++-7
   - os: osx
     osx_image: xcode10.2
+    addons:
+      homebrew:
+        packages:
+          - cmake
 before_install:
 # install conda for py 3.7
 - |
@@ -34,8 +38,14 @@ before_install:
 - source activate test-env
 - conda install pip
 # End install conda
+- |
+  if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+    export DYLD_LIBRARY_PATH=/usr/local/lib:$DYLD_LIBRARY_PATH
+  else
+    export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
+  fi
 - cd build
-- cmake -DCMAKE_INSTALL_PREFIX=/usr ..
+- cmake ..
 - make -j2
 - sudo make install
 - cd -

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,10 @@ matrix:
     - CXX=g++-7
   - os: osx
     osx_image: xcode10.2
+    addons:
+      homebrew:
+        packages:
+          - verilator
 before_install:
 # install conda for py 3.7
 - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,14 +34,8 @@ before_install:
 - source activate test-env
 - conda install pip
 # End install conda
-- |
-  if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-    export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:/usr/local/lib
-  else
-    export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
-  fi
 - cd build
-- cmake ..
+- cmake -DCMAKE_INSTALL_PREFIX=/usr ..
 - make -j2
 - sudo make install
 - cd -

--- a/tests/install/run
+++ b/tests/install/run
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -x #echo on
 echo "$1"
 

--- a/tools/scripts/release.sh
+++ b/tools/scripts/release.sh
@@ -7,4 +7,5 @@ cp -r lib release/.
 #cmake -DCMAKE_BUILD_TYPE=release ..
 #make -j8
 #cd ..
-tar -zcvf coreir.tar.gz release 
+cp -r release coreir-${TRAVIS_OS_NAME}
+tar -zcvf coreir-${TRAVIS_OS_NAME}.tar.gz coreir-${TRAVIS_OS_NAME}


### PR DESCRIPTION
This changes the release flow to produce two tarballs named `coreir-{$OS}.tar.gz` where `$OS` is either `linux` or `mac`. It also runs the test suite under a macos environment in the travis builds.