### PR TITLE
Codegen source filename/lineno

### DIFF
--- a/src/passes/analysis/verilog.cpp
+++ b/src/passes/analysis/verilog.cpp
@@ -851,6 +851,18 @@ void Passes::Verilog::compileModule(Module *module) {
                                  definition->getInstances(),
                                  this->_inline);
 
+  if (module->getMetaData().count("filename") > 0) { 
+    std::string debug_str = "Module `" + module->getName() + "` defined at " +
+      module->getMetaData()["filename"].get<std::string>();
+    if (module->getMetaData().count("lineno") > 0) {
+      debug_str += ":" + module->getMetaData()["lineno"].get<std::string>();
+    }
+    body.insert(
+      body.begin(), std::make_unique<vAST::SingleLineComment>(debug_str));
+  }
+
+
+
   // Temporary support for inline verilog
   // See https://github.com/rdaly525/coreir/pull/823 for context
   if (module->getMetaData().count("inline_verilog") > 0) {

--- a/src/passes/analysis/verilog.cpp
+++ b/src/passes/analysis/verilog.cpp
@@ -498,12 +498,15 @@ public:
 
 // An entry in the connection map contains a source wireable (driving the port
 // denoted by the key). It also contains an index in the case of a driver
-// connecting to a sub element of the port.
+// connecting to a sub element of the port.  Metadata is used to generate debug
+// info
 class ConnMapEntry {
 public:
   Wireable *source;
   int index;
-  ConnMapEntry(Wireable *source, int index) : source(source), index(index){};
+  json& metadata;
+  ConnMapEntry(Wireable *source, int index, json& metadata) : source(source),
+    index(index), metadata(metadata){};
 };
 
 // Builds a map from pairs of strings of the form <instance_name, port_name>
@@ -515,8 +518,9 @@ public:
 // array of 3 bits, and each bit is connected to a 1-bit driver).  In this
 // case, each entry stores the index that it drives.
 std::map<ConnMapKey, std::vector<ConnMapEntry>>
-build_connection_map(std::vector<Connection> connections,
+build_connection_map(CoreIR::ModuleDef *definition,
                      std::map<std::string, Instance *> instances) {
+  std::vector<Connection> connections = definition->getSortedConnections();
   std::map<ConnMapKey, std::vector<ConnMapEntry>> connection_map;
   for (auto connection : connections) {
     // Check if this is connected to an instance to an instance input, if
@@ -530,7 +534,8 @@ build_connection_map(std::vector<Connection> connections,
           index = std::stoi(first_sel_path[2]);
         }
         connection_map[ConnMapKey(instance.first, first_sel_path[1])].push_back(
-            ConnMapEntry(connection.second, index));
+            ConnMapEntry(connection.second, index,
+                definition->getMetaData(connection.first, connection.second)));
       } else if (connection.second->getTopParent() == instance.second &&
                  connection.second->getType()->isInput()) {
         SelectPath second_sel_path = connection.second->getSelectPath();
@@ -539,7 +544,9 @@ build_connection_map(std::vector<Connection> connections,
           index = std::stoi(second_sel_path[2]);
         }
         connection_map[ConnMapKey(instance.first, second_sel_path[1])]
-            .push_back(ConnMapEntry(connection.first, index));
+            .push_back(ConnMapEntry(connection.first, index,
+                        definition->getMetaData(connection.first,
+                            connection.second)));
       }
     }
     // Also check if the connection is driving a self port, which will be
@@ -552,7 +559,8 @@ build_connection_map(std::vector<Connection> connections,
         index = std::stoi(first_sel_path[2]);
       }
       connection_map[ConnMapKey("self", first_sel_path[1])].push_back(
-          ConnMapEntry(connection.second, index));
+          ConnMapEntry(connection.second, index,
+              definition->getMetaData(connection.first, connection.second)));
     } else if (connection.second->getSelectPath()[0] == "self" &&
                connection.second->getType()->isInput()) {
       SelectPath second_sel_path = connection.second->getSelectPath();
@@ -561,7 +569,8 @@ build_connection_map(std::vector<Connection> connections,
         index = std::stoi(second_sel_path[2]);
       }
       connection_map[ConnMapKey("self", second_sel_path[1])].push_back(
-          ConnMapEntry(connection.first, index));
+          ConnMapEntry(connection.first, index,
+              definition->getMetaData(connection.first, connection.second)));
     }
   }
   return connection_map;
