### PR TITLE
Fix bug in debug port generation

### DIFF
--- a/src/passes/analysis/verilog.cpp
+++ b/src/passes/analysis/verilog.cpp
@@ -229,11 +229,6 @@ Passes::Verilog::compilePorts(RecordType *record_type) {
   std::vector<std::unique_ptr<vAST::AbstractPort>> ports;
   for (auto entry : record_type->getRecord()) {
     std::string name_str = entry.first;
-    if (this->verilator_debug) {
-        // FIXME: Hack to get comment into port name, we need to design a way
-        // to attach comments to expressions
-        name_str += "/*verilator public*/";
-    }
     std::unique_ptr<vAST::Identifier> name =
         std::make_unique<vAST::Identifier>(name_str);
 
@@ -249,9 +244,17 @@ Passes::Verilog::compilePorts(RecordType *record_type) {
     } else {
       ASSERT(false, "Not implemented for type = " + toString(type));
     }
-
-    ports.push_back(std::make_unique<vAST::Port>(
-        process_decl(std::move(name), type), verilog_direction, vAST::WIRE));
+    std::unique_ptr<vAST::Port> port = std::make_unique<vAST::Port>(
+            process_decl(std::move(name), type), verilog_direction, vAST::WIRE);
+    if (this->verilator_debug) {
+      // FIXME: Hack to get comment into port decl, we need to add support
+      // attaching comments to expressions
+      std::string port_str = port->toString();
+      port_str += "/*verilator public*/";
+      ports.push_back(std::make_unique<vAST::StringPort>(port_str));
+    } else {
+      ports.push_back(std::move(port));
+    }
   };
   return ports;
 }


### PR DESCRIPTION
Before, coreir was appending a comment string to an identifier name to insert the verilator debug hook, this triggered the escape logic in the identifier code generator leading to this bug https://github.com/leonardt/fault/issues/183

This change fixes the logic to instead generate a StringPort (inline port string) with the comment, rather than using the Identifier name field.  This properly code generates the debug port for now, in the future we will add a way to attach arbitrary comments to nodes.