### PR TITLE
Allow test_isolate to run without install

### DIFF
--- a/tests/gtest/test_isolate.cpp
+++ b/tests/gtest/test_isolate.cpp
@@ -3,13 +3,14 @@
 #include "coreir.h"
 #include "coreir/definitions/coreVerilog.hpp"
 #include "coreir/definitions/corebitVerilog.hpp"
+#include "coreir/libs/commonlib.h"
 
 using namespace CoreIR;
 
 namespace {
 
 Module* create_module(Context* c, std::string mname) {
-  c->getLibraryManager()->loadLib("commonlib");
+  CoreIRLoadLibrary_commonlib(c);
   auto Bits16 = c->Bit()->Arr(16);
   auto ab = c->Record({
     {"a", c->In(Bits16)},


### PR DESCRIPTION
This updates the commonlib loading logic so that it works without having
corier installed into a system path (the current logic assumes it's
available somewhere, but sometimes when you're developing locally and
you don't have a copy installed into the system)