### PR TITLE
Ignore ice40 default lib

### DIFF
--- a/src/ir/fileWriter.cpp
+++ b/src/ir/fileWriter.cpp
@@ -140,7 +140,8 @@ bool skip_namespace(std::string name, bool nocoreir, bool no_default_libs) {
   if (nocoreir && (name == "coreir" || name == "corebit")) { return true; }
   else if (
     no_default_libs &&
-    (name == "mantle" || name == "commonlib" || name == "memory")) {
+    (name == "mantle" || name == "commonlib" || name == "memory" ||
+     name == "ice40")) {
     return true;
   }
   return false;


### PR DESCRIPTION
Adds ice40 to the default ignore list for namespaces (loaded automatically in coreir, so we don't need to serialize them to the json).  Needed to fix https://travis-ci.org/github/phanrahan/mantle/builds/710895391