### PR TITLE
Change reg to have clear priority over enable to match mantle

### DIFF
--- a/src/ir/headers/mantle.hpp
+++ b/src/ir/headers/mantle.hpp
@@ -78,6 +78,14 @@ Namespace* CoreIRLoadHeader_mantle(Context* c) {
     def->connect("reg0.clk", "self.clk");
     Wireable* toIn = reg->sel("in");
 
+    if (en) {
+      auto mux = def->addInstance("enMux", "coreir.mux", wval);
+      def->connect(mux->sel("out"), toIn);
+      def->connect(mux->sel("in0"), reg->sel("out"));
+      def->connect(mux->sel("sel"), io->sel("en"));
+      toIn = mux->sel("in1");
+    }
+
     if (clr) {
       auto mux = def->addInstance("clrMux", "coreir.mux", wval);
       auto zero = def->addInstance(
@@ -90,14 +98,7 @@ Namespace* CoreIRLoadHeader_mantle(Context* c) {
       def->connect(mux->sel("sel"), io->sel("clr"));
       toIn = mux->sel("in0");
     }
-
-    if (en) {
-      auto mux = def->addInstance("enMux", "coreir.mux", wval);
-      def->connect(mux->sel("out"), toIn);
-      def->connect(mux->sel("in0"), reg->sel("out"));
-      def->connect(mux->sel("sel"), io->sel("en"));
-      toIn = mux->sel("in1");
-    }
+    
     def->connect(io->sel("in"), toIn);
   });
 


### PR DESCRIPTION
Follows this discussion: https://github.com/phanrahan/mantle/issues/149

And fixes the CoreIR version of the mantle reg to have clear priority over the enable signal.