### PR TITLE
Pin verilogAST version to a specific directory

### DIFF
--- a/CMakeLists.txt.in
+++ b/CMakeLists.txt.in
@@ -7,7 +7,7 @@ project(verilogAST-download NONE)
 include(ExternalProject)
 ExternalProject_Add(verilogAST
   GIT_REPOSITORY    https://github.com/leonardt/verilogAST-cpp.git
-  GIT_TAG           master
+  GIT_TAG           e2054f208bdf527ca7b4eda7649656f30d7ec86e
   SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/verilogAST-src"
   BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/verilogAST-build"
   CONFIGURE_COMMAND ""


### PR DESCRIPTION
While we normally keep coreir/verilogAST-cpp master branches in sync, this presents a problem with the https://github.com/StanfordAHA/aha flow.  Basically, coreir master may be updated, but other PRs into the main branch of the aha flow will use an older version of coreir (before the coreir bump PR has been merged), which will pull verilogAST-cpp master and may cause a build failure (since it's using an old commit of coreir not up to date with verilogAST-cpp master).  This avoids the issue by pinning the verilgoAST-cpp commit in the Cmake dependency logic