### PR TITLE
Add initialization logic to accumulation register

### DIFF
--- a/src/libs/commonlib.cpp
+++ b/src/libs/commonlib.cpp
@@ -2353,16 +2353,16 @@ Namespace* CoreIRLoadLibrary_commonlib(Context* c) {
 
     // initialize register
     def->connect("init_phase_sel.in0", "init_phase_value.out");
-    def->connect("init_phase_sel.in0", "phase_counter.out");
+    def->connect("init_phase_sel.in1", "phase_counter.out");
 
     // create output data
     def->connect("accum_adder.in0", "self.in_data");
-    def->connect("accum_adder.in1", "accum_reg.out");
+    def->connect("accum_adder.in1", "input_mux.out");
     def->connect("accum_adder.out", "self.out_data");
     def->connect("input_mux.in1", "self.bias");
-    def->connect("input_mux.in0", "accum_adder.out");
+    def->connect("input_mux.in0", "accum_reg.out");
     def->connect("input_mux.sel", "init_phase_sel.out");
-    def->connect("input_mux.out", "accum_reg.in");
+    def->connect("accum_adder.out", "accum_reg.in");
 
     });
   

--- a/src/libs/commonlib.cpp
+++ b/src/libs/commonlib.cpp
@@ -2335,6 +2335,10 @@ Namespace* CoreIRLoadLibrary_commonlib(Context* c) {
     def->addInstance("phase_sel", "coreir.eq", bitwidthParams);
     def->addInstance("accum_adder", "coreir.add", bitwidthParams);
 
+    Values init_phase_const = {{"value", Const::make(c,BitVector(width,0))}};
+    def->addInstance("init_phase_value", "coreir.const", bitwidthParams, init_phase_const);
+    def->addInstance("init_phase_sel", "coreir.eq", bitwidthParams);
+
     // create output phase logic
     def->connect("self.in_valid", "phase_counter.en");
     def->connect("self.reset", "phase_counter.reset");
@@ -2347,13 +2351,17 @@ Namespace* CoreIRLoadLibrary_commonlib(Context* c) {
     def->connect("valid_mux.sel", "phase_sel.out");
     def->connect("valid_mux.out", "self.valid");
 
+    // initialize register
+    def->connect("init_phase_sel.in0", "init_phase_value.out");
+    def->connect("init_phase_sel.in0", "phase_counter.out");
+
     // create output data
     def->connect("accum_adder.in0", "self.in_data");
     def->connect("accum_adder.in1", "accum_reg.out");
     def->connect("accum_adder.out", "self.out_data");
     def->connect("input_mux.in1", "self.bias");
     def->connect("input_mux.in0", "accum_adder.out");
-    def->connect("input_mux.sel", "phase_sel.out");
+    def->connect("input_mux.sel", "init_phase_sel.out");
     def->connect("input_mux.out", "accum_reg.in");
 
     });


### PR DESCRIPTION
The previous accumulation register logic works great, except for the first time the register is used. The register value isn't initialized to anything, which messes things up.

To fix this, I
- added selector that is true when it is the first iteration
- move mux to in front of the adder that chooses between the bias and accum_reg. chooses bias on the first iteration; accum_reg otherwise

Note: this still outputs valid on the last iteration. We could change it to output and initialize on iteration 0 (would save a PE by removing a selector), but we would need a register to hold the in_valid signal of the previous sequence as we move to a new computation sequence. I chose not to do this for now but it can be changed later.
