### PR TITLE
Hotfix inline corebit

### DIFF
--- a/src/passes/analysis/verilog.cpp
+++ b/src/passes/analysis/verilog.cpp
@@ -107,6 +107,14 @@ bool can_inline_binary_op(CoreIR::Module *module, bool _inline) {
     return false;
 }
 
+std::unique_ptr<vAST::Expression> get_primitive_expr(CoreIR::Instance *instance) {
+    CoreIR::Module *module = instance->getModuleRef();
+    if (module->isGenerated()) {
+        return module->getGenerator()->getPrimitiveExpressionLambda()();
+    }
+    return module->getPrimitiveExpressionLambda()();
+}
+
 std::unique_ptr<vAST::StructuralStatement> inline_binary_op(
     std::pair<std::string, CoreIR::Instance *> instance,
     std::map<std::string, std::unique_ptr<vAST::Expression>> verilog_connections
@@ -114,16 +122,9 @@ std::unique_ptr<vAST::StructuralStatement> inline_binary_op(
     BinaryOpReplacer transformer( 
             std::move(verilog_connections["in0"]),
             std::move(verilog_connections["in1"]));
-    std::unique_ptr<vAST::Expression> primitive_expr;
-    CoreIR::Module *module = instance.second->getModuleRef();
-    if (module->isGenerated()) {
-        primitive_expr = module->getGenerator()->getPrimitiveExpressionLambda()();
-    } else {
-        primitive_expr = module->getPrimitiveExpressionLambda()();
-    }
     return std::make_unique<vAST::ContinuousAssign>(
         std::make_unique<vAST::Identifier>(instance.first + "_out"),
-        transformer.visit(std::move(primitive_expr)));
+        transformer.visit(get_primitive_expr(instance.second)));
 }
 
 bool can_inline_unary_op(CoreIR::Module *module, bool _inline) {
@@ -152,16 +153,9 @@ std::unique_ptr<vAST::StructuralStatement> inline_unary_op(
     std::map<std::string, std::unique_ptr<vAST::Expression>> verilog_connections
         ) {
     UnaryOpReplacer transformer(std::move(verilog_connections["in"]));
-    std::unique_ptr<vAST::Expression> primitive_expr;
-    CoreIR::Module *module = instance.second->getModuleRef();
-    if (module->isGenerated()) {
-        primitive_expr = module->getGenerator()->getPrimitiveExpressionLambda()();
-    } else {
-        primitive_expr = module->getPrimitiveExpressionLambda()();
-    }
     return std::make_unique<vAST::ContinuousAssign>(
         std::make_unique<vAST::Identifier>(instance.first + "_out"),
-        transformer.visit(std::move(primitive_expr)));
+        transformer.visit(get_primitive_expr(instance.second)));
 }
 
 bool can_inline_const_op(CoreIR::Module *module, bool _inline) {
@@ -208,16 +202,9 @@ std::unique_ptr<vAST::StructuralStatement> inline_mux_op(
     MuxReplacer transformer(std::move(verilog_connections["in0"]),
                             std::move(verilog_connections["in1"]),
                             std::move(verilog_connections["sel"]));
-    std::unique_ptr<vAST::Expression> primitive_expr;
-    CoreIR::Module *module = instance.second->getModuleRef();
-    if (module->isGenerated()) {
-        primitive_expr = module->getGenerator()->getPrimitiveExpressionLambda()();
-    } else {
-        primitive_expr = module->getPrimitiveExpressionLambda()();
-    }
     return std::make_unique<vAST::ContinuousAssign>(
         std::make_unique<vAST::Identifier>(instance.first + "_out"),
-        transformer.visit(std::move(primitive_expr)));
+        transformer.visit(get_primitive_expr(instance.second)));
 }
 
 bool can_inline_slice_op(CoreIR::Module *module, bool _inline) {

--- a/src/passes/analysis/verilog.cpp
+++ b/src/passes/analysis/verilog.cpp
@@ -96,6 +96,14 @@ bool can_inline_binary_op(CoreIR::Module *module, bool _inline) {
              verilog_json["primitive_type"] == "binaryReduce")
             && _inline;
     }