@@ -607,8 +616,19 @@ void assign_module_outputs(
       std::vector<std::unique_ptr<vAST::Expression>> args;
       args.resize(entries.size());
       for (auto entry : entries) {
-        args[entry.index] =
+        std::unique_ptr<vAST::Expression> verilog_conn =
             convert_to_expression(convert_to_verilog_connection(entry.source));
+        if (entry.metadata.count("filename") > 0) {
+          std::string debug_str = "Connection `(" + port.first + "[" +
+              std::to_string(entry.index) + "]" + ", " +
+              verilog_conn->toString() +")` created at " +
+              entry.metadata["filename"].get<std::string>();
+          if (entry.metadata.count("lineno") > 0) {
+            debug_str += ":" + entry.metadata["lineno"].get<std::string>();
+          }
+          body.push_back(std::make_unique<vAST::SingleLineComment>(debug_str));
+        }
+        args[entry.index] = std::move(verilog_conn);
       }
       std::reverse(args.begin(), args.end());
       std::unique_ptr<vAST::Concat> concat =
@@ -616,10 +636,21 @@ void assign_module_outputs(
       body.push_back(std::make_unique<vAST::ContinuousAssign>(
           std::make_unique<vAST::Identifier>(port.first), std::move(concat)));
     } else {
+      std::unique_ptr<vAST::Expression> verilog_conn =
+          convert_to_expression(convert_to_verilog_connection(entries[0].source));
+      if (entries[0].metadata.count("filename") > 0) {
+        std::string debug_str = "Connection `(" + port.first + ", " +
+            verilog_conn->toString() +")` created at " +
+            entries[0].metadata["filename"].get<std::string>();
+        if (entries[0].metadata.count("lineno") > 0) {
+          debug_str += ":" + entries[0].metadata["lineno"].get<std::string>();
+        }
+        body.push_back(std::make_unique<vAST::SingleLineComment>(debug_str));
+      }
       // Regular (possibly bulk) connection
       body.push_back(std::make_unique<vAST::ContinuousAssign>(
           std::make_unique<vAST::Identifier>(port.first),
-          convert_to_expression(convert_to_verilog_connection(entries[0].source))
+          std::move(verilog_conn)
       ));
     }
   }
