### PR TITLE
Isolate primitives

### DIFF
--- a/include/coreir/ir/common.h
+++ b/include/coreir/ir/common.h
@@ -98,19 +98,23 @@ static std::map<std::string, std::set<std::string>> coreMap({
 void mergeValues(Values& v0, Values v1);
 
 template <typename ContainerT, typename PredicateT>
-ContainerT filterOver(const ContainerT &container, PredicateT predicate) {
+ContainerT filterOver(const ContainerT& container, PredicateT predicate) {
   ContainerT result;
-  std::copy_if(container.begin(), container.end(), std::inserter(result, result.end()), predicate);
+  std::copy_if(
+    container.begin(),
+    container.end(),
+    std::inserter(result, result.end()),
+    predicate);
   return result;
 }
 
 template <typename ContainerT, typename PredicateT>
-bool anyOf(const ContainerT &container, PredicateT predicate) {
+bool anyOf(const ContainerT& container, PredicateT predicate) {
   return std::any_of(container.begin(), container.end(), predicate);
 }
 
 template <typename ContainerT, typename PredicateT>
-bool allOf(const ContainerT &container, PredicateT predicate) {
+bool allOf(const ContainerT& container, PredicateT predicate) {
   return std::all_of(container.begin(), container.end(), predicate);
 }
 

--- a/include/coreir/ir/common.h
+++ b/include/coreir/ir/common.h
@@ -97,6 +97,23 @@ static std::map<std::string, std::set<std::string>> coreMap({
 
 void mergeValues(Values& v0, Values v1);
 
+template <typename ContainerT, typename PredicateT>
+ContainerT filterOver(const ContainerT &container, PredicateT predicate) {
+  ContainerT result;
+  std::copy_if(container.begin(), container.end(), std::inserter(result, result.end()), predicate);
+  return result;
+}
+
+template <typename ContainerT, typename PredicateT>
+bool anyOf(const ContainerT &container, PredicateT predicate) {
+  return std::any_of(container.begin(), container.end(), predicate);
+}
+
+template <typename ContainerT, typename PredicateT>
+bool allOf(const ContainerT &container, PredicateT predicate) {
+  return std::all_of(container.begin(), container.end(), predicate);
+}
+
 // Compare select paths
 bool SPComp(const SelectPath& l, const SelectPath& r);
 

--- a/include/coreir/ir/fwd_declare.h
+++ b/include/coreir/ir/fwd_declare.h
@@ -14,6 +14,9 @@
 
 #include <execinfo.h>
 
+#define UNUSED(var)                                                            \
+  do { (void)(var); } while (0)
+
 #define ASSERT(C, MSG)                                                         \
   do {                                                                         \
     if (!(C)) {                                                                \

--- a/include/coreir/passes/common.h
+++ b/include/coreir/passes/common.h
@@ -46,6 +46,7 @@
 #include "transform/unresolvedsymbols.h"
 #include "transform/wireclocks.h"
 
+#include "coreir/passes/transform/isolate_primitives.h"
 #include "transform/adddirected.h"
 #include "transform/clock_gate.h"
 #include "transform/inline_single_instances.h"
@@ -105,6 +106,7 @@ void initializePasses(PassManager& pm) {
   pm.addPass(new Passes::MarkDirty());
   pm.addPass(new Passes::InlineSingleInstances());
   pm.addPass(new Passes::ClockGate());
+  pm.addPass(new Passes::IsolatePrimitives());
 }
 }  // namespace CoreIR
 

--- a/include/coreir/passes/transform/isolate_primitives.h
+++ b/include/coreir/passes/transform/isolate_primitives.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "coreir.h"
+
+namespace CoreIR {
+namespace Passes {
+
+class IsolatePrimitives : public ModulePass {
+ public:
+  static std::string ID;
+  IsolatePrimitives()
+      : ModulePass(
+          ID,
+          "Isolates all coreir/corebit primitives into its own module", false) {}
+  bool runOnModule(Module* m) override;
+};
+}  // namespace Passes
+}  // namespace CoreIR

--- a/include/coreir/passes/transform/isolate_primitives.h
+++ b/include/coreir/passes/transform/isolate_primitives.h
@@ -11,7 +11,8 @@ class IsolatePrimitives : public ModulePass {
   IsolatePrimitives()
       : ModulePass(
           ID,
-          "Isolates all coreir/corebit primitives into its own module", false) {}
+          "Isolates all coreir/corebit primitives into its own module",
+          false) {}
   bool runOnModule(Module* m) override;
 };
 }  // namespace Passes

--- a/src/ir/passmanager.cpp
+++ b/src/ir/passmanager.cpp
@@ -46,8 +46,8 @@ bool PassManager::runModulePass(Pass* pass) {
   // create static list of modules in case new modules are added in the pass
   for (auto ns : this->nss) { modMap[ns] = ns->getModules(); }
 
-  for (auto const& [ns, modules] : modMap) {
-    for (auto const& [mname, m] : modules) {
+  for (auto const& [_, modules] : modMap) {
+    for (auto const& [_, m] : modules) {
       if (m->hasDef()) { modified |= mpass->runOnModule(m); }
     }
   }

--- a/src/ir/passmanager.cpp
+++ b/src/ir/passmanager.cpp
@@ -42,9 +42,12 @@ bool PassManager::runContextPass(Pass* pass) {
 bool PassManager::runModulePass(Pass* pass) {
   bool modified = false;
   ModulePass* mpass = cast<ModulePass>(pass);
-  for (auto ns : this->nss) {
-    for (auto modmap : ns->getModules()) {
-      Module* m = modmap.second;
+  std::map<Namespace*, std::map<std::string, Module*>> modMap;
+  // create static list of modules in case new modules are added in the pass
+  for (auto ns : this->nss) { modMap[ns] = ns->getModules(); }
+
+  for (auto const& [ns, modules] : modMap) {
+    for (auto const& [mname, m] : modules) {
       if (m->hasDef()) { modified |= mpass->runOnModule(m); }
     }
   }

--- a/src/ir/passmanager.cpp
+++ b/src/ir/passmanager.cpp
@@ -47,7 +47,9 @@ bool PassManager::runModulePass(Pass* pass) {
   for (auto ns : this->nss) { modMap[ns] = ns->getModules(); }
 
   for (auto const& [_, modules] : modMap) {
+    UNUSED(_);
     for (auto const& [_, m] : modules) {
+      UNUSED(_);
       if (m->hasDef()) { modified |= mpass->runOnModule(m); }
     }
   }

--- a/src/passes/transform/isolate_primitives.cpp
+++ b/src/passes/transform/isolate_primitives.cpp
@@ -69,6 +69,7 @@ bool IsolatePrimitives::runOnModule(Module* m) {
 
   // External connections
   for (auto const& [wP, _, portName] : boundary_info) {
+    UNUSED(_);
     auto portSP = SelectPath({"self", portName});
     pdef->connect(wP->getSelectPath(), portSP);
   }
@@ -77,11 +78,13 @@ bool IsolatePrimitives::runOnModule(Module* m) {
   // Create instance of prim module and connect appropriately
   auto primInst = def->addInstance("primitive_" + c->getUnique(), primModule);
   for (auto const& [_, connE, portName] : boundary_info) {
+    UNUSED(_);
     def->connect(connE, primInst->sel(portName));
   }
 
   // remove all primtiive instnaces
   for (auto const& [_, inst] : primitiveInstances) {
+    UNUSED(_);
     def->removeInstance(inst);
   }
 

--- a/src/passes/transform/isolate_primitives.cpp
+++ b/src/passes/transform/isolate_primitives.cpp
@@ -1,0 +1,84 @@
+#include "coreir/passes/transform/isolate_primitives.h"
+
+std::string CoreIR::Passes::IsolatePrimitives::ID = "isolate_primitives";
+
+// Creates a separate module that isolates all the primitive (coreir/corebit) instances
+
+namespace CoreIR {
+namespace Passes {
+bool IsolatePrimitives::runOnModule(Module* m) {
+  if (!m->hasDef()) {return false;}
+  auto def = m->getDef();
+  auto c = this->getContext();
+
+  //get a map of only primitive instances
+  auto primitiveInstances = filterOver(
+    def->getInstances(),
+    [](auto it) {
+      auto nsname = it.second->getModuleRef()->getNamespace()->getName();
+      return nsname == "coreir" || nsname == "corebit";
+    }
+  );
+
+  //early out
+  if (primitiveInstances.size()==0) {return false;}
+
+  std::vector<std::pair<Wireable*, Wireable*>> internal_connections; //prim <=> prim
+  std::vector<std::pair<Wireable*, Wireable*>> external_connections; //prim <=> other
+  for (auto const& [wA, wB] : def->getConnections()) {
+    //Put into two piles external and internal
+    bool AIsPrimitive = primitiveInstances.count(wA->getSelectPath()[0]);
+    bool BIsPrimitive = primitiveInstances.count(wB->getSelectPath()[0]);
+    if (AIsPrimitive && BIsPrimitive) {internal_connections.push_back(std::make_pair(wA, wB));}
+    else if (AIsPrimitive) {external_connections.push_back(std::make_pair(wA, wB));}
+    else if (BIsPrimitive) {external_connections.push_back(std::make_pair(wB, wA));}
+  }
+
+  //Construct module type interface
+  //maintain info for external, internal, and port name
+  //disconnect external_connections
+  RecordParams ports;
+  std::vector<std::tuple<Wireable*, Wireable*, std::string>> boundary_info;
+  for (auto const& [wP, wE] : external_connections) {
+    std::string portName = c->getUnique();
+    ports.push_back(std::make_pair(portName, wP->getType()));
+    boundary_info.push_back(std::make_tuple(wP, wE, portName));
+    def->disconnect(wP, wE);
+  }
+
+  //Create new prim module and definition
+  auto primModule = c->getNamespace("_")->newModuleDecl(m->getName() + "_primitives", c->Record(ports));
+  //Add all primitive instances into new module
+  auto pdef = primModule->newModuleDef();
+  for (auto const& [iname, inst] : primitiveInstances) {
+    pdef->addInstance(iname, inst->getModuleRef());
+  }
+
+  //Internal connections
+  for (auto const& [wA, wB] : internal_connections) {
+    pdef->connect(wA->getSelectPath(), wB->getSelectPath());
+  }
+
+  //External connections
+  for (auto const& [wP, _, portName] : boundary_info) {
+    auto portSP = SelectPath({"self", portName});
+    pdef->connect(wP->getSelectPath(), portSP);
+  }
+  primModule->setDef(pdef);
+
+  //Create instance of prim module and connect appropriately
+  auto primInst = def->addInstance("primitive_" + c->getUnique(), primModule);
+  for (auto const& [_, connE, portName] : boundary_info) {
+    def->connect(connE, primInst->sel(portName));
+  }
+
+  //remove all primtiive instnaces
+  for (auto const& [_, inst] : primitiveInstances) {
+    def->removeInstance(inst);
+  }
+
+  return true;
+
+}  // runOnModule
+}  // namespace Passes
+}  // namespace CoreIR

--- a/src/passes/transform/isolate_primitives.cpp
+++ b/src/passes/transform/isolate_primitives.cpp
@@ -2,41 +2,47 @@
 
 std::string CoreIR::Passes::IsolatePrimitives::ID = "isolate_primitives";
 
-// Creates a separate module that isolates all the primitive (coreir/corebit) instances
+// Creates a separate module that isolates all the primitive (coreir/corebit)
+// instances
 
 namespace CoreIR {
 namespace Passes {
 bool IsolatePrimitives::runOnModule(Module* m) {
-  if (!m->hasDef()) {return false;}
+  if (!m->hasDef()) return false;
   auto def = m->getDef();
   auto c = this->getContext();
 
-  //get a map of only primitive instances
-  auto primitiveInstances = filterOver(
-    def->getInstances(),
-    [](auto it) {
-      auto nsname = it.second->getModuleRef()->getNamespace()->getName();
-      return nsname == "coreir" || nsname == "corebit";
-    }
-  );
+  // get a map of only primitive instances
+  auto primitiveInstances = filterOver(def->getInstances(), [](auto it) {
+    auto nsname = it.second->getModuleRef()->getNamespace()->getName();
+    return nsname == "coreir" || nsname == "corebit";
+  });
 
-  //early out
-  if (primitiveInstances.size()==0) {return false;}
+  // early out
+  if (primitiveInstances.size() == 0) return false;
 
-  std::vector<std::pair<Wireable*, Wireable*>> internal_connections; //prim <=> prim
-  std::vector<std::pair<Wireable*, Wireable*>> external_connections; //prim <=> other
+  std::vector<std::pair<Wireable*, Wireable*>>
+    internal_connections;  // prim <=> prim
+  std::vector<std::pair<Wireable*, Wireable*>>
+    external_connections;  // prim <=> other
   for (auto const& [wA, wB] : def->getConnections()) {
-    //Put into two piles external and internal
+    // Put into two piles external and internal
     bool AIsPrimitive = primitiveInstances.count(wA->getSelectPath()[0]);
     bool BIsPrimitive = primitiveInstances.count(wB->getSelectPath()[0]);
-    if (AIsPrimitive && BIsPrimitive) {internal_connections.push_back(std::make_pair(wA, wB));}
-    else if (AIsPrimitive) {external_connections.push_back(std::make_pair(wA, wB));}
-    else if (BIsPrimitive) {external_connections.push_back(std::make_pair(wB, wA));}
+    if (AIsPrimitive && BIsPrimitive) {
+      internal_connections.push_back(std::make_pair(wA, wB));
+    }
+    else if (AIsPrimitive) {
+      external_connections.push_back(std::make_pair(wA, wB));
+    }
+    else if (BIsPrimitive) {
+      external_connections.push_back(std::make_pair(wB, wA));
+    }
   }
 
-  //Construct module type interface
-  //maintain info for external, internal, and port name
-  //disconnect external_connections
+  // Construct module type interface
+  // maintain info for external, internal, and port name
+  // disconnect external_connections
   RecordParams ports;
   std::vector<std::tuple<Wireable*, Wireable*, std::string>> boundary_info;
   for (auto const& [wP, wE] : external_connections) {
@@ -46,33 +52,35 @@ bool IsolatePrimitives::runOnModule(Module* m) {
     def->disconnect(wP, wE);
   }
 
-  //Create new prim module and definition
-  auto primModule = c->getNamespace("_")->newModuleDecl(m->getName() + "_primitives", c->Record(ports));
-  //Add all primitive instances into new module
+  // Create new prim module and definition
+  auto primModule = c->getNamespace("_")->newModuleDecl(
+    m->getName() + "_primitives",
+    c->Record(ports));
+  // Add all primitive instances into new module
   auto pdef = primModule->newModuleDef();
   for (auto const& [iname, inst] : primitiveInstances) {
     pdef->addInstance(iname, inst->getModuleRef());
   }
 
-  //Internal connections
+  // Internal connections
   for (auto const& [wA, wB] : internal_connections) {
     pdef->connect(wA->getSelectPath(), wB->getSelectPath());
   }
 
-  //External connections
+  // External connections
   for (auto const& [wP, _, portName] : boundary_info) {
     auto portSP = SelectPath({"self", portName});
     pdef->connect(wP->getSelectPath(), portSP);
   }
   primModule->setDef(pdef);
 
-  //Create instance of prim module and connect appropriately
+  // Create instance of prim module and connect appropriately
   auto primInst = def->addInstance("primitive_" + c->getUnique(), primModule);
   for (auto const& [_, connE, portName] : boundary_info) {
     def->connect(connE, primInst->sel(portName));
   }
 
-  //remove all primtiive instnaces
+  // remove all primtiive instnaces
   for (auto const& [_, inst] : primitiveInstances) {
     def->removeInstance(inst);
   }

--- a/tests/gtest/CMakeLists.txt
+++ b/tests/gtest/CMakeLists.txt
@@ -36,3 +36,7 @@ add_test(NAME test_inline_wires COMMAND test_inline_wires WORKING_DIRECTORY ${CM
 add_executable(test_hierarchical_select test_hierarchical_select.cpp)
 target_link_libraries(test_hierarchical_select gtest_main coreir coreir-commonlib)
 add_test(NAME test_hierarchical_select COMMAND test_hierarchical_select WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests/gtest)
+
+add_executable(test_isolate test_isolate.cpp)
+target_link_libraries(test_isolate gtest_main coreir coreir-commonlib)
+add_test(NAME test_isolate COMMAND test_isolate WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests/gtest)

--- a/tests/gtest/test_isolate.cpp
+++ b/tests/gtest/test_isolate.cpp
@@ -1,0 +1,109 @@
+#include <gtest/gtest.h>
+#include "assert_pass.h"
+#include "coreir.h"
+#include "coreir/definitions/coreVerilog.hpp"
+#include "coreir/definitions/corebitVerilog.hpp"
+
+using namespace CoreIR;
+
+namespace {
+
+Module* create_module(Context* c, std::string mname) {
+  c->getLibraryManager()->loadLib("commonlib");
+  auto Bits16 = c->Bit()->Arr(16);
+  auto ab = c->Record({
+    {"a", c->In(Bits16)},
+    {"b", c->In(Bits16)},
+  });
+  auto g = c->getGlobal();
+  auto ports = c->Record({{"in0", ab}, {"in1", ab}, {"out", c->Out(ab)}});
+  auto m = g->newModuleDecl(mname, ports);
+
+  //Create a complex definition with mixed primitives, other instances, and complex types
+  auto def = m->newModuleDef();
+
+  //Use Constructor view to easily create primitives
+  auto C = Constructor(def);
+
+  auto io = def->getInterface();
+  auto not_bit = C.not_(def->sel("self.in0.a.0"));
+  auto mux4 = def->addInstance("m", "commonlib.muxn", {{"width", Const::make(c, 16)}, {"N", Const::make(c, 4)},});
+  def->connect(not_bit, mux4->sel("in")->sel("sel")->sel(0));
+  def->connect(not_bit, mux4->sel("in")->sel("sel")->sel(1));
+  def->connect("self.in0.a", "m.in.data.0");
+  def->connect("self.in0.b", "m.in.data.1");
+  def->connect("self.in1.a", "m.in.data.2");
+
+  auto reg = def->addInstance("r0", "coreir.reg", {{"width", Const::make(c, 16)}});
+
+  //add a primitive op before passing into last data
+  auto add_out = C.add(io->sel("in1")->sel("a"), reg->sel("out"));
+  def->connect(add_out, mux4->sel("in")->sel("data")->sel(3));
+
+  //connect output of mux to a stream of primitives
+  auto mul_out = C.mul(mux4->sel("out"), reg->sel("out"));
+  auto sub_out = C.sub(mul_out, mux4->sel("out"));
+
+  //connect back to register input
+  def->connect(sub_out, reg->sel("in"));
+
+  //Connect some internal coreir values to the module output
+  def->connect(mux4->sel("out"), io->sel("out")->sel("a"));
+  def->connect(mul_out, io->sel("out")->sel("b"));
+  m->setDef(def);
+  return m;
+}
+
+
+TEST(IsolateTest, Test1) {
+  auto c = newContext();
+  auto m = create_module(c, "m1");
+  assert(m->hasDef());
+  c->setTop(m);
+
+  //Testing isolate pass
+  c->runPasses({"isolate_primitives"});
+  c->checkerrors();
+
+  auto def = m->getDef();
+
+  // Module should now contain no primitives
+  bool has_primitives = anyOf(def->getInstances(), [](auto it) {
+    auto nsname = it.second->getModuleRef()->getNamespace()->getName();
+    return nsname == "coreir" || nsname == "corebit";
+  });
+
+  ASSERT_TRUE(!has_primitives);
+
+  // Also a single instance with namespace "_"
+  auto isolated_insts = filterOver(def->getInstances(), [](auto it) {
+    auto nsname = it.second->getModuleRef()->getNamespace()->getName();
+    return nsname == "_";
+  });
+  ASSERT_TRUE(isolated_insts.size()==1);
+
+  auto isolated_inst = isolated_insts.begin()->second;
+  auto pmod = isolated_inst->getModuleRef();
+  ASSERT_TRUE(pmod->hasDef());
+
+  auto pdef = pmod->getDef();
+
+  //All instances should be primitives
+  bool only_primitives = allOf(pdef->getInstances(), [](auto it) {
+    auto nsname = it.second->getModuleRef()->getNamespace()->getName();
+    return nsname == "coreir" || nsname == "corebit";
+  });
+  ASSERT_TRUE(only_primitives);
+
+  //Should be 5 primitives
+  ASSERT_EQ(pdef->getInstances().size(), 5);
+
+  deleteContext(c);
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/tests/gtest/test_isolate.cpp
+++ b/tests/gtest/test_isolate.cpp
@@ -19,41 +19,50 @@ Module* create_module(Context* c, std::string mname) {
   auto ports = c->Record({{"in0", ab}, {"in1", ab}, {"out", c->Out(ab)}});
   auto m = g->newModuleDecl(mname, ports);
 
-  //Create a complex definition with mixed primitives, other instances, and complex types
+  // Create a complex definition with mixed primitives, other instances, and
+  // complex types
   auto def = m->newModuleDef();
 
-  //Use Constructor view to easily create primitives
+  // Use Constructor view to easily create primitives
   auto C = Constructor(def);
 
   auto io = def->getInterface();
   auto not_bit = C.not_(def->sel("self.in0.a.0"));
-  auto mux4 = def->addInstance("m", "commonlib.muxn", {{"width", Const::make(c, 16)}, {"N", Const::make(c, 4)},});
+  auto mux4 = def->addInstance(
+    "m",
+    "commonlib.muxn",
+    {
+      {"width", Const::make(c, 16)},
+      {"N", Const::make(c, 4)},
+    });
   def->connect(not_bit, mux4->sel("in")->sel("sel")->sel(0));
   def->connect(not_bit, mux4->sel("in")->sel("sel")->sel(1));
   def->connect("self.in0.a", "m.in.data.0");
   def->connect("self.in0.b", "m.in.data.1");
   def->connect("self.in1.a", "m.in.data.2");
 
-  auto reg = def->addInstance("r0", "coreir.reg", {{"width", Const::make(c, 16)}});
+  auto reg = def->addInstance(
+    "r0",
+    "coreir.reg",
+    {{"width", Const::make(c, 16)}});
 
-  //add a primitive op before passing into last data
+  // add a primitive op before passing into last data
   auto add_out = C.add(io->sel("in1")->sel("a"), reg->sel("out"));
   def->connect(add_out, mux4->sel("in")->sel("data")->sel(3));
 
-  //connect output of mux to a stream of primitives
+  // connect output of mux to a stream of primitives
   auto mul_out = C.mul(mux4->sel("out"), reg->sel("out"));
   auto sub_out = C.sub(mul_out, mux4->sel("out"));
 
-  //connect back to register input
+  // connect back to register input
   def->connect(sub_out, reg->sel("in"));
 
-  //Connect some internal coreir values to the module output
+  // Connect some internal coreir values to the module output
   def->connect(mux4->sel("out"), io->sel("out")->sel("a"));
   def->connect(mul_out, io->sel("out")->sel("b"));
   m->setDef(def);
   return m;
 }
-
 
 TEST(IsolateTest, Test1) {
   auto c = newContext();
@@ -61,7 +70,7 @@ TEST(IsolateTest, Test1) {
   assert(m->hasDef());
   c->setTop(m);
 
-  //Testing isolate pass
+  // Testing isolate pass
   c->runPasses({"isolate_primitives"});
   c->checkerrors();
 
@@ -80,7 +89,7 @@ TEST(IsolateTest, Test1) {
     auto nsname = it.second->getModuleRef()->getNamespace()->getName();
     return nsname == "_";
   });
-  ASSERT_TRUE(isolated_insts.size()==1);
+  ASSERT_TRUE(isolated_insts.size() == 1);
 
   auto isolated_inst = isolated_insts.begin()->second;
   auto pmod = isolated_inst->getModuleRef();
@@ -88,14 +97,14 @@ TEST(IsolateTest, Test1) {
 
   auto pdef = pmod->getDef();
 
-  //All instances should be primitives
+  // All instances should be primitives
   bool only_primitives = allOf(pdef->getInstances(), [](auto it) {
     auto nsname = it.second->getModuleRef()->getNamespace()->getName();
     return nsname == "coreir" || nsname == "corebit";
   });
   ASSERT_TRUE(only_primitives);
 
-  //Should be 5 primitives
+  // Should be 5 primitives
   ASSERT_EQ(pdef->getInstances().size(), 5);
 
   deleteContext(c);


### PR DESCRIPTION
This pass is a sort of "reverse inlining" pass. It essentially collects all instances of coreir primitives and isolates them into a single instance of their own module. This is very useful when needing to operate on only the coreir instances of the module.

Also, I could imagine this being a first step in being able to generate always_comb/always_ff blocks during verilog generation.