### PR TITLE
Fix mem leaks

### DIFF
--- a/src/binary/coreir.cpp
+++ b/src/binary/coreir.cpp
@@ -161,7 +161,7 @@ int main(int argc, char* argv[]) {
           outExt == "v",
         "Cannot support out extention: " + outExt);
       if (!split_files) {
-        std::unique_ptr<std::ofstream> fout(new std::ofstream(outfile));
+        std::unique_ptr<std::ofstream> fout(std::ofstream(outfile));
         ASSERT(fout->is_open(), "Cannot open file: " + outfile);
         sout = fout.release();
       }
@@ -266,6 +266,8 @@ int main(int argc, char* argv[]) {
     LOG(DEBUG) << "NYI";
   }
   LOG(DEBUG) << "Modified?: " << (modified ? "Yes" : "No");
+
+  delete c;
 
   return 0;
 }

--- a/src/binary/coreir.cpp
+++ b/src/binary/coreir.cpp
@@ -27,9 +27,8 @@ string getExt(string s) {
 int main(int argc, char* argv[]) {
   int argc_copy = argc;
   cxxopts::Options options("coreir", "a simple hardware compiler");
-  options.add_options()(
-    "h,help",
-    "help")("version",
+  options.add_options()("h,help", "help")(
+    "version",
     "Show version")("v,verbose", "Set verbosity", cxxopts::value<int>())(
     "i,input",
     "input file: '<file1>.json,<file2.json,...'",
@@ -148,6 +147,7 @@ int main(int argc, char* argv[]) {
   }
 
   std::ostream* sout = &std::cout;
+  bool delete_sout = false;
   std::string outExt = "json";
   std::string output_dir = "";
   auto parse_outputs = [&] {
@@ -161,9 +161,9 @@ int main(int argc, char* argv[]) {
           outExt == "v",
         "Cannot support out extention: " + outExt);
       if (!split_files) {
-        std::unique_ptr<std::ofstream> fout(std::ofstream(outfile));
-        ASSERT(fout->is_open(), "Cannot open file: " + outfile);
-        sout = fout.release();
+        sout = new std::ofstream(outfile);
+        ASSERT(sout->is_open(), "Cannot open file: " + outfile);
+        delete_sout = true;
       }
     }
     if (split_files) {
@@ -267,6 +267,7 @@ int main(int argc, char* argv[]) {
   }
   LOG(DEBUG) << "Modified?: " << (modified ? "Yes" : "No");
 
+  if (delete_sout) delete sout;
   delete c;
 
   return 0;

--- a/src/binary/coreir.cpp
+++ b/src/binary/coreir.cpp
@@ -147,6 +147,7 @@ int main(int argc, char* argv[]) {
   }
 
   std::ostream* sout = &std::cout;
+  // split files logic overwrites default sout, needs to be freed
   bool delete_sout = false;
   std::string outExt = "json";
   std::string output_dir = "";
@@ -161,8 +162,9 @@ int main(int argc, char* argv[]) {
           outExt == "v",
         "Cannot support out extention: " + outExt);
       if (!split_files) {
-        sout = new std::ofstream(outfile);
-        ASSERT(sout->is_open(), "Cannot open file: " + outfile);
+        std::unique_ptr<std::ofstream> fout(std::ofstream(outfile));
+        ASSERT(fout->is_open(), "Cannot open file: " + outfile);
+        sout = fout.release();
         delete_sout = true;
       }
     }
@@ -267,7 +269,7 @@ int main(int argc, char* argv[]) {
   }
   LOG(DEBUG) << "Modified?: " << (modified ? "Yes" : "No");
 
-  if (delete_sout) delete sout;
+  if (delete_sout) delete_sout;
   delete c;
 
   return 0;

--- a/src/binary/coreir.cpp
+++ b/src/binary/coreir.cpp
@@ -162,7 +162,7 @@ int main(int argc, char* argv[]) {
           outExt == "v",
         "Cannot support out extention: " + outExt);
       if (!split_files) {
-        std::unique_ptr<std::ofstream> fout(std::ofstream(outfile));
+        std::unique_ptr<std::ofstream> fout(new std::ofstream(outfile));
         ASSERT(fout->is_open(), "Cannot open file: " + outfile);
         sout = fout.release();
         delete_sout = true;
@@ -269,7 +269,7 @@ int main(int argc, char* argv[]) {
   }
   LOG(DEBUG) << "Modified?: " << (modified ? "Yes" : "No");
 
-  if (delete_sout) delete_sout;
+  if (delete_sout) delete sout;
   delete c;
 
   return 0;

--- a/src/binary/coreir.cpp
+++ b/src/binary/coreir.cpp
@@ -270,7 +270,7 @@ int main(int argc, char* argv[]) {
   LOG(DEBUG) << "Modified?: " << (modified ? "Yes" : "No");
 
   if (delete_sout) delete sout;
-  delete c;
+  deleteContext(c);
 
   return 0;
 }


### PR DESCRIPTION
These came up when debugging https://github.com/rdaly525/coreir/pull/911

Minor changes to cleanup some code in the binary exit logic.  Also one style change caught by clang-format