@@ -646,15 +677,16 @@ void assign_inouts(
 std::vector<std::variant<std::unique_ptr<vAST::StructuralStatement>,
                          std::unique_ptr<vAST::Declaration>>>
 compile_module_body(RecordType *module_type,
-                    std::vector<Connection> connections,
-                    std::map<std::string, Instance *> instances,
+                    CoreIR::ModuleDef *definition,
                     bool _inline) {
+  std::map<std::string, Instance *> instances = definition->getInstances();
+
   std::vector<std::variant<std::unique_ptr<vAST::StructuralStatement>,
                            std::unique_ptr<vAST::Declaration>>>
       body = declare_connections(instances);
 
   std::map<ConnMapKey, std::vector<ConnMapEntry>> connection_map =
-      build_connection_map(connections, instances);
+      build_connection_map(definition, instances);
 
   for (auto instance : instances) {
     Module *instance_module = instance.second->getModuleRef();
@@ -673,6 +705,16 @@ compile_module_body(RecordType *module_type,
     }
     vAST::Parameters instance_parameters;
     std::string instance_name = instance.first;
+
+    if (instance.second->getMetaData().count("filename") > 0) {
+      std::string debug_str = "Instance `" + instance_name + "` created at " +
+        instance.second->getMetaData()["filename"].get<std::string>();
+      if (instance.second->getMetaData().count("lineno") > 0) {
+        debug_str += ":" + instance.second->getMetaData()["lineno"].get<std::string>();
+      }
+      body.push_back(std::make_unique<vAST::SingleLineComment>(debug_str));
+    }
+
     std::map<std::string, std::unique_ptr<vAST::Expression>> verilog_connections;
     for (auto port :
          cast<RecordType>(instance_module->getType())->getRecord()) {
@@ -692,8 +734,19 @@ compile_module_body(RecordType *module_type,
         std::vector<std::unique_ptr<vAST::Expression>> args;
         args.resize(entries.size());
         for (auto entry : entries) {
-          args[entry.index] = 
+          std::unique_ptr<vAST::Expression> verilog_conn =
               convert_to_expression(convert_to_verilog_connection(entry.source));
+          if (entry.metadata.count("filename") > 0) {
+            std::string debug_str = "Connection `(" + instance_name + "." + port.first + "[" +
+                std::to_string(entry.index) + "]" + ", " +
+                verilog_conn->toString() +")` created at " +
+                entry.metadata["filename"].get<std::string>();
+            if (entry.metadata.count("lineno") > 0) {
+              debug_str += ":" + entry.metadata["lineno"].get<std::string>();
+            }
+            body.push_back(std::make_unique<vAST::SingleLineComment>(debug_str));
+          }
+          args[entry.index] = std::move(verilog_conn);
         }
         std::reverse(args.begin(), args.end());
         std::unique_ptr<vAST::Concat> concat =
@@ -702,9 +755,18 @@ compile_module_body(RecordType *module_type,
             std::make_pair(port.first, std::move(concat)));
         // Otherwise we just use the entry in the connection map
       } else {
-        verilog_connections.insert(std::make_pair(
-            port.first,
-            convert_to_expression(convert_to_verilog_connection(entries[0].source))));
+        std::unique_ptr<vAST::Expression> verilog_conn =
+            convert_to_expression(convert_to_verilog_connection(entries[0].source));
+        if (entries[0].metadata.count("filename") > 0) {
+          std::string debug_str = "Connection `(" + instance_name + "." +
+              port.first + ", " + verilog_conn->toString() +")` created at " +
+              entries[0].metadata["filename"].get<std::string>();
+          if (entries[0].metadata.count("lineno") > 0) {
+            debug_str += ":" + entries[0].metadata["lineno"].get<std::string>();
+          }
+          body.push_back(std::make_unique<vAST::SingleLineComment>(debug_str));
+        }
+        verilog_connections.insert(std::make_pair(port.first, std::move(verilog_conn)));
       }
     }
     // Handle module arguments
@@ -764,7 +826,7 @@ compile_module_body(RecordType *module_type,
   }
   // Wire the outputs of the module and inout connections
   assign_module_outputs(module_type, body, connection_map);
-  assign_inouts(connections, body);
+  assign_inouts(definition->getSortedConnections(), body);
   return body;
 }
 
@@ -846,10 +908,7 @@ void Passes::Verilog::compileModule(Module *module) {
   ModuleDef *definition = module->getDef();
   std::vector<std::variant<std::unique_ptr<vAST::StructuralStatement>,
                            std::unique_ptr<vAST::Declaration>>>
-      body = compile_module_body(module->getType(),
-                                 definition->getSortedConnections(),
-                                 definition->getInstances(),
-                                 this->_inline);
+      body = compile_module_body(module->getType(), definition, this->_inline);
 
   if (module->getMetaData().count("filename") > 0) { 
     std::string debug_str = "Module `" + module->getName() + "` defined at " +

--- a/tests/gtest/debug_info.json
+++ b/tests/gtest/debug_info.json
@@ -2,6 +2,12 @@
 "namespaces":{
   "global":{
     "modules":{
+      "Term2":{
+        "type":["Record",[
+          ["I",["Array",2,"BitIn"]]
+        ]],
+        "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"90"}
+      },
       "And2":{
         "type":["Record",[
           ["I0","BitIn"],
@@ -13,9 +19,14 @@
       "main":{
         "type":["Record",[
           ["I",["Array",2,"BitIn"]],
-          ["O","Bit"]
+          ["O","Bit"],
+          ["O1",["Array",2,"Bit"]]
         ]],
         "instances":{
+          "term0":{
+            "modref":"global.Term2",
+            "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"77"}
+          },
           "and2_0":{
             "modref":"global.And2",
             "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"61"}
@@ -42,7 +53,11 @@
           ["self.I.1","and2_2.I1",{"filename":"tests/test_circuit/test_define.py","lineno":"67"}],
           ["and2_3.I0","and2_2.O",{"filename":"tests/test_circuit/test_define.py","lineno":"66"}],
           ["self.I.1","and2_3.I1",{"filename":"tests/test_circuit/test_define.py","lineno":"67"}],
-          ["self.O","and2_3.O",{"filename":"tests/test_circuit/test_define.py","lineno":"70"}]
+          ["self.O","and2_3.O",{"filename":"tests/test_circuit/test_define.py","lineno":"70"}],
+          ["self.O1.0","and2_2.O",{"filename":"tests/test_circuit/test_define.py","lineno":"77"}],
+          ["self.O1.1","and2_3.O",{"filename":"tests/test_circuit/test_define.py","lineno":"78"}],
+          ["term0.I.0","and2_3.O",{"filename":"tests/test_circuit/test_define.py","lineno":"99"}],
+          ["term0.I.1","and2_2.O",{"filename":"tests/test_circuit/test_define.py","lineno":"103"}]
         ],
         "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"57"}
       }

--- a/tests/gtest/debug_info.json
+++ b/tests/gtest/debug_info.json
@@ -1,0 +1,52 @@
+{"top":"global.main",
+"namespaces":{
+  "global":{
+    "modules":{
+      "And2":{
+        "type":["Record",[
+          ["I0","BitIn"],
+          ["I1","BitIn"],
+          ["O","Bit"]
+        ]],
+        "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"55"}
+      },
+      "main":{
+        "type":["Record",[
+          ["I",["Array",2,"BitIn"]],
+          ["O","Bit"]
+        ]],
+        "instances":{
+          "and2_0":{
+            "modref":"global.And2",
+            "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"61"}
+          },
+          "and2_1":{
+            "modref":"global.And2",
+            "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"61"}
+          },
+          "and2_2":{
+            "modref":"global.And2",
+            "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"61"}
+          },
+          "and2_3":{
+            "modref":"global.And2",
+            "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"61"}
+          }
+        },
+        "connections":[
+          ["self.I.0","and2_0.I0",{"filename":"tests/test_circuit/test_define.py","lineno":"63"}],
+          ["self.I.1","and2_0.I1",{"filename":"tests/test_circuit/test_define.py","lineno":"64"}],
+          ["and2_1.I0","and2_0.O",{"filename":"tests/test_circuit/test_define.py","lineno":"66"}],
+          ["self.I.1","and2_1.I1",{"filename":"tests/test_circuit/test_define.py","lineno":"67"}],
+          ["and2_2.I0","and2_1.O",{"filename":"tests/test_circuit/test_define.py","lineno":"66"}],
+          ["self.I.1","and2_2.I1",{"filename":"tests/test_circuit/test_define.py","lineno":"67"}],
+          ["and2_3.I0","and2_2.O",{"filename":"tests/test_circuit/test_define.py","lineno":"66"}],
+          ["self.I.1","and2_3.I1",{"filename":"tests/test_circuit/test_define.py","lineno":"67"}],
+          ["self.O","and2_3.O",{"filename":"tests/test_circuit/test_define.py","lineno":"70"}]
+        ],
+        "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"57"}
+      }
+    }
+  }
+}
+}

--- a/tests/gtest/debug_info_golden.v
+++ b/tests/gtest/debug_info_golden.v
@@ -1,0 +1,31 @@
+// Module `And2` defined externally
+module main (input [1:0] I, output O);
+// Module `main` defined at tests/test_circuit/test_define.py:57
+wire and2_0_O;
+wire and2_1_O;
+wire and2_2_O;
+wire and2_3_O;
+// Instanced at tests/test_circuit/test_define.py:61
+// Argument I0(I[0]) wired at tests/test_circuit/test_define.py:63
+// Argument I1(I[1]) wired at tests/test_circuit/test_define.py:64
+// Argument O(and2_0_O) wired at tests/test_circuit/test_define.py:66
+And2 and2_0 (.I0(I[0]), .I1(I[1]), .O(and2_0_O));
+// Instanced at tests/test_circuit/test_define.py:61
+// Argument I0(and2_0_O) wired at tests/test_circuit/test_define.py:66
+// Argument I1(I[1]) wired at tests/test_circuit/test_define.py:67
+// Argument O(and2_1_O) wired at tests/test_circuit/test_define.py:66
+And2 and2_1 (.I0(and2_0_O), .I1(I[1]), .O(and2_1_O));
+// Instanced at tests/test_circuit/test_define.py:61
+// Argument I0(and2_1_O) wired at tests/test_circuit/test_define.py:66
+// Argument I1(I[1]) wired at tests/test_circuit/test_define.py:67
+// Argument O(and2_2_O) wired at tests/test_circuit/test_define.py:66
+And2 and2_2 (.I0(and2_1_O), .I1(I[1]), .O(and2_2_O));
+// Instanced at tests/test_circuit/test_define.py:61
+// Argument I0(and2_2_O) wired at tests/test_circuit/test_define.py:66
+// Argument I1(I[1]) wired at tests/test_circuit/test_define.py:67
+// Argument O(and2_3_O) wired at tests/test_circuit/test_define.py:70
+And2 and2_3 (.I0(and2_2_O), .I1(I[1]), .O(and2_3_O));
+// Wired at tests/test_circuit/test_define.py:70
+assign O = and2_3_O;
+endmodule
+

--- a/tests/gtest/debug_info_golden.v
+++ b/tests/gtest/debug_info_golden.v
@@ -1,31 +1,35 @@
+// Module `Term2` defined externally
 // Module `And2` defined externally
-module main (input [1:0] I, output O);
+module main (input [1:0] I, output O, output [1:0] O1);
 // Module `main` defined at tests/test_circuit/test_define.py:57
 wire and2_0_O;
 wire and2_1_O;
 wire and2_2_O;
 wire and2_3_O;
-// Instanced at tests/test_circuit/test_define.py:61
-// Argument I0(I[0]) wired at tests/test_circuit/test_define.py:63
-// Argument I1(I[1]) wired at tests/test_circuit/test_define.py:64
-// Argument O(and2_0_O) wired at tests/test_circuit/test_define.py:66
-And2 and2_0 (.I0(I[0]), .I1(I[1]), .O(and2_0_O));
-// Instanced at tests/test_circuit/test_define.py:61
-// Argument I0(and2_0_O) wired at tests/test_circuit/test_define.py:66
-// Argument I1(I[1]) wired at tests/test_circuit/test_define.py:67
-// Argument O(and2_1_O) wired at tests/test_circuit/test_define.py:66
-And2 and2_1 (.I0(and2_0_O), .I1(I[1]), .O(and2_1_O));
-// Instanced at tests/test_circuit/test_define.py:61
-// Argument I0(and2_1_O) wired at tests/test_circuit/test_define.py:66
-// Argument I1(I[1]) wired at tests/test_circuit/test_define.py:67
-// Argument O(and2_2_O) wired at tests/test_circuit/test_define.py:66
-And2 and2_2 (.I0(and2_1_O), .I1(I[1]), .O(and2_2_O));
-// Instanced at tests/test_circuit/test_define.py:61
-// Argument I0(and2_2_O) wired at tests/test_circuit/test_define.py:66
-// Argument I1(I[1]) wired at tests/test_circuit/test_define.py:67
-// Argument O(and2_3_O) wired at tests/test_circuit/test_define.py:70
-And2 and2_3 (.I0(and2_2_O), .I1(I[1]), .O(and2_3_O));
-// Wired at tests/test_circuit/test_define.py:70
+// Instance `and2_0` created at tests/test_circuit/test_define.py:61
+// Connection `(and2_0.I0, I[0])` created at tests/test_circuit/test_define.py:63
+// Connection `(and2_0.I1, I[1])` created at tests/test_circuit/test_define.py:64
+And2 and2_0(.I0(I[0]), .I1(I[1]), .O(and2_0_O));
+// Instance `and2_1` created at tests/test_circuit/test_define.py:61
+// Connection `(and2_1.I0, and2_0_O)` created at tests/test_circuit/test_define.py:66
+// Connection `(and2_1.I1, I[1])` created at tests/test_circuit/test_define.py:67
+And2 and2_1(.I0(and2_0_O), .I1(I[1]), .O(and2_1_O));
+// Instance `and2_2` created at tests/test_circuit/test_define.py:61
+// Connection `(and2_2.I0, and2_1_O)` created at tests/test_circuit/test_define.py:66
+// Connection `(and2_2.I1, I[1])` created at tests/test_circuit/test_define.py:67
+And2 and2_2(.I0(and2_1_O), .I1(I[1]), .O(and2_2_O));
+// Instance `and2_3` created at tests/test_circuit/test_define.py:61
+// Connection `(and2_3.I0, and2_2_O)` created at tests/test_circuit/test_define.py:66
+// Connection `(and2_3.I1, I[1])` created at tests/test_circuit/test_define.py:67
+And2 and2_3(.I0(and2_2_O), .I1(I[1]), .O(and2_3_O));
+// Instance `term0` created at tests/test_circuit/test_define.py:77
+// Connection `(term0.I[1], and2_2_O)` created at tests/test_circuit/test_define.py:103
+// Connection `(term0.I[0], and2_3_O)` created at tests/test_circuit/test_define.py:99
+Term2 term0(.I({and2_2_O,and2_3_O}));
+// Connection `(O, and2_3_O)` created at tests/test_circuit/test_define.py:70
 assign O = and2_3_O;
+// Connection `(O1[0], and2_2_O)` created at tests/test_circuit/test_define.py:77
+// Connection `(O1[1], and2_3_O)` created at tests/test_circuit/test_define.py:78
+assign O1 = {and2_3_O,and2_2_O};
 endmodule
 

--- a/tests/gtest/test_verilog.cpp
+++ b/tests/gtest/test_verilog.cpp
@@ -185,6 +185,27 @@ TEST(VerilogTests, TestInlineVerilogMetadata) {
   deleteContext(c);
 }
 
+TEST(VerilogTests, TestDebugInfo) {
+  Context* c = newContext();
+  Module* top;
+
+  if (!loadFromFile(c, "debug_info.json", &top)) {
+    c->die();
+  }
+  assert(top != nullptr);
+  c->setTop(top->getRefName());
+
+  const std::vector<std::string> passes = {
+    "rungenerators",
+    "removebulkconnections",
+    "flattentypes",
+    "verilog"
+  };
+  c->runPasses(passes, {});
+  assertPassEq<Passes::Verilog>(c, "debug_info_golden.v");
+  deleteContext(c);
+}
+
 }  // namespace
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
This feature was dropped when migrating to the new verilogAST backend.

This PR adds the logic to code generate the filename/lineno metadata for module definitions, instances, and connections.