### PR TITLE
Add fix for inlining slices

### DIFF
--- a/tests/binary/gold/flatten_slice.json
+++ b/tests/binary/gold/flatten_slice.json
@@ -1,0 +1,53 @@
+{"top":"global.A",
+"namespaces":{
+  "global":{
+    "modules":{
+      "A":{
+        "type":["Record",[
+          ["in",["Array",16,"BitIn"]],
+          ["out",["Array",16,"Bit"]]
+        ]],
+        "instances":{
+          "i0$_$0":{
+            "genref":"mantle.wire",
+            "genargs":{"type":["CoreIRType",["Array",16,"Bit"]]}
+          },
+          "i0$_$1":{
+            "genref":"mantle.wire",
+            "genargs":{"type":["CoreIRType",["Array",16,"BitIn"]]}
+          },
+          "i0$n1":{
+            "genref":"coreir.neg",
+            "genargs":{"width":["Int",16]}
+          }
+        },
+        "connections":[
+          ["self.in.0:3","i0$_$0.in.0:3"],
+          ["self.in.3:16","i0$_$0.in.3:16"],
+          ["i0$_$1.out.0:10","i0$_$0.out.0:10"],
+          ["i0$_$1.out.10:16","i0$_$0.out.10:16"],
+          ["i0$n1.in","i0$_$1.in"],
+          ["self.out","i0$n1.out"]
+        ]
+      },
+      "B":{
+        "type":["Record",[
+          ["in",["Array",16,"BitIn"]],
+          ["out",["Array",16,"Bit"]]
+        ]],
+        "instances":{
+          "n1":{
+            "genref":"coreir.neg",
+            "genargs":{"width":["Int",16]}
+          }
+        },
+        "connections":[
+          ["self.in.0:10","n1.in.0:10"],
+          ["self.in.10:16","n1.in.10:16"],
+          ["self.out","n1.out"]
+        ]
+      }
+    }
+  }
+}
+}

--- a/tests/binary/src/flatten_slice.json
+++ b/tests/binary/src/flatten_slice.json
@@ -1,0 +1,39 @@
+{"top":"global.A",
+  "namespaces": {
+    "global": {
+      "modules": {
+        "A": {
+          "type": ["Record",[
+            ["in", ["Array",16,"BitIn"]],
+            ["out", ["Array",16,"Bit"]]
+          ]],
+            "instances": {
+            "i0": {"modref": "global.B"}
+          },
+          "connections": [
+            ["self.in.0:3", "i0.in.0:3"],
+            ["self.in.3:16", "i0.in.3:16"],
+            ["i0.out", "self.out"]
+          ]
+        },
+        "B": {
+          "type": ["Record",[
+            ["in", ["Array",16,"BitIn"]],
+            ["out", ["Array",16,"Bit"]]
+          ]],
+          "instances": {
+            "n1": {
+              "genref": "coreir.neg",
+              "genargs": {"width":["Int", 16]}
+            }
+          },
+          "connections": [
+            ["self.in.0:10","n1.in.0:10"],
+            ["self.in.10:16","n1.in.10:16"],
+            ["n1.out","self.out"]
+          ]
+        }
+      }
+    }
+  }
+}

--- a/tests/binary/test_slice.py
+++ b/tests/binary/test_slice.py
@@ -12,3 +12,18 @@ def test_slice_connectivity():
         '           -l commonlib'
     )
     assert not res.return_code, res.out + res.err
+
+
+def test_flatten_slice():
+    res = delegator.run(
+        'bin/coreir -i tests/binary/src/flatten_slice.json'
+        '           -p flatten'
+        '           -o tests/binary/build/out.json'
+    )
+    print(res.out)
+    assert not res.return_code, res.err
+
+    res = delegator.run('diff tests/binary/build/out.json  '
+                        '     tests/binary/gold/flatten_slice.json')
+    assert not res.return_code, res.out + res.err
+


### PR DESCRIPTION
See https://github.com/rdaly525/coreir/issues/895 for more context

This adds a step in the inlining process to insert intermediate wires for slice selects so the current inlining implementation works.  There might be alternative solutions to this, but hopefully this fixes the functionality bug with minimal changes to the code.  I played around with some other ideas but it seems pretty complicated to get this right in the actual inlining logic (need to map from indices of one slice to indices of another).  I think this gets us a baseline working version with the least amount of code, but may introduce some overhead in the output (extra wire instances), but I think this might be better than blasting the slices into individual bits.