### PR TITLE
Adds support for magma's user defined namespace

### DIFF
--- a/include/coreir-c/coreir.h
+++ b/include/coreir-c/coreir.h
@@ -42,6 +42,8 @@ extern bool COREContextRunPasses(
   char** namespaces,
   int num_namespaces);
 
+void COREContextSetTop(COREContext* context, COREModule* module);
+
 extern bool COREInlineInstance(COREWireable* inst);
 extern COREWireable* COREAddPassthrough(COREWireable* w);
 extern void CORERemoveInstance(COREWireable* inst);
@@ -54,6 +56,12 @@ extern COREModule* CORELoadModule(
 // Errors:
 // Cannot open file for reading/writing
 extern void CORESaveModule(COREModule* module, char* filename, COREBool* err);
+extern void CORESaveContext(
+  COREContext* context,
+  char* filename,
+  COREBool* nocoreir,
+  COREBool* no_default_libs,
+  COREBool* err);
 extern CORENamespace* COREGetGlobal(COREContext* c);
 extern CORENamespace* COREGetNamespace(COREContext* c, char* name);
 extern CORENamespace* CORENewNamespace(COREContext* c, char* name);

--- a/include/coreir/ir/context.h
+++ b/include/coreir/ir/context.h
@@ -171,7 +171,11 @@ bool saveToFilePretty(
   Namespace* ns,
   std::string filename,
   Module* top = nullptr);
-bool saveToFile(Context* c, std::string filename, bool nocoreir = true);
+bool saveToFile(
+  Context* c,
+  std::string filename,
+  bool nocoreir = true,
+  bool no_default_libs = false);
 
 // Save a module to a dot file (for viewing in graphviz)
 bool saveToDot(Module* m, std::string filename);

--- a/src/coreir-c/coreir-c.cpp
+++ b/src/coreir-c/coreir-c.cpp
@@ -124,6 +124,10 @@ bool COREContextRunPasses(
   return context->runPasses(vec_passes, vec_namespaces);
 }
 
+void COREContextSetTop(COREContext* context, COREModule* module) {
+  rcast<Context*>(context)->setTop(rcast<Module*>(module));
+}
+
 bool CORECompileToVerilog(
   COREContext* ctx,
   COREModule* top,
@@ -156,10 +160,11 @@ bool CORECompileToVerilog(
   if (verilator_debug) verilog_pass += " -y";
   if (disable_width_cast) verilog_pass += " -w";
   std::vector<std::string> namespaces{"global"};
-  std::vector<std::string> passes{"rungenerators",
-                                  "removebulkconnections",
-                                  "flattentypes",
-                                  verilog_pass};
+  std::vector<std::string> passes{
+    "rungenerators",
+    "removebulkconnections",
+    "flattentypes",
+    verilog_pass};
   context->runPasses(passes, namespaces);
   auto pass = static_cast<Passes::Verilog*>(
     context->getPassManager()->getAnalysisPass("verilog"));
@@ -258,6 +263,24 @@ COREModule* CORELoadModule(COREContext* c, char* filename, bool* err) {
   }
   *err = !correct;
   return rcast<COREModule*>(top);
+}
+
+void CORESaveContext(
+  COREContext* context,
+  char* filename,
+  bool nocoreir,
+  bool no_default_libs,
+  bool* err) {
+
+  string file(filename);
+  std::cout << filename << std::endl;
+  bool correct = saveToFile(
+    rcast<Context*>(context),
+    file,
+    nocoreir,
+    no_default_libs);
+  *err = !correct;
+  return;
 }
 
 // bool saveToFile(Namespace* ns, string filename,Module* top=nullptr);

--- a/src/passes/analysis/coreirjson.cpp
+++ b/src/passes/analysis/coreirjson.cpp
@@ -295,8 +295,14 @@ Json Generator2Json(Generator* g) {
 }  // namespace
 
 bool Passes::CoreIRJson::runOnNamespace(Namespace* ns) {
-  Dict jns(2);
   auto modlist = ns->getModules(false);
+  if (
+    ns->getGenerators().empty() && ns->getTypeGens().empty() &&
+    modlist.empty()) {
+    // Skip if empty
+    return false;
+  }
+  Dict jns(2);
   if (!modlist.empty()) {
     Dict jmod(4);
     for (auto m : modlist) {


### PR DESCRIPTION
Magma added support for a user_namespace, but currently magma only
compiles the namespace containing the top module.  This doesn't work
when we want some modules in the user_namespace, but other modules in
the global namespace (e.g. imported verilog modules that shouldn't have the
user_namespace prefix).  These changes are required so that magma can
compile the whole context instead of just the namespace of the top
module.

* Add Context.setTop to C API (so magma can set the top module in a
  context)
* Add saveToFile of context to C API (so magma can save an entire
  context instead of just the namespace of the top module)
* Add option to saveToFile to skip default imported library namespaces
  like mantle and commonlib.  These don't need to be in the JSON (and
  break downstream gold files when switching to this flow), skipping
  them improves readability (less noise).
* Adds logic in json pass to skip a namespace if it's empty (e.g. global
  namespace may be empty when magma is using only the user_namespace)