+    if (module->getMetaData().count("verilog") > 0) {
+        json verilog_json =
+            module->getMetaData()["verilog"];
+        return module->hasPrimitiveExpressionLambda() &&
+            (verilog_json["primitive_type"] == "binary" ||
+             verilog_json["primitive_type"] == "binaryReduce")
+            && _inline;
+    }
     return false;
 }
 
@@ -106,9 +114,16 @@ std::unique_ptr<vAST::StructuralStatement> inline_binary_op(
     BinaryOpReplacer transformer( 
             std::move(verilog_connections["in0"]),
             std::move(verilog_connections["in1"]));
+    std::unique_ptr<vAST::Expression> primitive_expr;
+    CoreIR::Module *module = instance.second->getModuleRef();
+    if (module->isGenerated()) {
+        primitive_expr = module->getGenerator()->getPrimitiveExpressionLambda()();
+    } else {
+        primitive_expr = module->getPrimitiveExpressionLambda()();
+    }
     return std::make_unique<vAST::ContinuousAssign>(
         std::make_unique<vAST::Identifier>(instance.first + "_out"),
-        transformer.visit(instance.second->getModuleRef()->getGenerator()->getPrimitiveExpressionLambda()()));
+        transformer.visit(std::move(primitive_expr)));
 }
 
 bool can_inline_unary_op(CoreIR::Module *module, bool _inline) {
@@ -121,6 +136,14 @@ bool can_inline_unary_op(CoreIR::Module *module, bool _inline) {
              verilog_json["primitive_type"] == "unaryReduce")
             && _inline;
     }
+    if (module->getMetaData().count("verilog") > 0) {
+        json verilog_json =
+            module->getMetaData()["verilog"];
+        return module->hasPrimitiveExpressionLambda() &&
+            (verilog_json["primitive_type"] == "unary" ||
+             verilog_json["primitive_type"] == "unaryReduce")
+            && _inline;
+    }
     return false;
 }
 
@@ -129,9 +152,16 @@ std::unique_ptr<vAST::StructuralStatement> inline_unary_op(
     std::map<std::string, std::unique_ptr<vAST::Expression>> verilog_connections
         ) {
     UnaryOpReplacer transformer(std::move(verilog_connections["in"]));
+    std::unique_ptr<vAST::Expression> primitive_expr;
+    CoreIR::Module *module = instance.second->getModuleRef();
+    if (module->isGenerated()) {
+        primitive_expr = module->getGenerator()->getPrimitiveExpressionLambda()();
+    } else {
+        primitive_expr = module->getPrimitiveExpressionLambda()();
+    }
     return std::make_unique<vAST::ContinuousAssign>(
         std::make_unique<vAST::Identifier>(instance.first + "_out"),
-        transformer.visit(instance.second->getModuleRef()->getGenerator()->getPrimitiveExpressionLambda()()));
+        transformer.visit(std::move(primitive_expr)));
 }
 
 bool can_inline_const_op(CoreIR::Module *module, bool _inline) {
@@ -161,6 +191,13 @@ bool can_inline_mux_op(CoreIR::Module *module, bool _inline) {
             verilog_json["primitive_type"] == "other" &&
             module->getName() == "mux" && _inline;
     }
+    if (module->getMetaData().count("verilog") > 0) {
+        json verilog_json =
+            module->getMetaData()["verilog"];
+        return module->hasPrimitiveExpressionLambda() &&
+            verilog_json["primitive_type"] == "other" &&
+            module->getName() == "mux" && _inline;
+    }
     return false;
 }
 
