### PR TITLE
Use connection mapping for inline values

### DIFF
--- a/CMakeLists.txt.in
+++ b/CMakeLists.txt.in
@@ -7,7 +7,7 @@ project(verilogAST-download NONE)
 include(ExternalProject)
 ExternalProject_Add(verilogAST
   GIT_REPOSITORY    https://github.com/leonardt/verilogAST-cpp.git
-  GIT_TAG           inline-verilog-symbol-map
+  GIT_TAG           master
   SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/verilogAST-src"
   BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/verilogAST-build"
   CONFIGURE_COMMAND ""

--- a/CMakeLists.txt.in
+++ b/CMakeLists.txt.in
@@ -7,7 +7,7 @@ project(verilogAST-download NONE)
 include(ExternalProject)
 ExternalProject_Add(verilogAST
   GIT_REPOSITORY    https://github.com/leonardt/verilogAST-cpp.git
-  GIT_TAG           master
+  GIT_TAG           inline-verilog-symbol-map
   SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/verilogAST-src"
   BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/verilogAST-build"
   CONFIGURE_COMMAND ""

--- a/src/passes/analysis/verilog.cpp
+++ b/src/passes/analysis/verilog.cpp
@@ -1028,6 +1028,7 @@ void Passes::Verilog::compileModule(Module *module) {
   // Temporary support for inline verilog
   // See https://github.com/rdaly525/coreir/pull/823 for context
   json metadata = module->getMetaData();
+  std::vector<std::pair<std::string, std::unique_ptr<vAST::Expression>>> interpolated_symbols;
   if (metadata.count("inline_verilog") > 0) {
       json inline_verilog = metadata["inline_verilog"];
       std::string inline_str = inline_verilog["str"].get<std::string>();
@@ -1047,14 +1048,13 @@ void Passes::Verilog::compileModule(Module *module) {
                   it.key() + " -- " + connect_select_path +
                   " , orig =" + it.value().get<std::string>());
           }
-          std::string value = std::visit(
-              [](auto &&value) -> std::string { return value->toString(); },
-              convert_to_verilog_connection(
-                  module->getDef()->sel(connect_select_path), this->_inline));
-          inline_str = std::regex_replace(
-              inline_str, std::regex("\\{" + it.key() + "\\}"), value);
+          interpolated_symbols.push_back(std::make_pair(
+              it.key(),
+              convert_to_expression(convert_to_verilog_connection(
+                  module->getDef()->sel(connect_select_path), this->_inline))));
       }
-      body.push_back(std::make_unique<vAST::InlineVerilog>(inline_str));
+      body.push_back(std::make_unique<vAST::InlineVerilog>(inline_str,
+                  std::move(interpolated_symbols)));
   }
 
   vAST::Parameters parameters = compile_params(module);

--- a/src/passes/analysis/verilog.cpp
+++ b/src/passes/analysis/verilog.cpp
@@ -1053,8 +1053,8 @@ void Passes::Verilog::compileModule(Module *module) {
               convert_to_expression(convert_to_verilog_connection(
                   module->getDef()->sel(connect_select_path), this->_inline))));
       }
-      body.push_back(std::make_unique<vAST::InlineVerilog>(inline_str,
-                  std::move(interpolated_symbols)));
+      body.push_back(std::make_unique<vAST::InlineVerilog>(
+          inline_str, std::move(interpolated_symbols)));
   }
 
   vAST::Parameters parameters = compile_params(module);

--- a/src/passes/analysis/verilog.cpp
+++ b/src/passes/analysis/verilog.cpp
@@ -1053,8 +1053,8 @@ void Passes::Verilog::compileModule(Module *module) {
               convert_to_expression(convert_to_verilog_connection(
                   module->getDef()->sel(connect_select_path), this->_inline))));
       }
-      body.push_back(std::make_unique<vAST::InlineVerilog>(
-          inline_str, std::move(interpolated_symbols)));
+      body.push_back(std::make_unique<vAST::InlineVerilog>(inline_str,
+                  std::move(interpolated_symbols)));
   }
 
   vAST::Parameters parameters = compile_params(module);

