### PR TITLE
Unset corebit_term primitive expression lambda

### DIFF
--- a/include/coreir/definitions/corebitVerilog.hpp
+++ b/include/coreir/definitions/corebitVerilog.hpp
@@ -42,7 +42,6 @@ void CoreIRLoadVerilog_corebit(Context* c) {
       {"const",{"value",
         [](){ return vAST::make_id("value"); 
       }}},
-      {"term",{"", [](){ return nullptr; }}},
       {"tribuf",{"en ? in : 'hz",
           [](){ return std::make_unique<vAST::TernaryOp>(
                   vAST::make_id("en"),


### PR DESCRIPTION
term is being defined later on (see https://github.com/rdaly525/coreir/blob/e070dc0c57a964fd65ed8b46a10eb9916b54a49a/include/coreir/definitions/corebitVerilog.hpp#L128-L135) so it should not be a part of `vmap`.  The redefinition of term removes the primitive type because it overrides the `vjson`, but the expression lambda is still set from the earlier logic.  Term shouldn't be part of vmap because it's body doesn't match the `"assign ="` pattern used for the other primitives.