### PR TITLE
Hotifx cansel instance

### DIFF
--- a/src/ir/inline.cpp
+++ b/src/ir/inline.cpp
@@ -91,7 +91,9 @@ void PTTraverse(ModuleDef* def, Wireable* from, Wireable* to) {
     def->disconnect(from,other);
   }
   for (auto sels : from->getSelects()) {
-    PTTraverse(def,sels.second,to->sel(sels.first));
+    if (!isa<InstanceSelect>(sels.second)) {
+      PTTraverse(def,sels.second,to->sel(sels.first));
+    }
   }
 }
 }

--- a/src/ir/moduledef.cpp
+++ b/src/ir/moduledef.cpp
@@ -112,11 +112,11 @@ bool ModuleDef::canSel(SelectPath path) {
   if (this->instances.count(inst_name) == 0) {
     return false;
   };
-  Instance* inst = this->instances[inst_name];
   if (path.size() == 0) {
+    // Nothing left to select, instance exists
     return true;
   }
-  return inst->canSel(path);
+  return this->instances[inst_name]->canSel(path);
 }
 
 

--- a/src/ir/moduledef.cpp
+++ b/src/ir/moduledef.cpp
@@ -112,7 +112,11 @@ bool ModuleDef::canSel(SelectPath path) {
   if (this->instances.count(inst_name) == 0) {
         return false;
   };
-  return this->instances[inst_name]->canSel(path);
+  Instance* inst = this->instances[inst_name];
+  if (path.size() == 0) {
+      return true;
+  }
+  return inst->canSel(path);
 }
 
 

--- a/src/ir/moduledef.cpp
+++ b/src/ir/moduledef.cpp
@@ -98,23 +98,23 @@ bool ModuleDef::canSel(const std::string& selstr) {
 bool ModuleDef::canSel(SelectPath path) {
   string inst_name = path[0];
   if (hasChar(inst_name, ';')) {
-      // Hierarchical reference, pop off first instance name from string
-      inst_name = splitString<SelectPath>(inst_name, ';')[0];
-      // Preserves ; as prefix so instance knows it's a hierarchical rather
-      // than port select
-      path[0] = path[0].substr(inst_name.length());
+    // Hierarchical reference, pop off first instance name from string
+    inst_name = splitString<SelectPath>(inst_name, ';')[0];
+    // Preserves ; as prefix so instance knows it's a hierarchical rather
+    // than port select
+    path[0] = path[0].substr(inst_name.length());
   } else {
-      path.pop_front();
+    path.pop_front();
   }
   if (inst_name=="self") {
     return this->interface->canSel(path);
   }
   if (this->instances.count(inst_name) == 0) {
-        return false;
+    return false;
   };
   Instance* inst = this->instances[inst_name];
   if (path.size() == 0) {
-      return true;
+    return true;
   }
   return inst->canSel(path);
 }


### PR DESCRIPTION
Fixes a bug where canSel fails trying to select an instance (with no subsequent port).  In this case, it should just check whether the instance exists, rather than trying to select an empty select string on the instance.