--- a/src/passes/transform/flattentypes.cpp
+++ b/src/passes/transform/flattentypes.cpp
@@ -72,6 +72,8 @@ bool Passes::FlattenTypes::runOnInstanceGraphNode(InstanceGraphNode& node) {
   //Early out if no new ports
   if (ports.size()==0) return false;
 
+  json symbol_table = json::object();
+
   //Create a list of new names for the ports
   vector<std::pair<string,Type*>> newports;
   unordered_set<string> verifyUnique;
@@ -80,7 +82,10 @@ bool Passes::FlattenTypes::runOnInstanceGraphNode(InstanceGraphNode& node) {
     ASSERT(verifyUnique.count(newport)==0,"NYI: Name clashes");
     newports.push_back({newport,portpair.second});
     verifyUnique.insert(newport);
+    symbol_table["self." + toString(portpair.first)] = "self." + newport;
   }
+
+  mod->getMetaData()["symbol_table"] = symbol_table;
 
   //Append new ports to this module (should not affect any connections)
   for (auto newportpair : newports) {

--- a/src/passes/transform/flattentypes.cpp
+++ b/src/passes/transform/flattentypes.cpp
@@ -72,7 +72,12 @@ bool Passes::FlattenTypes::runOnInstanceGraphNode(InstanceGraphNode& node) {
   //Early out if no new ports
   if (ports.size()==0) return false;
 
-  json symbol_table = json::object();
+  json symbol_table;
+  if (!mod->getMetaData().count("symbol_table")) {
+    symbol_table = json::object();
+  } else {
+    symbol_table = mod->getMetaData()["symbol_table"];
+  }
 
   //Create a list of new names for the ports
   vector<std::pair<string,Type*>> newports;

--- a/tests/gtest/inline_verilog.json
+++ b/tests/gtest/inline_verilog.json
@@ -8,12 +8,13 @@
           ["O","Bit"],
           ["CLK",["Named","coreir.clkIn"]]
         ]],
-        "metadata":{"verilog":{"verilog_string":"module FF(input I, output O, input CLK);\nalways @(posedge CLK) begin\n  O <= I;\nend\nendmodule"}}
+        "metadata":{"verilog":{"verilog_string":"module FF(input I, output reg O, input CLK);\nalways @(posedge CLK) begin\n  O <= I;\nend\nendmodule"}}
       },
       "Main":{
         "type":["Record",[
           ["I","BitIn"],
           ["O","Bit"],
+          ["arr",["Array",2,"BitIn"]],
           ["CLK",["Named","coreir.clkIn"]]
         ]],
         "instances":{
@@ -26,7 +27,7 @@
           ["self.I","FF_inst0.I"],
           ["self.O","FF_inst0.O"]
         ],
-        "metadata":{"inline_verilog":"\nassert property { @(posedge CLK) I |-> ##1 O };\n"}
+        "metadata":{"inline_verilog":{"connect_references":{"__magma_inline_value_1":"self.arr.0","__magma_inline_value_2":"self.arr.1"},"str":"\nassert property (@(posedge CLK) I |-> ##1 O);\n\n\n\nassert property (@(posedge CLK) {__magma_inline_value_1} |-> ##1 {__magma_inline_value_2});\n"}}
       }
     }
   }

--- a/tests/gtest/inline_verilog_golden.v
+++ b/tests/gtest/inline_verilog_golden.v
@@ -1,4 +1,4 @@
-module FF(input I, output O, input CLK);
+module FF(input I, output reg O, input CLK);
 always @(posedge CLK) begin
   O <= I;
 end
