### PR TITLE
Add inline verilog string metadata

### DIFF
--- a/src/passes/analysis/verilog.cpp
+++ b/src/passes/analysis/verilog.cpp
@@ -599,6 +599,10 @@ void Passes::Verilog::compileModule(Module *module) {
       body = compile_module_body(module->getType(),
                                  definition->getSortedConnections(),
                                  definition->getInstances());
+  if (module->getMetaData().count("inline_verilog") > 0) {
+    std::string inline_str = module->getMetaData()["inline_verilog"].get<std::string>();
+    body.push_back(std::make_unique<vAST::InlineVerilog>(inline_str));
+  }
 
   vAST::Parameters parameters = compile_params(module);
 

--- a/src/passes/analysis/verilog.cpp
+++ b/src/passes/analysis/verilog.cpp
@@ -599,6 +599,8 @@ void Passes::Verilog::compileModule(Module *module) {
       body = compile_module_body(module->getType(),
                                  definition->getSortedConnections(),
                                  definition->getInstances());
+  // Temporary support for inline verilog
+  // See https://github.com/rdaly525/coreir/pull/823 for context
   if (module->getMetaData().count("inline_verilog") > 0) {
     std::string inline_str = module->getMetaData()["inline_verilog"].get<std::string>();
     body.push_back(std::make_unique<vAST::InlineVerilog>(inline_str));

--- a/tests/gtest/inline_verilog.json
+++ b/tests/gtest/inline_verilog.json
@@ -1,0 +1,34 @@
+{"top":"global.Main",
+"namespaces":{
+  "global":{
+    "modules":{
+      "FF":{
+        "type":["Record",[
+          ["I","BitIn"],
+          ["O","Bit"],
+          ["CLK",["Named","coreir.clkIn"]]
+        ]],
+        "metadata":{"verilog":{"verilog_string":"module FF(input I, output O, input CLK);\nalways @(posedge CLK) begin\n  O <= I;\nend\nendmodule"}}
+      },
+      "Main":{
+        "type":["Record",[
+          ["I","BitIn"],
+          ["O","Bit"],
+          ["CLK",["Named","coreir.clkIn"]]
+        ]],
+        "instances":{
+          "FF_inst0":{
+            "modref":"global.FF"
+          }
+        },
+        "connections":[
+          ["self.CLK","FF_inst0.CLK"],
+          ["self.I","FF_inst0.I"],
+          ["self.O","FF_inst0.O"]
+        ],
+        "metadata":{"inline_verilog":"\nassert property { @(posedge CLK) I |-> ##1 O };\n"}
+      }
+    }
+  }
+}
+}

--- a/tests/gtest/inline_verilog_golden.v
+++ b/tests/gtest/inline_verilog_golden.v
@@ -1,0 +1,14 @@
+module FF(input I, output O, input CLK);
+always @(posedge CLK) begin
+  O <= I;
+end
+endmodule
+module Main (input CLK, input I, output O);
+wire FF_inst0_O;
+FF FF_inst0(.CLK(CLK), .I(I), .O(FF_inst0_O));
+assign O = FF_inst0_O;
+
+assert property { @(posedge CLK) I |-> ##1 O };
+
+endmodule
+

--- a/tests/gtest/test_verilog.cpp
+++ b/tests/gtest/test_verilog.cpp
@@ -69,6 +69,27 @@ TEST(VerilogTests, TestArraySelect) {
   deleteContext(c);
 }
 
+TEST(VerilogTests, TestInlineVerilogMetadata) {
+  Context* c = newContext();
+  Module* top;
+
+  if (!loadFromFile(c, "inline_verilog.json", &top)) {
+    c->die();
+  }
+  assert(top != nullptr);
+  c->setTop(top->getRefName());
+
+  const std::vector<std::string> passes = {
+    "rungenerators",
+    "removebulkconnections",
+    "flattentypes",
+    "verilog --inline"
+  };
+  c->runPasses(passes, {});
+  assertPassEq<Passes::Verilog>(c, "inline_verilog_golden.v");
+  deleteContext(c);
+}
+
 }  // namespace
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
This is a temporary solution for handling inline assertions inside magma modules.

We should investigate a more principled approach to passing through inline module assertions, but for now we just compile the assertions in python to verilog strings that are inlined into the module definition at the end.

An improvement would be to give CoreIR some representation of the string and allow it to interpolate names (e.g. tuple fields are replaced with the corresponding verilog name).  To do this, we would need to extend the system with some IR for representing verilog assertions (e.g. we could extend verilogAST to support these expressions, then introduce special nodes for CoreIR names that are eventually replaced with verilog names.