### PR TITLE
Inline mantle wires from slice

### DIFF
--- a/CMakeLists.txt.in
+++ b/CMakeLists.txt.in
@@ -7,7 +7,7 @@ project(verilogAST-download NONE)
 include(ExternalProject)
 ExternalProject_Add(verilogAST
   GIT_REPOSITORY    https://github.com/leonardt/verilogAST-cpp.git
-  GIT_TAG           master
+  GIT_TAG           inline-slice-id
   SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/verilogAST-src"
   BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/verilogAST-build"
   CONFIGURE_COMMAND ""

--- a/CMakeLists.txt.in
+++ b/CMakeLists.txt.in
@@ -7,7 +7,7 @@ project(verilogAST-download NONE)
 include(ExternalProject)
 ExternalProject_Add(verilogAST
   GIT_REPOSITORY    https://github.com/leonardt/verilogAST-cpp.git
-  GIT_TAG           inline-slice-id
+  GIT_TAG           master
   SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/verilogAST-src"
   BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/verilogAST-build"
   CONFIGURE_COMMAND ""

--- a/include/coreir/passes/analysis/verilog/inline_utils.hpp
+++ b/include/coreir/passes/analysis/verilog/inline_utils.hpp
@@ -90,4 +90,6 @@ class AlwaysStarMerger : public vAST::Transformer {
     std::unique_ptr<vAST::Module> node);
 };
 
+bool is_mantle_wire(CoreIR::Module* module);
+
 #endif

--- a/src/ir/headers/mantle.hpp
+++ b/src/ir/headers/mantle.hpp
@@ -37,17 +37,19 @@ Namespace* CoreIRLoadHeader_mantle(Context* c) {
     return {modparams, defaultargs};
   };
 
-  Params regGenParams({{"width", c->Int()},
-                       {"has_en", c->Bool()},
-                       {"has_clr", c->Bool()},
-                       {"has_rst", c->Bool()}});
+  Params regGenParams(
+    {{"width", c->Int()},
+     {"has_en", c->Bool()},
+     {"has_clr", c->Bool()},
+     {"has_rst", c->Bool()}});
   TypeGen* regTypeGen = mantle->newTypeGen("regType", regGenParams, regFun);
 
   auto reg = mantle->newGeneratorDecl("reg", regTypeGen, regGenParams);
   reg->setModParamsGen(regModParamFun);
-  reg->addDefaultGenArgs({{"has_en", Const::make(c, false)},
-                          {"has_clr", Const::make(c, false)},
-                          {"has_rst", Const::make(c, false)}});
+  reg->addDefaultGenArgs(
+    {{"has_en", Const::make(c, false)},
+     {"has_clr", Const::make(c, false)},
+     {"has_rst", Const::make(c, false)}});
 
   reg->setGeneratorDefFromFun([](Context* c, Values genargs, ModuleDef* def) {
     int width = genargs.at("width")->get<int>();
@@ -147,10 +149,13 @@ Namespace* CoreIRLoadHeader_mantle(Context* c) {
     def->connect("self.in", "self.out");
   });
 
-  Params counterParams({{"width", c->Int()},
-                        {"has_en", c->Bool()},
-                        {"has_srst", c->Bool()},
-                        {"has_max", c->Bool()}});
+  wire->setPrimitiveExpressionLambda([]() { return vAST::make_id("in"); });
+
+  Params counterParams(
+    {{"width", c->Int()},
+     {"has_en", c->Bool()},
+     {"has_srst", c->Bool()},
+     {"has_max", c->Bool()}});
   // counter type
   mantle->newTypeGen(
     "counter_type",  // name for the typegen
@@ -182,9 +187,10 @@ Namespace* CoreIRLoadHeader_mantle(Context* c) {
     mantle->getTypeGen("counter_type"),
     counterParams);
   counter->setModParamsGen(counterModParamFun);
-  counter->addDefaultGenArgs({{"has_max", Const::make(c, false)},
-                              {"has_en", Const::make(c, false)},
-                              {"has_srst", Const::make(c, false)}});
+  counter->addDefaultGenArgs(
+    {{"has_max", Const::make(c, false)},
+     {"has_en", Const::make(c, false)},
+     {"has_srst", Const::make(c, false)}});
   counter->setGeneratorDefFromFun(
     [](Context* c, Values genargs, ModuleDef* def) {
       uint width = genargs.at("width")->get<int>();
@@ -259,10 +265,11 @@ Namespace* CoreIRLoadHeader_mantle(Context* c) {
       regCETypeGen,
       regCEGenParams);
     json vjson;
-    vjson["interface"] = {"input [width-1:0] in",
-                          "input ce",
-                          "output [width-1:0] out",
-                          "input clk"};
+    vjson["interface"] = {
+      "input [width-1:0] in",
+      "input ce",
+      "output [width-1:0] out",
+      "input clk"};
     vjson["definition"] =
       ""
       "  reg [width-1:0] value;\n"

--- a/src/ir/inline.cpp
+++ b/src/ir/inline.cpp
@@ -100,6 +100,7 @@ void PTTraverse(ModuleDef* def, Wireable* from, Wireable* to) {
         def->generateUniqueInstanceName(),
         c->getGenerator("mantle.wire"),
         {{"type", Const::make(c, from->getType())}});
+      wire->getMetaData()["inline_verilog_wire"] = true;
       def->connect(to, wire->sel("in"));
       wire->getModuleRef()->runGenerator();
       to = wire->sel("out");
@@ -229,7 +230,11 @@ bool inlineInstance(Instance* inst) {
         modargs[vpair.first] = instModArgs[varg->getField()];
       }
     }
-    def->addInstance(iname, instpair.second->getModuleRef(), modargs);
+    Instance* inst = def->addInstance(
+      iname,
+      instpair.second->getModuleRef(),
+      modargs);
+    inst->setMetaData(instpair.second->getMetaData());
   }
 
   // Now add all the easy connections (that do not touch the boundary)

--- a/src/ir/moduledef.cpp
+++ b/src/ir/moduledef.cpp
@@ -81,7 +81,10 @@ ModuleDef* ModuleDef::copy() {
 
   map<Wireable*, Wireable*> oldWireablesToCopies;
 
-  for (auto inst : this->getInstances()) { def->addInstance(inst.second); }
+  for (auto inst : this->getInstances()) {
+    Instance* new_inst = def->addInstance(inst.second);
+    new_inst->setMetaData(inst.second->getMetaData());
+  }
 
   for (auto con : this->getConnections()) {
 

--- a/src/passes/analysis/verilog.cpp
+++ b/src/passes/analysis/verilog.cpp
@@ -1125,9 +1125,9 @@ bool Passes::Verilog::runOnInstanceGraphNode(InstanceGraphNode& node) {
   }
   if (is_mantle_wire(module)) {
       // Check if all instances are inlined
-      bool all_inlined = false;
+      bool all_inlined = true;
       for (auto inst : node.getInstanceList()) {
-          all_inlined = check_inline_verilog_wire_metadata(inst);
+          all_inlined &= check_inline_verilog_wire_metadata(inst);
       }
       // if all inlined, don't compile the module
       if (all_inlined) return false;

--- a/src/passes/analysis/verilog.cpp
+++ b/src/passes/analysis/verilog.cpp
@@ -1124,13 +1124,13 @@ bool Passes::Verilog::runOnInstanceGraphNode(InstanceGraphNode& node) {
     return false;
   }
   if (is_mantle_wire(module)) {
-      // Check if all instances are inlined
-      bool all_inlined = true;
-      for (auto inst : node.getInstanceList()) {
-          all_inlined &= check_inline_verilog_wire_metadata(inst);
-      }
-      // if all inlined, don't compile the module
-      if (all_inlined) return false;
+    // Check if all instances are inlined
+    bool all_inlined = true;
+    for (auto inst : node.getInstanceList()) {
+      all_inlined &= check_inline_verilog_wire_metadata(inst);
+    }
+    // if all inlined, don't compile the module
+    if (all_inlined) return false;
   }
   compileModule(module);
   return false;

--- a/src/passes/analysis/verilog.cpp
+++ b/src/passes/analysis/verilog.cpp
@@ -1123,6 +1123,15 @@ bool Passes::Verilog::runOnInstanceGraphNode(InstanceGraphNode& node) {
     verilog_generators_seen.count(module->getGenerator()) > 0) {
     return false;
   }
+  if (is_mantle_wire(module)) {
+      // Check if all instances are inlined
+      bool all_inlined = false;
+      for (auto inst : node.getInstanceList()) {
+          all_inlined = check_inline_verilog_wire_metadata(inst);
+      }
+      // if all inlined, don't compile the module
+      if (all_inlined) return false;
+  }
   compileModule(module);
   return false;
 }

--- a/tests/binary/gold/flatten_slice.json
+++ b/tests/binary/gold/flatten_slice.json
@@ -11,15 +11,18 @@
         "instances":{
           "_$_U1":{
             "genref":"mantle.wire",
-            "genargs":{"type":["CoreIRType",["Array",16,"BitIn"]]}
+            "genargs":{"type":["CoreIRType",["Array",16,"BitIn"]]},
+            "metadata":{"inline_verilog_wire":true}
           },
           "_$_U3":{
             "genref":"mantle.wire",
-            "genargs":{"type":["CoreIRType",["Array",16,"BitIn"]]}
+            "genargs":{"type":["CoreIRType",["Array",16,"BitIn"]]},
+            "metadata":{"inline_verilog_wire":true}
           },
           "i0$_$_U0":{
             "genref":"mantle.wire",
-            "genargs":{"type":["CoreIRType",["Array",16,"Bit"]]}
+            "genargs":{"type":["CoreIRType",["Array",16,"Bit"]]},
+            "metadata":{"inline_verilog_wire":true}
           },
           "i0$n1":{
             "genref":"coreir.neg",
@@ -27,7 +30,8 @@
           },
           "i1$_$_U2":{
             "genref":"mantle.wire",
-            "genargs":{"type":["CoreIRType",["Array",16,"Bit"]]}
+            "genargs":{"type":["CoreIRType",["Array",16,"Bit"]]},
+            "metadata":{"inline_verilog_wire":true}
           },
           "i1$n1":{
             "genref":"coreir.neg",

--- a/tests/gtest/golds/basic_slice.v
+++ b/tests/gtest/golds/basic_slice.v
@@ -25,19 +25,8 @@ module top (
     output [3:0] out0_1,
     output [7:0] out1
 );
-wire [15:0] _$_U1_out;
-mantle_wire__typeBit16 _$_U1 (
-    .in(in),
-    .out(_$_U1_out)
-);
-mantle_wire__typeBitIn4 _$_U2 (
-    .in(out0_0),
-    .out({_$_U1_out[1:0],_$_U1_out[3:2]})
-);
-mantle_wire__typeBitIn8 _$_U3 (
-    .in(out1),
-    .out({_$_U1_out[15:12],_$_U1_out[11:8]})
-);
-assign out0_1 = _$_U1_out[7:4];
+assign out0_0 = {in[1:0],in[3:2]};
+assign out0_1 = in[7:4];
+assign out1 = {in[15:12],in[11:8]};
 endmodule
 

--- a/tests/gtest/golds/basic_slice.v
+++ b/tests/gtest/golds/basic_slice.v
@@ -1,24 +1,3 @@
-module mantle_wire__typeBitIn8 (
-    output [7:0] in,
-    input [7:0] out
-);
-assign in = out;
-endmodule
-
-module mantle_wire__typeBitIn4 (
-    output [3:0] in,
-    input [3:0] out
-);
-assign in = out;
-endmodule
-
-module mantle_wire__typeBit16 (
-    input [15:0] in,
-    output [15:0] out
-);
-assign out = in;
-endmodule
-
 module top (
     input [15:0] in,
     output [3:0] out0_0,

--- a/tests/gtest/golds/slice_combview.v
+++ b/tests/gtest/golds/slice_combview.v
@@ -19,24 +19,14 @@ module top (
     output [15:0] out,
     input CLK
 );
-wire [15:0] _$_U1_in;
-wire [15:0] _$_U2_out;
 wire [15:0] value_src_out;
-mantle_wire__typeBitIn16 _$_U1 (
-    .in(_$_U1_in),
-    .out({in[7:0],in[15:8]})
-);
-mantle_wire__typeBit16 _$_U2 (
-    .in(value_src_out),
-    .out(_$_U2_out)
-);
 coreir_coreir_reg__width16_snk value_snk (
     .clk(CLK),
-    .in(_$_U1_in)
+    .in({in[7:0],in[15:8]})
 );
 coreir_coreir_reg__width16_src value_src (
     .out(value_src_out)
 );
-assign out = {_$_U2_out[7:0],_$_U2_out[15:8]};
+assign out = {value_src_out[7:0],value_src_out[15:8]};
 endmodule
 

--- a/tests/gtest/golds/slice_combview.v
+++ b/tests/gtest/golds/slice_combview.v
@@ -1,19 +1,5 @@
 // Module `coreir_reg__width16_src` defined externally
 // Module `coreir_reg__width16_snk` defined externally
-module mantle_wire__typeBitIn16 (
-    output [15:0] in,
-    input [15:0] out
-);
-assign in = out;
-endmodule
-
-module mantle_wire__typeBit16 (
-    input [15:0] in,
-    output [15:0] out
-);
-assign out = in;
-endmodule
-
 module top (
     input [15:0] in,
     output [15:0] out,


### PR DESCRIPTION
Fixes https://github.com/rdaly525/coreir/issues/899
Depends on https://github.com/leonardt/verilogAST-cpp/pull/53

* Adds a metadata field for enabling the inlining of a specific wire instance (by default wires are not inlined)
* Adds verilog codegen support for mantle wires (there's a subtetly where mantle wires can have "in" be an output depending on the type used in the generator)

While this avoids intermediate mantle wire instances, the mantle wire modules are still generated.  I'll need to update the verilog code gen logic to figure this out, it's not necessarily easy since the module dependency graph is computed generically.  We'd want to check that all instances of a module are inlined, then skip it.  Not sure how blocking this is, so we can merge this with the extra unused modules code generated or wait for that improvement to be added.