@@ -6,6 +6,7 @@ endmodule
 module Main (
     input I,
     output O,
+    input [1:0] arr,
     input CLK
 );
 FF FF_inst0 (
@@ -14,7 +15,11 @@ FF FF_inst0 (
     .CLK(CLK)
 );
 
-assert property { @(posedge CLK) I |-> ##1 O };
+assert property (@(posedge CLK) I |-> ##1 O);
+
+
+
+assert property (@(posedge CLK) arr[0] |-> ##1 arr[1]);
 
 endmodule
 

--- a/tests/gtest/inline_verilog_top.json
+++ b/tests/gtest/inline_verilog_top.json
@@ -1,8 +1,8 @@
-{"top":"global.Monitor",
+{"top":"global.RTLMonitor",
 "namespaces":{
   "global":{
     "modules":{
-      "Monitor":{
+      "RTLMonitor":{
         "type":["Record",[
           ["CLK",["Named","coreir.clkIn"]],
           ["in1",["Array",4,"BitIn"]],
@@ -14,7 +14,43 @@
           ["mon_temp2","BitIn"],
           ["intermediate_tuple",["Record",[["_0","BitIn"],["_1","BitIn"]]]]
         ]],
-        "metadata":{"inline_verilog":"\n                        logic temp1, temp2;\n                        assign temp1 = |(in1);\n                        assign temp2 = &(in1);\n                        assert property (@(posedge CLK) handshake_valid -> out === temp1 && temp2);\n                    "}
+        "instances":{
+          "arr_2d_0":{
+            "genref":"coreir.wire",
+            "genargs":{"width":["Int",4]}
+          },
+          "arr_2d_1":{
+            "genref":"coreir.wire",
+            "genargs":{"width":["Int",4]}
+          },
+          "corebit_term_inst0":{
+            "modref":"corebit.term"
+          },
+          "corebit_term_inst1":{
+            "modref":"corebit.term"
+          },
+          "corebit_term_inst2":{
+            "modref":"corebit.term"
+          },
+          "term_inst0":{
+            "genref":"coreir.term",
+            "genargs":{"width":["Int",4]}
+          },
+          "term_inst1":{
+            "genref":"coreir.term",
+            "genargs":{"width":["Int",4]}
+          }
+        },
+        "connections":[
+          ["self.in1","arr_2d_0.in"],
+          ["term_inst0.in","arr_2d_0.out"],
+          ["corebit_term_inst1.in","arr_2d_0.out.1"],
+          ["self.in2","arr_2d_1.in"],
+          ["term_inst1.in","arr_2d_1.out"],
+          ["self.intermediate_tuple._0","corebit_term_inst0.in"],
+          ["self.handshake.valid","corebit_term_inst2.in"]
+        ],
+        "metadata":{"inline_verilog":{"connect_references":{"__magma_inline_value_1":"self.intermediate_tuple._0","__magma_inline_value_2":"arr_2d_0.out.1","__magma_inline_value_3":"arr_2d_1.out","__magma_inline_value_4":"arr_2d_0.out","__magma_inline_value_5":"self.handshake.valid"},"str":"\nlogic temp1, temp2;\nlogic temp3;\nassign temp1 = |(in1);\nassign temp2 = &(in1) & {__magma_inline_value_1};\nassign temp3 = temp1 ^ temp2 & {__magma_inline_value_2};\nassert property (@(posedge CLK) {__magma_inline_value_5} -> out === temp1 && temp2);\nlogic [3:0] temp4 [1:0];\nassign temp4 = '{{__magma_inline_value_3}, {__magma_inline_value_4}};\n                                   "}}
       }
     }
   }

--- a/tests/gtest/inline_verilog_top_golden.v
+++ b/tests/gtest/inline_verilog_top_golden.v
@@ -1,4 +1,18 @@
-module Monitor (
+module coreir_term #(
+    parameter width = 1
+) (
+    input [width-1:0] in
+);
+
+endmodule
+
+module corebit_term (
+    input in
+);
+
+endmodule
+
+module RTLMonitor (
     input CLK,
     input handshake_arr_0_ready,
     input handshake_arr_0_valid,
@@ -16,11 +30,38 @@ module Monitor (
     input mon_temp2,
     input out
 );
+wire [3:0] arr_2d_0;
+wire [3:0] arr_2d_1;
+assign arr_2d_0 = in1;
+assign arr_2d_1 = in2;
+corebit_term corebit_term_inst0 (
+    .in(intermediate_tuple__0)
+);
+corebit_term corebit_term_inst1 (
+    .in(arr_2d_0[1])
+);
+corebit_term corebit_term_inst2 (
+    .in(handshake_valid)
+);
+coreir_term #(
+    .width(4)
+) term_inst0 (
+    .in(arr_2d_0)
+);
+coreir_term #(
+    .width(4)
+) term_inst1 (
+    .in(arr_2d_1)
+);
 
-                        logic temp1, temp2;
-                        assign temp1 = |(in1);
-                        assign temp2 = &(in1);
-                        assert property (@(posedge CLK) handshake_valid -> out === temp1 && temp2);
-                    
+logic temp1, temp2;
+logic temp3;
+assign temp1 = |(in1);
+assign temp2 = &(in1) & intermediate_tuple__0;
+assign temp3 = temp1 ^ temp2 & arr_2d_0[1];
+assert property (@(posedge CLK) handshake_valid -> out === temp1 && temp2);
+logic [3:0] temp4 [1:0];
+assign temp4 = '{arr_2d_1, arr_2d_0};
+                                   
 endmodule
 


### PR DESCRIPTION
This augments the inline_verilog feature to accept a mapping of symbols to connections (select paths) that coreir will handle the replacement of.  The goal of this was to have coreir manage the names of the final verilog values, rather than having magma guess them up front.  For this initial implementation, I tested this on the flatten types pass logic by introducing a new object "symbol_table" in the metadata that tracks a mapping from unflattened names to flattened names.  This allows the verilog backend to interpolate the flattened names in the final inline verilog.

In the future we can look into building a more robust symbol table implementation, but for now this logic is so simple that just using the JSON seems reasonable enough.  One option would be to build an API wrapper around the json representation, which has the value of being able to serialize the symbol table for intermediate stages (e.g. run coreir to produce new coreir, with the original symbol table mapping, that could then be used by a future pass of coreir).  An alternative is to have an in-memory data structure for the symbol table (we could then define serialize/deserialize logic for this to achieve the same feature for multiple coreir stages).

The main interface change is that `inline_verilog` metadata is now an object with two fields:
1) "str" corresponds to the inline verilog string that may contain symbols using Python's format string syntax, e.g. `{_special_name_to_be_filled_in_by_coreir}`
2) "connect_references" is an object that maps these symbols to a correspond select path, e.g. `"_special_name_to_be_filled_in_by_coreir": "self.I0.tuple_field.arr.0.2"`.

In the backend, the verilog code generator looks up the connection reference, checks the symbol table for a mapping (following chained mappings, in case multiple passes rename symbols), and replaces the reference name in the verilog string with the final verilog name.