### PR TITLE
preserve inline verilog ordering

### DIFF
--- a/src/passes/analysis/verilog.cpp
+++ b/src/passes/analysis/verilog.cpp
@@ -814,6 +814,10 @@ compile_module_body(RecordType *module_type,
                     bool _inline, std::set<std::string> &wires) {
   std::map<std::string, Instance *> instances = definition->getInstances();
 
+  std::vector<
+      std::pair<std::string, std::unique_ptr<vAST::StructuralStatement>>>
+      inline_verilog_body;
+
   std::vector<std::variant<std::unique_ptr<vAST::StructuralStatement>,
                            std::unique_ptr<vAST::Declaration>>>
       body = declare_connections(instances, _inline);
@@ -945,7 +949,9 @@ compile_module_body(RecordType *module_type,
               inline_str = std::regex_replace(
                   inline_str, std::regex("\\{" + it.key() + "\\}"), value);
           }
-          body.push_back(std::make_unique<vAST::InlineVerilog>(inline_str));
+          inline_verilog_body.push_back(std::make_pair(
+              instance_name,
+              std::make_unique<vAST::InlineVerilog>(inline_str)));
       }
       // no statement to push
       continue;
@@ -961,6 +967,13 @@ compile_module_body(RecordType *module_type,
   // much (e.g. _inline flag)
   assign_module_outputs(module_type, body, connection_map, _inline);
   assign_inouts(definition->getSortedConnections(), body, _inline);
+
+  // Sort inline verilog by instance name (so ordering is preserved) and append
+  // to body
+  sort(inline_verilog_body.begin(), inline_verilog_body.end());
+  for (auto &&it : inline_verilog_body) {
+      body.push_back(std::move(it.second));
+  }
   return body;
 }
 

--- a/tests/gtest/inline_verilog_golden.v
+++ b/tests/gtest/inline_verilog_golden.v
@@ -21,15 +21,15 @@ FF FF_inst0 (
     .O(O),
     .CLK(CLK)
 );
+assign _magma_inline_wire0 = O;
+corebit_term corebit_term_inst0 (
+    .in(_magma_inline_wire0)
+);
 
 assert property (@(posedge CLK) I |-> ##1 _magma_inline_wire0);
 
 
 assert property (@(posedge CLK) arr[0] |-> ##1 arr[1]);
 
-assign _magma_inline_wire0 = O;
-corebit_term corebit_term_inst0 (
-    .in(_magma_inline_wire0)
-);
 endmodule
 

--- a/tests/gtest/inline_verilog_top_golden.v
+++ b/tests/gtest/inline_verilog_top_golden.v
@@ -42,16 +42,6 @@ wire [3:0] _magma_inline_wire1;
 wire [3:0] _magma_inline_wire2;
 wire [3:0] arr_2d_0;
 wire [3:0] arr_2d_1;
-
-logic temp1, temp2;
-logic temp3;
-assign temp1 = |(in1);
-assign temp2 = &(in1) & intermediate_tuple__0;
-assign temp3 = temp1 ^ temp2 & _magma_inline_wire0;
-assert property (@(posedge CLK) handshake_valid -> out === temp1 && temp2);
-logic [3:0] temp4 [1:0];
-assign temp4 = '{_magma_inline_wire1, _magma_inline_wire2};
-                                   
 assign _magma_inline_wire0 = arr_2d_0[1];
 assign _magma_inline_wire1 = arr_2d_1;
 assign _magma_inline_wire2 = arr_2d_0;
@@ -70,5 +60,15 @@ coreir_term #(
 ) term_inst1 (
     .in(_magma_inline_wire2)
 );
+
+logic temp1, temp2;
+logic temp3;
+assign temp1 = |(in1);
+assign temp2 = &(in1) & intermediate_tuple__0;
+assign temp3 = temp1 ^ temp2 & _magma_inline_wire0;
+assert property (@(posedge CLK) handshake_valid -> out === temp1 && temp2);
+logic [3:0] temp4 [1:0];
+assign temp4 = '{_magma_inline_wire1, _magma_inline_wire2};
+                                   
 endmodule
 


### PR DESCRIPTION
First, we move inline verilog to the end of the module, as it was done before.  This simplifies regression tests for existing code and shouldn't affect any new code.

Next, we sort the inline verilog strings by the instance name, this allows us to preserve the original order of the code generator (since it generates instances names in order).  The reason for this is there is existing code that relies on the order in which inline verilog nodes are code generated (For example, one inline verilog node opens an if def, then subsequent ones insert code, and a final node closes the ifdef).  Since coreir instances are a generic graph that don't have a notion of ordering, and because we code generate by tracing from outputs, this seems like the simplest way to preserve the ordering.  When we move to more explicit verification nodes in the graph, this won't be an issue since they should be self contained, but the existing inline verilog code relies on this ordering behavior.