@@ -171,9 +208,16 @@ std::unique_ptr<vAST::StructuralStatement> inline_mux_op(
     MuxReplacer transformer(std::move(verilog_connections["in0"]),
                             std::move(verilog_connections["in1"]),
                             std::move(verilog_connections["sel"]));
+    std::unique_ptr<vAST::Expression> primitive_expr;
+    CoreIR::Module *module = instance.second->getModuleRef();
+    if (module->isGenerated()) {
+        primitive_expr = module->getGenerator()->getPrimitiveExpressionLambda()();
+    } else {
+        primitive_expr = module->getPrimitiveExpressionLambda()();
+    }
     return std::make_unique<vAST::ContinuousAssign>(
         std::make_unique<vAST::Identifier>(instance.first + "_out"),
-        transformer.visit(instance.second->getModuleRef()->getGenerator()->getPrimitiveExpressionLambda()()));
+        transformer.visit(std::move(primitive_expr)));
 }
 
 bool can_inline_slice_op(CoreIR::Module *module, bool _inline) {

--- a/tests/gtest/test_verilog.cpp
+++ b/tests/gtest/test_verilog.cpp
@@ -118,6 +118,28 @@ TEST(VerilogTests, TestTwoInline) {
   deleteContext(c);
 }
 
+TEST(VerilogTests, TestTwoBitInline) {
+  Context* c = newContext();
+  CoreIRLoadVerilog_corebit(c);
+  Module* top;
+
+  if (!loadFromFile(c, "two_ops_bit.json", &top)) {
+    c->die();
+  }
+  assert(top != nullptr);
+  c->setTop(top->getRefName());
+
+  const std::vector<std::string> passes = {
+    "rungenerators",
+    "removebulkconnections",
+    "flattentypes",
+    "verilog --inline"
+  };
+  c->runPasses(passes, {});
+  assertPassEq<Passes::Verilog>(c, "two_ops_bit_golden.v");
+  deleteContext(c);
+}
+
 TEST(VerilogTests, TestMuxInline) {
   Context* c = newContext();
   CoreIRLoadVerilog_coreir(c);

--- a/tests/gtest/two_ops_bit.json
+++ b/tests/gtest/two_ops_bit.json
@@ -1,0 +1,53 @@
+{"top":"global.Top",
+"namespaces":{
+  "global":{
+    "modules":{
+      "Top":{
+        "type":["Record",[
+          ["I","BitIn"],
+          ["I1","BitIn"],
+          ["I2","BitIn"],
+          ["I3","BitIn"],
+          ["O","Bit"],
+          ["O1","Bit"]
+        ]],
+        "instances":{
+          "bit_const_1_None":{
+            "modref":"corebit.const",
+            "modargs":{"value":["Bool",true]}
+          },
+          "magma_Bit_and_inst0":{
+            "modref":"corebit.and"
+          },
+          "magma_Bit_not_inst0":{
+            "modref":"corebit.not"
+          },
+          "magma_Bit_or_inst0":{
+            "modref":"corebit.or"
+          },
+          "magma_Bit_xor_inst0":{
+            "modref":"corebit.xor"
+          },
+          "test_mux":{
+            "modref":"corebit.mux"
+          }
+        },
+        "connections":[
+          ["magma_Bit_and_inst0.in1","bit_const_1_None.out"],
+          ["magma_Bit_not_inst0.out","magma_Bit_and_inst0.in0"],
+          ["magma_Bit_or_inst0.in1","magma_Bit_and_inst0.out"],
+          ["self.I","magma_Bit_not_inst0.in"],
+          ["magma_Bit_xor_inst0.out","magma_Bit_or_inst0.in0"],
+          ["self.O","magma_Bit_or_inst0.out"],
+          ["self.I","magma_Bit_xor_inst0.in0"],
+          ["self.I","magma_Bit_xor_inst0.in1"],
+          ["self.I1","test_mux.in0"],
+          ["self.I2","test_mux.in1"],
+          ["self.I3","test_mux.sel"],
+          ["self.O1","test_mux.out"]
+        ]
+      }
+    }
+  }
+}
+}

--- a/tests/gtest/two_ops_bit_golden.v
+++ b/tests/gtest/two_ops_bit_golden.v
@@ -1,0 +1,5 @@
+module Top (input I, input I1, input I2, input I3, output O, output O1);
+assign O = (I ^ I) | ((~ I) & 1'b1);
+assign O1 = I3 ? I2 : I1;
+endmodule
+


### PR DESCRIPTION
The inline logic was not properly handling the `corebit` primitives which are not generated modules.  This fixes the logic and adds tests to cover the cases when the primitive is a module and not a generated module.

Fixes https://github.com/phanrahan/magma/issues/529