### PR TITLE
Add undriven primitive

### DIFF
--- a/include/coreir/definitions/coreVerilog.hpp
+++ b/include/coreir/definitions/coreVerilog.hpp
@@ -283,6 +283,7 @@ void CoreIRLoadVerilog_coreir(Context* c) {
     }},
     {"const",{"output [width-1:0] out"}},
     {"term",{"input [width-1:0] in"}},
+    {"undriven",{"output [width-1:0] out"}},
     {"tribuf",{
       "input [width-1:0] in",
       "input en",
@@ -345,6 +346,14 @@ void CoreIRLoadVerilog_coreir(Context* c) {
     vjson["interface"] = coreIMap["term"];
     vjson["definition"] = "";
     core->getGenerator("term")->getMetaData()["verilog"] = vjson;
+  }
+  {
+    //Undriven
+    json vjson;
+    vjson["prefix"] = "coreir_";
+    vjson["interface"] = coreIMap["undriven"];
+    vjson["definition"] = "";
+    core->getGenerator("undriven")->getMetaData()["verilog"] = vjson;
   }
   {
     json vjson;

--- a/include/coreir/definitions/coreVerilog.hpp
+++ b/include/coreir/definitions/coreVerilog.hpp
@@ -348,7 +348,7 @@ void CoreIRLoadVerilog_coreir(Context* c) {
     core->getGenerator("term")->getMetaData()["verilog"] = vjson;
   }
   {
-    //Undriven
+    // Undriven
     json vjson;
     vjson["prefix"] = "coreir_";
     vjson["interface"] = coreIMap["undriven"];

--- a/include/coreir/definitions/corebitVerilog.hpp
+++ b/include/coreir/definitions/corebitVerilog.hpp
@@ -78,6 +78,7 @@ void CoreIRLoadVerilog_corebit(Context* c) {
     }},
     {"const",{"output out"}},
     {"term",{"input in"}},
+    {"undriven",{"output out"}},
     {"tribuf",{
       "input in",
       "input en",
@@ -132,6 +133,14 @@ void CoreIRLoadVerilog_corebit(Context* c) {
     vjson["interface"] = bitIMap["term"];
     vjson["definition"] = "";
     bit->getModule("term")->getMetaData()["verilog"] = vjson;
+  }
+  {
+    //Undriven
+    json vjson;
+    vjson["prefix"] = "corebit_";
+    vjson["interface"] = bitIMap["undriven"];
+    vjson["definition"] = "";
+    bit->getModule("undriven")->getMetaData()["verilog"] = vjson;
   }
   {
     //reg

--- a/include/coreir/definitions/corebitVerilog.hpp
+++ b/include/coreir/definitions/corebitVerilog.hpp
@@ -135,7 +135,7 @@ void CoreIRLoadVerilog_corebit(Context* c) {
     bit->getModule("term")->getMetaData()["verilog"] = vjson;
   }
   {
-    //Undriven
+    // Undriven
     json vjson;
     vjson["prefix"] = "corebit_";
     vjson["interface"] = bitIMap["undriven"];

--- a/src/ir/headers/core.hpp
+++ b/src/ir/headers/core.hpp
@@ -409,7 +409,7 @@ Namespace* CoreIRLoadHeader_core(Context* c) {
   );
   core->newGeneratorDecl("term",core->getTypeGen("in"),widthparams);
 
-  //Add Undriven
+  // Add Undriven
   core->newTypeGen(
     "out",
     widthparams,

--- a/src/ir/headers/core.hpp
+++ b/src/ir/headers/core.hpp
@@ -409,6 +409,20 @@ Namespace* CoreIRLoadHeader_core(Context* c) {
   );
   core->newGeneratorDecl("term",core->getTypeGen("in"),widthparams);
 
+  //Add Undriven
+  core->newTypeGen(
+    "out",
+    widthparams,
+    [](Context* c, Values args) {
+      uint width = args.at("width")->get<int>();
+      Type* ptype = c->Bit()->Arr(width);
+      return c->Record({
+        {"out",ptype}
+      });
+    }
+  );
+  core->newGeneratorDecl("undriven",core->getTypeGen("out"),widthparams);
+
   /////////////////////////////////
   // Stdlib convert primitives
   //   slice,concat,cast,strip

--- a/src/ir/headers/corebit.hpp
+++ b/src/ir/headers/corebit.hpp
@@ -49,6 +49,7 @@ Namespace* CoreIRLoadHeader_corebit(Context* c) {
   //Const and Term
   bitop->newModuleDecl("const",c->Record({{"out",c->Bit()}}),{{"value",c->Bool()}});
   bitop->newModuleDecl("term",c->Record({{"in",c->BitIn()}}));
+  bitop->newModuleDecl("undriven",c->Record({{"out",c->Bit()}}));
 
 
 

--- a/tests/gtest/test_verilog.cpp
+++ b/tests/gtest/test_verilog.cpp
@@ -246,7 +246,7 @@ TEST(VerilogTests, TestUndriven) {
     "rungenerators",
     "removebulkconnections",
     "flattentypes",
-    "verilog"
+    "verilog --inline"
   };
   c->runPasses(passes, {});
   assertPassEq<Passes::Verilog>(c, "undriven_golden.v");

--- a/tests/gtest/test_verilog.cpp
+++ b/tests/gtest/test_verilog.cpp
@@ -230,6 +230,29 @@ TEST(VerilogTests, TestRegisterMode) {
   deleteContext(c);
 }
 
+TEST(VerilogTests, TestUndriven) {
+  Context* c = newContext();
+  CoreIRLoadVerilog_coreir(c);
+  CoreIRLoadVerilog_corebit(c);
+  Module* top;
+
+  if (!loadFromFile(c, "undriven.json", &top)) {
+    c->die();
+  }
+  assert(top != nullptr);
+  c->setTop(top->getRefName());
+
+  const std::vector<std::string> passes = {
+    "rungenerators",
+    "removebulkconnections",
+    "flattentypes",
+    "verilog"
+  };
+  c->runPasses(passes, {});
+  assertPassEq<Passes::Verilog>(c, "undriven_golden.v");
+  deleteContext(c);
+}
+
 }  // namespace
 
 int main(int argc, char **argv) {

--- a/tests/gtest/undriven.json
+++ b/tests/gtest/undriven.json
@@ -1,0 +1,27 @@
+{"top":"global.Top",
+"namespaces":{
+  "global":{
+    "modules":{
+      "Top":{
+        "type":["Record",[
+          ["O0","Bit"],
+          ["O1",["Array",8,"Bit"]]
+        ]],
+        "instances":{
+          "inst0":{
+            "modref":"corebit.undriven"
+          },
+          "inst1":{
+            "genref":"coreir.undriven",
+            "genargs":{"width":["Int",8]}
+          }
+        },
+        "connections":[
+          ["self.O0","inst0.out"],
+          ["self.O1","inst1.out"]
+        ]
+      }
+    }
+  }
+}
+}

--- a/tests/gtest/undriven_golden.v
+++ b/tests/gtest/undriven_golden.v
@@ -1,0 +1,13 @@
+module coreir_undriven #(parameter width = 1) (output [width-1:0] out);
+
+endmodule
+
+module corebit_undriven (output out);
+
+endmodule
+
+module Top (output O0, output [7:0] O1);
+corebit_undriven inst0(.out(O0));
+coreir_undriven #(.width(8)) inst1(.out(O1));
+endmodule
+


### PR DESCRIPTION
Counterpart to `Term` which allows the user to explicitly specify a port is undriven (useful for formal verification tools where an undriven port is used to represent a value that can take on any value supplied by the tool).