### PR TITLE
Resolve extremely occasional inout codegen ordering problem

### DIFF
--- a/include/coreir/ir/common.h
+++ b/include/coreir/ir/common.h
@@ -97,6 +97,9 @@ static std::map<std::string, std::set<std::string>> coreMap({
 
 void mergeValues(Values& v0, Values v1);
 
+// Compare select paths
+bool SPComp(const SelectPath& l, const SelectPath& r);
+
 }  // namespace CoreIR
 
 #endif

--- a/tests/gtest/intermediate_connection_golden.v
+++ b/tests/gtest/intermediate_connection_golden.v
@@ -23,7 +23,7 @@ foo inst1 (
     .O(O)
 );
 assign inst0_IO = inst1_IO;
-assign IO0 = inst0_IO;
+assign inst0_IO = IO0;
 assign inst0_IO = IO1;
 endmodule
 

--- a/tests/gtest/test_verilog.cpp
+++ b/tests/gtest/test_verilog.cpp
@@ -27,22 +27,20 @@ TEST(VerilogTests, TestStringModule) {
 }
 
 TEST(VerilogTests, TestIntermediateConnection) {
-  for (int i = 0; i < 15; i++) {
-    Context* c = newContext();
-    Module* top;
+  Context* c = newContext();
+  Module* top;
 
-    if (!loadFromFile(c, "intermediate_connection.json", &top)) { c->die(); }
-    assert(top != nullptr);
-    c->setTop(top->getRefName());
+  if (!loadFromFile(c, "intermediate_connection.json", &top)) { c->die(); }
+  assert(top != nullptr);
+  c->setTop(top->getRefName());
 
-    const std::vector<std::string> passes = {"rungenerators",
-                                             "removebulkconnections",
-                                             "flattentypes",
-                                             "verilog --inline"};
-    c->runPasses(passes, {});
-    assertPassEq<Passes::Verilog>(c, "intermediate_connection_golden.v");
-    deleteContext(c);
-  }
+  const std::vector<std::string> passes = {"rungenerators",
+                                           "removebulkconnections",
+                                           "flattentypes",
+                                           "verilog --inline"};
+  c->runPasses(passes, {});
+  assertPassEq<Passes::Verilog>(c, "intermediate_connection_golden.v");
+  deleteContext(c);
 }
 
 TEST(VerilogTests, TestArraySelect) {

--- a/tests/gtest/test_verilog.cpp
+++ b/tests/gtest/test_verilog.cpp
@@ -27,20 +27,22 @@ TEST(VerilogTests, TestStringModule) {
 }
 
 TEST(VerilogTests, TestIntermediateConnection) {
-  Context* c = newContext();
-  Module* top;
+  for (int i = 0; i < 15; i++) {
+    Context* c = newContext();
+    Module* top;
 
-  if (!loadFromFile(c, "intermediate_connection.json", &top)) { c->die(); }
-  assert(top != nullptr);
-  c->setTop(top->getRefName());
+    if (!loadFromFile(c, "intermediate_connection.json", &top)) { c->die(); }
+    assert(top != nullptr);
+    c->setTop(top->getRefName());
 
-  const std::vector<std::string> passes = {"rungenerators",
-                                           "removebulkconnections",
-                                           "flattentypes",
-                                           "verilog --inline"};
-  c->runPasses(passes, {});
-  assertPassEq<Passes::Verilog>(c, "intermediate_connection_golden.v");
-  deleteContext(c);
+    const std::vector<std::string> passes = {"rungenerators",
+                                             "removebulkconnections",
+                                             "flattentypes",
+                                             "verilog --inline"};
+    c->runPasses(passes, {});
+    assertPassEq<Passes::Verilog>(c, "intermediate_connection_golden.v");
+    deleteContext(c);
+  }
 }
 
 TEST(VerilogTests, TestArraySelect) {


### PR DESCRIPTION
CoreIR does not assume that connections are deterministically ordered (i.e. conn.first and conn.second do not always match the JSON).  This resulted in the very occasional test failures for the inout code generation logic (which assumed this was always a deterministic relationship).  This adds a fix to make sure the output is deterministic.

I was able to consistently reproduce the issue with 15 test runs of the intermediate connection test: https://github.com/rdaly525/coreir/commit/434163e44f2b3f4878c8326380399d8721928500
verified it resolved the issue with the same test setup: https://github.com/rdaly525/coreir/commit/eec74dca23169e5189e2f338163de5ea9d35ad20
then i removed the repeated tests so our test suite doesn't take too long: https://github.com/rdaly525/coreir/commit/c4542de32bcc6a9263d15b5d3ef150290e7181ea