### PR TITLE
Set CMAKE_CXX_STANDARD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,19 @@ cmake_minimum_required(VERSION 2.8)
 project(coreir)
 option(STATIC "Statically link everything" OFF)
 
+# handle different versions of CMake
+if (NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 8.0 AND NOT APPLE)
+  set(CMAKE_CXX17_STANDARD_COMPILE_OPTION "-std=c++17")
+  set(CMAKE_CXX17_EXTENSION_COMPILE_OPTION "-std=gnu++17")
+elseif (NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.1 OR APPLE)
+  set(CMAKE_CXX17_STANDARD_COMPILE_OPTION "-std=c++1z")
+  set(CMAKE_CXX17_EXTENSION_COMPILE_OPTION "-std=gnu++1z")
+endif()
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules")
 include(GetGitRevisionDescription)
@@ -27,7 +40,7 @@ if (STATIC)
     endif()
 endif()
 
-set(CMAKE_CXX_FLAGS "-std=c++17 -Wall -fPIC -Werror ${STATIC_FLAGS}")
+set(CMAKE_CXX_FLAGS "-Wall -Werror ${STATIC_FLAGS}")
 
 # Based on
 # https://github.com/google/googletest/tree/master/googletest#incorporating-into-an-existing-cmake-project


### PR DESCRIPTION
When I try to build `coreir` from source on my machine, I get a long error trace when building the tests (included below). It appears that the C++ standard is not set correctly for the tests subdirectory of the cmake project. There are likely multiple ways to handle this. This PR would fix this issue in the way that I know, which I believe is also the more idiomatic way to set the standard in CMake. The extra lines in the beginning of the diff are simply to deal with old versions of CMake that didn't support the C++17 standard explicitly.

Here is the beginning of the error trace I get before making the change in this PR:
```
[ 91%] Building CXX object tests/gtest/CMakeFiles/test_isolate.dir/test_isolate.cpp.o
In file included from /home/makaim/repos/forks/makaim/coreir/include/coreir/primitive.h:4,
                 from /home/makaim/repos/forks/makaim/coreir/include/coreir/ir/generator.h:4,
                 from /home/makaim/repos/forks/makaim/coreir/include/coreir.h:10,
                 from /home/makaim/repos/forks/makaim/coreir/include/coreir/passes/analysis/coreirjson.h:5,
                 from /home/makaim/repos/forks/makaim/coreir/include/coreir/passes/common.h:5,
                 from /home/makaim/repos/forks/makaim/coreir/tests/gtest/assert_pass.h:6,
                 from /home/makaim/repos/forks/makaim/coreir/tests/gtest/test_isolate.cpp:2:
/home/makaim/repos/forks/makaim/coreir/build/verilogAST-src/include/verilogAST.hpp: In function ‘std::unique_ptr<verilogAST::WithComment<T> > verilogAST::AddComment(std::unique_ptr<_Codecvt>, std::string)’:
/home/makaim/repos/forks/makaim/coreir/build/verilogAST-src/include/verilogAST.hpp:32:15: error: ‘make_unique’ is not a member of ‘std’
   32 |   return std::make_unique<WithComment<T>>(std::move(node), comment);
      |               ^~~~~~~~~~~
/home/makaim/repos/forks/makaim/coreir/build/verilogAST-src/include/verilogAST.hpp:32:15: note: ‘std::make_unique’ is only available from C++14 onwards
/home/makaim/repos/forks/makaim/coreir/build/verilogAST-src/include/verilogAST.hpp:32:40: error: expected primary-expression before ‘>’ token
   32 |   return std::make_unique<WithComment<T>>(std::move(node), comment);
      |                                        ^~
/home/makaim/repos/forks/makaim/coreir/build/verilogAST-src/include/verilogAST.hpp: At global scope:
/home/makaim/repos/forks/makaim/coreir/build/verilogAST-src/include/verilogAST.hpp:48:3: error: ‘clone’ function uses ‘auto’ type specifier without trailing return type
   48 |   auto clone() const { return std::unique_ptr<Expression>(clone_impl()); }
      |   ^~~~
/home/makaim/repos/forks/makaim/coreir/build/verilogAST-src/include/verilogAST.hpp:48:3: note: deduced return type only available with ‘-std=c++14’ or ‘-std=gnu++14’
/home/makaim/repos/forks/makaim/coreir/build/verilogAST-src/include/verilogAST.hpp:101:3: error: ‘clone’ function uses ‘auto’ type specifier without trailing return type
  101 |   auto clone() const { return std::unique_ptr<NumericLiteral>(clone_impl()); }
      |   ^~~~
/home/makaim/repos/forks/makaim/coreir/build/verilogAST-src/include/verilogAST.hpp:101:3: note: deduced return type only available with ‘-std=c++14’ or ‘-std=gnu++14’
/home/makaim/repos/forks/makaim/coreir/build/verilogAST-src/include/verilogAST.hpp:118:3: error: ‘clone’ function uses ‘auto’ type specifier without trailing return type
  118 |   auto clone() const { return std::unique_ptr<Cast>(clone_impl()); }
      |   ^~~~
/home/makaim/repos/forks/makaim/coreir/build/verilogAST-src/include/verilogAST.hpp:118:3: note: deduced return type only available with ‘-std=c++14’ or ‘-std=gnu++14’
/home/makaim/repos/forks/makaim/coreir/build/verilogAST-src/include/verilogAST.hpp:137:3: error: ‘clone’ function uses ‘auto’ type specifier without trailing return type
  137 |   auto clone() const { return std::unique_ptr<Identifier>(clone_impl()); }
      |   ^~~~
/home/makaim/repos/forks/makaim/coreir/build/verilogAST-src/include/verilogAST.hpp:137:3: note: deduced return type only available with ‘-std=c++14’ or ‘-std=gnu++14’
/home/makaim/repos/forks/makaim/coreir/build/verilogAST-src/include/verilogAST.hpp:152:8: error: ‘variant’ in namespace ‘std’ does not name a template type
  152 |   std::variant<std::unique_ptr<Identifier>, std::unique_ptr<Attribute>> value;
      |        ^~~~~~~
/home/makaim/repos/forks/makaim/coreir/build/verilogAST-src/include/verilogAST.hpp:152:3: note: ‘std::variant’ is only available from C++17 onwards
  152 |   std::variant<std::unique_ptr<Identifier>, std::unique_ptr<Attribute>> value;
      |   ^~~
/home/makaim/repos/forks/makaim/coreir/build/verilogAST-src/include/verilogAST.hpp:156:19: error: expected ‘)’ before ‘<’ token
  156 |       std::variant<std::unique_ptr<Identifier>, std::unique_ptr<Attribute>>
      |                   ^
      |                   )
```