### PR TITLE
[verilog] Simplify instance input connection logic

### DIFF
--- a/src/passes/analysis/verilog.cpp
+++ b/src/passes/analysis/verilog.cpp
@@ -984,6 +984,14 @@ void assign_inouts(
   };
 }
 
+bool isMemModule(Module* module) {
+  return module->isGenerated() &&
+    ((module->getGenerator()->getName() == "mem" &&
+      module->getGenerator()->getNamespace()->getName() == "coreir") ||
+     (module->getGenerator()->getName() == "rom2" &&
+      module->getGenerator()->getNamespace()->getName() == "memory"));
+}
+
 // Traverses the instance map and creates a vector of module instantiations
 // using connection_map to wire up instance ports
 std::vector<std::variant<
@@ -1135,13 +1143,7 @@ Passes::Verilog::compileModuleBody(
         }
       }
     }
-    bool is_mem_inst = instance_module->isGenerated() &&
-      ((instance_module->getGenerator()->getName() == "mem" &&
-        instance_module->getGenerator()->getNamespace()->getName() ==
-          "coreir") ||
-       (instance_module->getGenerator()->getName() == "rom2" &&
-        instance_module->getGenerator()->getNamespace()->getName() ==
-          "memory"));
+    bool is_mem_inst = isMemModule(instance_module);
     // Handle module arguments
     if (instance.second->hasModArgs()) {
       for (auto parameter : instance.second->getModArgs()) {

--- a/src/passes/analysis/verilog.cpp
+++ b/src/passes/analysis/verilog.cpp
@@ -856,7 +856,7 @@ processSingleArrayElementTarget(
 // unpacked concat doesn't seem to work with ncsim/garnet test,
 // so instead we emit an assignment statement for each index of the
 // unpacked array
-void wireUnpackecDriver(
+void wireUnpackedDriver(
   std::vector<std::variant<
     std::unique_ptr<vAST::StructuralStatement>,
     std::unique_ptr<vAST::Declaration>>>& body,
@@ -886,7 +886,7 @@ void wireUnpackecDriver(
     if (auto ptr = dynamic_cast<vAST::Concat*>(curr_arg.get())) {
       if (ptr->unpacked) {
         curr_arg.release();
-        wireUnpackecDriver(
+        wireUnpackedDriver(
           body,
           std::unique_ptr<vAST::Concat>(ptr),
           std::move(curr_target));
@@ -922,7 +922,7 @@ void assign_module_outputs(
           field,
           _inline);
       if (concat->unpacked) {
-        wireUnpackecDriver(body, std::move(concat), vAST::make_id(field));
+        wireUnpackedDriver(body, std::move(concat), vAST::make_id(field));
       }
       else {
         body.push_back(std::make_unique<vAST::ContinuousAssign>(
@@ -1077,7 +1077,7 @@ Passes::Verilog::compileModuleBody(
           verilog_connections->insert(
             field,
             std::make_unique<vAST::Identifier>(wire_name));
-          wireUnpackecDriver(body, std::move(concat), vAST::make_id(wire_name));
+          wireUnpackedDriver(body, std::move(concat), vAST::make_id(wire_name));
           continue;
         }
         driver = std::move(concat);

--- a/src/passes/analysis/verilog.cpp
+++ b/src/passes/analysis/verilog.cpp
@@ -1105,21 +1105,18 @@ Passes::Verilog::compileModuleBody(
             wire_name,
             field_type,
             entries);
-        auto target_id = dynamic_cast<vAST::Identifier*>(driver.get());
+        auto driver_id = dynamic_cast<vAST::Identifier*>(driver.get());
+        auto driver_index = dynamic_cast<vAST::Index*>(driver.get());
+        auto driver_slice = dynamic_cast<vAST::Slice*>(driver.get());
         if (
-          target_id &&
-          (std::holds_alternative<std::unique_ptr<vAST::Identifier>>(target) ||
-           std::holds_alternative<std::unique_ptr<vAST::Index>>(target) ||
-           std::holds_alternative<std::unique_ptr<vAST::Slice>>(target))) {
+          (driver_id || driver_index || driver_slice) &&
+          std::holds_alternative<std::unique_ptr<vAST::Identifier>>(target)) {
           // If it's not a concat, we connect it directly and prevent it from
           // being inlined
           //
           // slices/indices are blacklisted automatically, but identifiers need
           // to be marked
-          if (std::holds_alternative<std::unique_ptr<vAST::Identifier>>(
-                target)) {
-            this->wires.insert(target_id->value);
-          }
+          if (driver_id) { this->wires.insert(driver_id->value); }
           verilog_connections->insert(field, std::move(driver));
         }
         else {

--- a/tests/binary/gold/concat.v
+++ b/tests/binary/gold/concat.v
@@ -24,39 +24,31 @@ module concats (
     input [15:0] in,
     output [15:0] out
 );
-wire [3:0] cc0_in0;
-wire [11:0] cc0_in1;
 wire [15:0] cc0_out;
-wire [15:0] s0_in;
 wire [3:0] s0_out;
-wire [15:0] s1_in;
 wire [11:0] s1_out;
-assign cc0_in0 = s0_out;
-assign cc0_in1 = s1_out;
 coreir_concat #(
     .width0(4),
     .width1(12)
 ) cc0 (
-    .in0(cc0_in0),
-    .in1(cc0_in1),
+    .in0(s0_out),
+    .in1(s1_out),
     .out(cc0_out)
 );
-assign s0_in = in;
 coreir_slice #(
     .hi(16),
     .lo(12),
     .width(16)
 ) s0 (
-    .in(s0_in),
+    .in(in),
     .out(s0_out)
 );
-assign s1_in = in;
 coreir_slice #(
     .hi(15),
     .lo(3),
     .width(16)
 ) s1 (
-    .in(s1_in),
+    .in(in),
     .out(s1_out)
 );
 assign out = cc0_out;

--- a/tests/binary/gold/mantle_reg_ce.v
+++ b/tests/binary/gold/mantle_reg_ce.v
@@ -21,20 +21,14 @@ module test (
     input CLK,
     input CE
 );
-wire [15:0] Register_has_ce_True_has_reset_False_has_async_reset_False_has_async_resetn_False_type_Bits_n_16_inst0$value__CE_in;
-wire Register_has_ce_True_has_reset_False_has_async_reset_False_has_async_resetn_False_type_Bits_n_16_inst0$value__CE_ce;
 wire [15:0] Register_has_ce_True_has_reset_False_has_async_reset_False_has_async_resetn_False_type_Bits_n_16_inst0$value__CE_out;
-wire Register_has_ce_True_has_reset_False_has_async_reset_False_has_async_resetn_False_type_Bits_n_16_inst0$value__CE_clk;
-assign Register_has_ce_True_has_reset_False_has_async_reset_False_has_async_resetn_False_type_Bits_n_16_inst0$value__CE_in = In0;
-assign Register_has_ce_True_has_reset_False_has_async_reset_False_has_async_resetn_False_type_Bits_n_16_inst0$value__CE_ce = CE;
-assign Register_has_ce_True_has_reset_False_has_async_reset_False_has_async_resetn_False_type_Bits_n_16_inst0$value__CE_clk = CLK;
 regCE #(
     .width(16)
 ) Register_has_ce_True_has_reset_False_has_async_reset_False_has_async_resetn_False_type_Bits_n_16_inst0$value__CE (
-    .in(Register_has_ce_True_has_reset_False_has_async_reset_False_has_async_resetn_False_type_Bits_n_16_inst0$value__CE_in),
-    .ce(Register_has_ce_True_has_reset_False_has_async_reset_False_has_async_resetn_False_type_Bits_n_16_inst0$value__CE_ce),
+    .in(In0),
+    .ce(CE),
     .out(Register_has_ce_True_has_reset_False_has_async_reset_False_has_async_resetn_False_type_Bits_n_16_inst0$value__CE_out),
-    .clk(Register_has_ce_True_has_reset_False_has_async_reset_False_has_async_resetn_False_type_Bits_n_16_inst0$value__CE_clk)
+    .clk(CLK)
 );
 assign Out0 = Register_has_ce_True_has_reset_False_has_async_reset_False_has_async_resetn_False_type_Bits_n_16_inst0$value__CE_out;
 endmodule

--- a/tests/binary/gold/mantle_reg_ce_arst.v
+++ b/tests/binary/gold/mantle_reg_ce_arst.v
@@ -27,24 +27,16 @@ module test (
     input CE,
     input ASYNCRESET
 );
-wire [15:0] Register_has_ce_True_has_reset_False_has_async_reset_True_has_async_resetn_False_type_Bits_n_16_inst0$value__CE_in;
-wire Register_has_ce_True_has_reset_False_has_async_reset_True_has_async_resetn_False_type_Bits_n_16_inst0$value__CE_ce;
 wire [15:0] Register_has_ce_True_has_reset_False_has_async_reset_True_has_async_resetn_False_type_Bits_n_16_inst0$value__CE_out;
-wire Register_has_ce_True_has_reset_False_has_async_reset_True_has_async_resetn_False_type_Bits_n_16_inst0$value__CE_clk;
-wire Register_has_ce_True_has_reset_False_has_async_reset_True_has_async_resetn_False_type_Bits_n_16_inst0$value__CE_arst;
-assign Register_has_ce_True_has_reset_False_has_async_reset_True_has_async_resetn_False_type_Bits_n_16_inst0$value__CE_in = In0;
-assign Register_has_ce_True_has_reset_False_has_async_reset_True_has_async_resetn_False_type_Bits_n_16_inst0$value__CE_ce = CE;
-assign Register_has_ce_True_has_reset_False_has_async_reset_True_has_async_resetn_False_type_Bits_n_16_inst0$value__CE_clk = CLK;
-assign Register_has_ce_True_has_reset_False_has_async_reset_True_has_async_resetn_False_type_Bits_n_16_inst0$value__CE_arst = ASYNCRESET;
 regCE_arst #(
     .init(16'h0000),
     .width(16)
 ) Register_has_ce_True_has_reset_False_has_async_reset_True_has_async_resetn_False_type_Bits_n_16_inst0$value__CE (
-    .in(Register_has_ce_True_has_reset_False_has_async_reset_True_has_async_resetn_False_type_Bits_n_16_inst0$value__CE_in),
-    .ce(Register_has_ce_True_has_reset_False_has_async_reset_True_has_async_resetn_False_type_Bits_n_16_inst0$value__CE_ce),
+    .in(In0),
+    .ce(CE),
     .out(Register_has_ce_True_has_reset_False_has_async_reset_True_has_async_resetn_False_type_Bits_n_16_inst0$value__CE_out),
-    .clk(Register_has_ce_True_has_reset_False_has_async_reset_True_has_async_resetn_False_type_Bits_n_16_inst0$value__CE_clk),
-    .arst(Register_has_ce_True_has_reset_False_has_async_reset_True_has_async_resetn_False_type_Bits_n_16_inst0$value__CE_arst)
+    .clk(CLK),
+    .arst(ASYNCRESET)
 );
 assign Out0 = Register_has_ce_True_has_reset_False_has_async_reset_True_has_async_resetn_False_type_Bits_n_16_inst0$value__CE_out;
 endmodule

--- a/tests/gtest/array_select_golden.v
+++ b/tests/gtest/array_select_golden.v
@@ -6,15 +6,15 @@ module top (
     input [3:0] self_I,
     output [3:0] O
 );
-wire [3:0] inst0_I;
 wire [3:0] inst0_O;
-wire [3:0] inst1_I;
 wire [3:0] inst1_O;
+wire [3:0] inst0_I;
 assign inst0_I = {self_I[2],self_I[1],self_I[0],self_I[0]};
 foo inst0 (
     .I(inst0_I),
     .O(inst0_O)
 );
+wire [3:0] inst1_I;
 assign inst1_I = {self_I[1],inst0_O[1],inst0_O[1],inst0_O[0]};
 foo inst1 (
     .I(inst1_I),

--- a/tests/gtest/blackbox_verilog_golden.v
+++ b/tests/gtest/blackbox_verilog_golden.v
@@ -6,10 +6,8 @@ module top (
     input I,
     output O
 );
-wire inst0_I;
-assign inst0_I = I;
 foo inst0 (
-    .I(inst0_I),
+    .I(I),
     .O(O)
 );
 endmodule

--- a/tests/gtest/debug_info_golden.v
+++ b/tests/gtest/debug_info_golden.v
@@ -6,23 +6,16 @@ module main (
     output [1:0] O1
 );
 // Module `main` defined at tests/test_circuit/test_define.py:57
-wire and2_0_I0;
-wire and2_0_I1;
 wire and2_0_O;
-wire and2_1_I0;
-wire and2_1_I1;
 wire and2_1_O;
-wire and2_2_I0;
-wire and2_2_I1;
 wire and2_2_O;
-wire and2_3_I0;
-wire and2_3_I1;
 wire and2_3_O;
-wire [1:0] term0_I;
 // Instance `and2_0` created at tests/test_circuit/test_define.py:61
 // Connection `(and2_0.I0, I[0])` created at tests/test_circuit/test_define.py:63
+wire and2_0_I0;
 assign and2_0_I0 = I[0];
 // Connection `(and2_0.I1, I[1])` created at tests/test_circuit/test_define.py:64
+wire and2_0_I1;
 assign and2_0_I1 = I[1];
 And2 and2_0 (
     .I0(and2_0_I0),
@@ -31,37 +24,38 @@ And2 and2_0 (
 );
 // Instance `and2_1` created at tests/test_circuit/test_define.py:61
 // Connection `(and2_1.I0, and2_0_O)` created at tests/test_circuit/test_define.py:66
-assign and2_1_I0 = and2_0_O;
 // Connection `(and2_1.I1, I[1])` created at tests/test_circuit/test_define.py:67
+wire and2_1_I1;
 assign and2_1_I1 = I[1];
 And2 and2_1 (
-    .I0(and2_1_I0),
+    .I0(and2_0_O),
     .I1(and2_1_I1),
     .O(and2_1_O)
 );
 // Instance `and2_2` created at tests/test_circuit/test_define.py:61
 // Connection `(and2_2.I0, and2_1_O)` created at tests/test_circuit/test_define.py:66
-assign and2_2_I0 = and2_1_O;
 // Connection `(and2_2.I1, I[1])` created at tests/test_circuit/test_define.py:67
+wire and2_2_I1;
 assign and2_2_I1 = I[1];
 And2 and2_2 (
-    .I0(and2_2_I0),
+    .I0(and2_1_O),
     .I1(and2_2_I1),
     .O(and2_2_O)
 );
 // Instance `and2_3` created at tests/test_circuit/test_define.py:61
 // Connection `(and2_3.I0, and2_2_O)` created at tests/test_circuit/test_define.py:66
-assign and2_3_I0 = and2_2_O;
 // Connection `(and2_3.I1, I[1])` created at tests/test_circuit/test_define.py:67
+wire and2_3_I1;
 assign and2_3_I1 = I[1];
 And2 and2_3 (
-    .I0(and2_3_I0),
+    .I0(and2_2_O),
     .I1(and2_3_I1),
     .O(and2_3_O)
 );
 // Instance `term0` created at tests/test_circuit/test_define.py:77
 // Connection `(term0.I[1], and2_2_O)` created at tests/test_circuit/test_define.py:103
 // Connection `(term0.I[0], and2_3_O)` created at tests/test_circuit/test_define.py:99
+wire [1:0] term0_I;
 assign term0_I = {and2_2_O,and2_3_O};
 Term2 term0 (
     .I(term0_I)

--- a/tests/gtest/debug_info_golden.v
+++ b/tests/gtest/debug_info_golden.v
@@ -12,44 +12,34 @@ wire and2_2_O;
 wire and2_3_O;
 // Instance `and2_0` created at tests/test_circuit/test_define.py:61
 // Connection `(and2_0.I0, I[0])` created at tests/test_circuit/test_define.py:63
-wire and2_0_I0;
-assign and2_0_I0 = I[0];
 // Connection `(and2_0.I1, I[1])` created at tests/test_circuit/test_define.py:64
-wire and2_0_I1;
-assign and2_0_I1 = I[1];
 And2 and2_0 (
-    .I0(and2_0_I0),
-    .I1(and2_0_I1),
+    .I0(I[0]),
+    .I1(I[1]),
     .O(and2_0_O)
 );
 // Instance `and2_1` created at tests/test_circuit/test_define.py:61
 // Connection `(and2_1.I0, and2_0_O)` created at tests/test_circuit/test_define.py:66
 // Connection `(and2_1.I1, I[1])` created at tests/test_circuit/test_define.py:67
-wire and2_1_I1;
-assign and2_1_I1 = I[1];
 And2 and2_1 (
     .I0(and2_0_O),
-    .I1(and2_1_I1),
+    .I1(I[1]),
     .O(and2_1_O)
 );
 // Instance `and2_2` created at tests/test_circuit/test_define.py:61
 // Connection `(and2_2.I0, and2_1_O)` created at tests/test_circuit/test_define.py:66
 // Connection `(and2_2.I1, I[1])` created at tests/test_circuit/test_define.py:67
-wire and2_2_I1;
-assign and2_2_I1 = I[1];
 And2 and2_2 (
     .I0(and2_1_O),
-    .I1(and2_2_I1),
+    .I1(I[1]),
     .O(and2_2_O)
 );
 // Instance `and2_3` created at tests/test_circuit/test_define.py:61
 // Connection `(and2_3.I0, and2_2_O)` created at tests/test_circuit/test_define.py:66
 // Connection `(and2_3.I1, I[1])` created at tests/test_circuit/test_define.py:67
-wire and2_3_I1;
-assign and2_3_I1 = I[1];
 And2 and2_3 (
     .I0(and2_2_O),
-    .I1(and2_3_I1),
+    .I1(I[1]),
     .O(and2_3_O)
 );
 // Instance `term0` created at tests/test_circuit/test_define.py:77

--- a/tests/gtest/golds/arr_tuple.v
+++ b/tests/gtest/golds/arr_tuple.v
@@ -5,17 +5,13 @@ module Main (
     input z_1_x,
     output z_1_y
 );
-wire Foo_inst0_z_0_x;
 wire Foo_inst0_z_0_y;
-wire Foo_inst0_z_1_x;
 wire a_x;
 wire a_y;
-assign Foo_inst0_z_0_x = a_y;
-assign Foo_inst0_z_1_x = z_0_x;
 Foo Foo_inst0 (
-    .z_0_x(Foo_inst0_z_0_x),
+    .z_0_x(a_y),
     .z_0_y(Foo_inst0_z_0_y),
-    .z_1_x(Foo_inst0_z_1_x),
+    .z_1_x(z_0_x),
     .z_1_y(z_1_y)
 );
 assign a_x = Foo_inst0_z_0_y;

--- a/tests/gtest/golds/bits_instance.v
+++ b/tests/gtest/golds/bits_instance.v
@@ -3,12 +3,10 @@ module Main (
     input [4:0] I,
     output [4:0] O
 );
-wire [4:0] Foo_inst0_I;
 wire [4:0] Foo_inst0_O;
 wire [4:0] x;
-assign Foo_inst0_I = I;
 Foo Foo_inst0 (
-    .I(Foo_inst0_I),
+    .I(I),
     .O(Foo_inst0_O)
 );
 assign x = Foo_inst0_O;

--- a/tests/gtest/golds/camera_pipeline_dse1.v
+++ b/tests/gtest/golds/camera_pipeline_dse1.v
@@ -24,17 +24,15 @@ module mantle_reg__has_clrFalse__has_enTrue__has_rstFalse__width16 #(
     output [15:0] out,
     input en
 );
-wire reg0_clk;
-wire [15:0] reg0_in;
-assign reg0_clk = clk;
-assign reg0_in = en ? in : out;
+wire [15:0] enMux_out;
+assign enMux_out = en ? in : out;
 coreir_reg #(
     .clk_posedge(1'b1),
     .init(init),
     .width(16)
 ) reg0 (
-    .clk(reg0_clk),
-    .in(reg0_in),
+    .clk(clk),
+    .in(enMux_out),
     .out(out)
 );
 endmodule
@@ -89,21 +87,12 @@ module memory_rom2__depth255__width16 #(
     input [15:0] raddr,
     input ren
 );
-wire mem_clk;
-wire [15:0] mem_wdata;
-wire [7:0] mem_waddr;
-wire mem_wen;
 wire [15:0] mem_rdata;
-wire [7:0] mem_raddr;
-wire [15:0] readreg_in;
-wire readreg_clk;
-wire readreg_en;
+wire [7:0] raddr_slice_out;
+wire [7:0] waddr0_out;
 wire [15:0] wdata0_out;
-assign mem_clk = clk;
-assign mem_wdata = wdata0_out;
-assign mem_waddr = 8'h00;
+wire mem_wen;
 assign mem_wen = wdata0_out[0];
-assign mem_raddr = raddr[8 - 1:0];
 coreir_mem #(
     .init(init),
     .depth(255),
@@ -111,24 +100,23 @@ coreir_mem #(
     .sync_read(1'b0),
     .width(16)
 ) mem (
-    .clk(mem_clk),
-    .wdata(mem_wdata),
-    .waddr(mem_waddr),
+    .clk(clk),
+    .wdata(wdata0_out),
+    .waddr(waddr0_out),
     .wen(mem_wen),
     .rdata(mem_rdata),
-    .raddr(mem_raddr)
+    .raddr(raddr_slice_out)
 );
-assign readreg_in = mem_rdata;
-assign readreg_clk = clk;
-assign readreg_en = ren;
+assign raddr_slice_out = raddr[8 - 1:0];
 mantle_reg__has_clrFalse__has_enTrue__has_rstFalse__width16 #(
     .init(16'h0000)
 ) readreg (
-    .in(readreg_in),
-    .clk(readreg_clk),
+    .in(mem_rdata),
+    .clk(clk),
     .out(rdata),
-    .en(readreg_en)
+    .en(ren)
 );
+assign waddr0_out = 8'h00;
 assign wdata0_out = 16'h0000;
 endmodule
 
@@ -153,38 +141,30 @@ module hcompute_hw_output_stencil (
     input [15:0] in0_f6_stencil_0,
     output [15:0] out_hw_output_stencil
 );
-wire curve$1_clk;
-wire [15:0] curve$1_raddr;
-wire curve$1_ren;
-wire [15:0] smax_1597_1598_1599_in0;
-wire [15:0] smax_1597_1598_1599_in1;
+wire [15:0] const0__1598_out;
+wire [15:0] const1023__1596_out;
+wire curve$1_ren_out;
 wire [15:0] smax_1597_1598_1599_out;
-wire [15:0] smin_f6_stencil_1_1596_1597_in0;
-wire [15:0] smin_f6_stencil_1_1596_1597_in1;
 wire [15:0] smin_f6_stencil_1_1596_1597_out;
-assign curve$1_clk = clk;
-assign curve$1_raddr = smax_1597_1598_1599_out;
-assign curve$1_ren = 1'b1;
+assign const0__1598_out = 16'h0000;
+assign const1023__1596_out = 16'h03ff;
 memory_rom2__depth255__width16 #(
     .init({16'd63,16'd63,16'd62,16'd62,16'd62,16'd62,16'd61,16'd61,16'd61,16'd61,16'd60,16'd60,16'd60,16'd60,16'd59,16'd59,16'd59,16'd59,16'd58,16'd58,16'd58,16'd58,16'd57,16'd57,16'd57,16'd57,16'd56,16'd56,16'd56,16'd56,16'd55,16'd55,16'd55,16'd55,16'd54,16'd54,16'd54,16'd54,16'd53,16'd53,16'd53,16'd53,16'd52,16'd52,16'd52,16'd52,16'd51,16'd51,16'd51,16'd51,16'd50,16'd50,16'd50,16'd50,16'd49,16'd49,16'd49,16'd49,16'd48,16'd48,16'd48,16'd48,16'd47,16'd47,16'd47,16'd47,16'd46,16'd46,16'd46,16'd46,16'd45,16'd45,16'd45,16'd45,16'd44,16'd44,16'd44,16'd44,16'd43,16'd43,16'd43,16'd43,16'd42,16'd42,16'd42,16'd42,16'd41,16'd41,16'd41,16'd41,16'd40,16'd40,16'd40,16'd40,16'd39,16'd39,16'd39,16'd39,16'd38,16'd38,16'd38,16'd38,16'd37,16'd37,16'd37,16'd37,16'd36,16'd36,16'd36,16'd36,16'd35,16'd35,16'd35,16'd35,16'd34,16'd34,16'd34,16'd34,16'd33,16'd33,16'd33,16'd33,16'd32,16'd32,16'd32,16'd32,16'd31,16'd31,16'd31,16'd31,16'd30,16'd30,16'd30,16'd30,16'd29,16'd29,16'd29,16'd29,16'd28,16'd28,16'd28,16'd28,16'd27,16'd27,16'd27,16'd27,16'd26,16'd26,16'd26,16'd26,16'd25,16'd25,16'd25,16'd25,16'd24,16'd24,16'd24,16'd24,16'd23,16'd23,16'd23,16'd23,16'd22,16'd22,16'd22,16'd22,16'd21,16'd21,16'd21,16'd21,16'd20,16'd20,16'd20,16'd20,16'd19,16'd19,16'd19,16'd19,16'd18,16'd18,16'd18,16'd18,16'd17,16'd17,16'd17,16'd17,16'd16,16'd16,16'd16,16'd16,16'd15,16'd15,16'd15,16'd15,16'd14,16'd14,16'd14,16'd14,16'd13,16'd13,16'd13,16'd13,16'd12,16'd12,16'd12,16'd12,16'd11,16'd11,16'd11,16'd11,16'd10,16'd10,16'd10,16'd10,16'd9,16'd9,16'd9,16'd9,16'd8,16'd8,16'd8,16'd8,16'd7,16'd7,16'd7,16'd7,16'd6,16'd6,16'd6,16'd6,16'd5,16'd5,16'd5,16'd5,16'd4,16'd4,16'd4,16'd4,16'd3,16'd3,16'd3,16'd3,16'd2,16'd2,16'd2,16'd2,16'd1,16'd1,16'd1,16'd1,16'd0,16'd0,16'd0,16'd0,16'd0})
 ) curve$1 (
-    .clk(curve$1_clk),
+    .clk(clk),
     .rdata(out_hw_output_stencil),
-    .raddr(curve$1_raddr),
-    .ren(curve$1_ren)
+    .raddr(smax_1597_1598_1599_out),
+    .ren(curve$1_ren_out)
 );
-assign smax_1597_1598_1599_in0 = smin_f6_stencil_1_1596_1597_out;
-assign smax_1597_1598_1599_in1 = 16'h0000;
+assign curve$1_ren_out = 1'b1;
 commonlib_smax__width16 smax_1597_1598_1599 (
-    .in0(smax_1597_1598_1599_in0),
-    .in1(smax_1597_1598_1599_in1),
+    .in0(smin_f6_stencil_1_1596_1597_out),
+    .in1(const0__1598_out),
     .out(smax_1597_1598_1599_out)
 );
-assign smin_f6_stencil_1_1596_1597_in0 = in0_f6_stencil_0;
-assign smin_f6_stencil_1_1596_1597_in1 = 16'h03ff;
 commonlib_smin__width16 smin_f6_stencil_1_1596_1597 (
-    .in0(smin_f6_stencil_1_1596_1597_in0),
-    .in1(smin_f6_stencil_1_1596_1597_in1),
+    .in0(in0_f6_stencil_0),
+    .in1(const1023__1596_out),
     .out(smin_f6_stencil_1_1596_1597_out)
 );
 endmodule

--- a/tests/gtest/golds/camera_pipeline_dse1.v
+++ b/tests/gtest/golds/camera_pipeline_dse1.v
@@ -91,8 +91,6 @@ wire [15:0] mem_rdata;
 wire [7:0] raddr_slice_out;
 wire [7:0] waddr0_out;
 wire [15:0] wdata0_out;
-wire mem_wen;
-assign mem_wen = wdata0_out[0];
 coreir_mem #(
     .init(init),
     .depth(255),
@@ -103,7 +101,7 @@ coreir_mem #(
     .clk(clk),
     .wdata(wdata0_out),
     .waddr(waddr0_out),
-    .wen(mem_wen),
+    .wen(wdata0_out[0]),
     .rdata(mem_rdata),
     .raddr(raddr_slice_out)
 );

--- a/tests/gtest/golds/hierarchical_select.v
+++ b/tests/gtest/golds/hierarchical_select.v
@@ -3,10 +3,8 @@ module Bar (
     input I,
     output O
 );
-wire Baz_inst0_I;
-assign Baz_inst0_I = I;
 Baz Baz_inst0 (
-    .I(Baz_inst0_I),
+    .I(I),
     .O(O)
 );
 endmodule
@@ -16,13 +14,11 @@ module Foo (
     output O0,
     output O1
 );
-wire Bar_inst0_I;
-wire Bar_inst1_I;
-assign Bar_inst0_I = I;
 Bar Bar_inst0 (
-    .I(Bar_inst0_I),
+    .I(I),
     .O(O0)
 );
+wire Bar_inst1_I;
 assign Bar_inst1_I = Bar_inst0.Baz_inst0.O;
 Bar Bar_inst1 (
     .I(Bar_inst1_I),

--- a/tests/gtest/golds/hierarchical_select_2.v
+++ b/tests/gtest/golds/hierarchical_select_2.v
@@ -3,10 +3,8 @@ module Baz (
     input I,
     output O
 );
-wire Buzz_inst0_I;
-assign Buzz_inst0_I = I;
 Buzz Buzz_inst0 (
-    .I(Buzz_inst0_I),
+    .I(I),
     .O(O)
 );
 endmodule
@@ -15,10 +13,8 @@ module Bar (
     input I,
     output O
 );
-wire Baz_inst0_I;
-assign Baz_inst0_I = I;
 Baz Baz_inst0 (
-    .I(Baz_inst0_I),
+    .I(I),
     .O(O)
 );
 endmodule
@@ -28,13 +24,11 @@ module Foo (
     output O0,
     output O1
 );
-wire Bar_inst0_I;
-wire Bar_inst1_I;
-assign Bar_inst0_I = I;
 Bar Bar_inst0 (
-    .I(Bar_inst0_I),
+    .I(I),
     .O(O0)
 );
+wire Bar_inst1_I;
 assign Bar_inst1_I = Bar_inst0.Baz_inst0.Buzz_inst0.O;
 Bar Bar_inst1 (
     .I(Bar_inst1_I),

--- a/tests/gtest/golds/hierarchical_select_3.v
+++ b/tests/gtest/golds/hierarchical_select_3.v
@@ -3,10 +3,8 @@ module Baz (
     input I,
     output O
 );
-wire O_I;
-assign O_I = I;
 Buzz O (
-    .I(O_I),
+    .I(I),
     .O(O)
 );
 endmodule
@@ -15,10 +13,8 @@ module Bar (
     input I,
     output O
 );
-wire O_I;
-assign O_I = I;
 Baz O (
-    .I(O_I),
+    .I(I),
     .O(O)
 );
 endmodule
@@ -28,13 +24,11 @@ module Foo (
     output O0,
     output O1
 );
-wire Bar_inst0_I;
-wire Bar_inst1_I;
-assign Bar_inst0_I = I;
 Bar Bar_inst0 (
-    .I(Bar_inst0_I),
+    .I(I),
     .O(O0)
 );
+wire Bar_inst1_I;
 assign Bar_inst1_I = Bar_inst0.O.O.O;
 Bar Bar_inst1 (
     .I(Bar_inst1_I),

--- a/tests/gtest/golds/muxn_ndarray.v
+++ b/tests/gtest/golds/muxn_ndarray.v
@@ -31,12 +31,12 @@ module commonlib_muxn__N2__width32 (
     input [0:0] in_sel,
     output [31:0] out
 );
-wire [31:0] _join_in0;
-wire [31:0] _join_in1;
-wire _join_sel;
 wire [31:0] _join_out;
+wire [31:0] _join_in0;
 assign _join_in0 = in_data[0];
+wire [31:0] _join_in1;
 assign _join_in1 = in_data[1];
+wire _join_sel;
 assign _join_sel = in_sel[0];
 coreir_mux #(
     .width(32)
@@ -54,63 +54,51 @@ module commonlib_muxn__N4__width32 (
     input [1:0] in_sel,
     output [31:0] out
 );
-wire [31:0] _join_in0;
-wire [31:0] _join_in1;
-wire _join_sel;
 wire [31:0] _join_out;
-wire [31:0] muxN_0_in_data [1:0];
-wire [0:0] muxN_0_in_sel;
 wire [31:0] muxN_0_out;
-wire [31:0] muxN_1_in_data [1:0];
-wire [0:0] muxN_1_in_sel;
 wire [31:0] muxN_1_out;
-wire [1:0] sel_slice0_in;
 wire [0:0] sel_slice0_out;
-wire [1:0] sel_slice1_in;
 wire [0:0] sel_slice1_out;
-assign _join_in0 = muxN_0_out;
-assign _join_in1 = muxN_1_out;
+wire _join_sel;
 assign _join_sel = in_sel[1];
 coreir_mux #(
     .width(32)
 ) _join (
-    .in0(_join_in0),
-    .in1(_join_in1),
+    .in0(muxN_0_out),
+    .in1(muxN_1_out),
     .sel(_join_sel),
     .out(_join_out)
 );
+wire [31:0] muxN_0_in_data [1:0];
 assign muxN_0_in_data[1] = in_data[1];
 assign muxN_0_in_data[0] = in_data[0];
-assign muxN_0_in_sel = sel_slice0_out;
 commonlib_muxn__N2__width32 muxN_0 (
     .in_data(muxN_0_in_data),
-    .in_sel(muxN_0_in_sel),
+    .in_sel(sel_slice0_out),
     .out(muxN_0_out)
 );
+wire [31:0] muxN_1_in_data [1:0];
 assign muxN_1_in_data[1] = in_data[3];
 assign muxN_1_in_data[0] = in_data[2];
-assign muxN_1_in_sel = sel_slice1_out;
 commonlib_muxn__N2__width32 muxN_1 (
     .in_data(muxN_1_in_data),
-    .in_sel(muxN_1_in_sel),
+    .in_sel(sel_slice1_out),
     .out(muxN_1_out)
 );
-assign sel_slice0_in = in_sel;
 coreir_slice #(
     .hi(1),
     .lo(0),
     .width(2)
 ) sel_slice0 (
-    .in(sel_slice0_in),
+    .in(in_sel),
     .out(sel_slice0_out)
 );
-assign sel_slice1_in = in_sel;
 coreir_slice #(
     .hi(1),
     .lo(0),
     .width(2)
 ) sel_slice1 (
-    .in(sel_slice1_in),
+    .in(in_sel),
     .out(sel_slice1_out)
 );
 assign out = _join_out;
@@ -134,64 +122,52 @@ module commonlib_muxn__N5__width32 (
     input [2:0] in_sel,
     output [31:0] out
 );
-wire [31:0] _join_in0;
-wire [31:0] _join_in1;
-wire _join_sel;
 wire [31:0] _join_out;
-wire [31:0] muxN_0_in_data [3:0];
-wire [1:0] muxN_0_in_sel;
 wire [31:0] muxN_0_out;
-wire [31:0] muxN_1_in_data [0:0];
-wire [0:0] muxN_1_in_sel;
 wire [31:0] muxN_1_out;
-wire [2:0] sel_slice0_in;
 wire [1:0] sel_slice0_out;
-wire [2:0] sel_slice1_in;
 wire [0:0] sel_slice1_out;
-assign _join_in0 = muxN_0_out;
-assign _join_in1 = muxN_1_out;
+wire _join_sel;
 assign _join_sel = in_sel[2];
 coreir_mux #(
     .width(32)
 ) _join (
-    .in0(_join_in0),
-    .in1(_join_in1),
+    .in0(muxN_0_out),
+    .in1(muxN_1_out),
     .sel(_join_sel),
     .out(_join_out)
 );
+wire [31:0] muxN_0_in_data [3:0];
 assign muxN_0_in_data[3] = in_data[3];
 assign muxN_0_in_data[2] = in_data[2];
 assign muxN_0_in_data[1] = in_data[1];
 assign muxN_0_in_data[0] = in_data[0];
-assign muxN_0_in_sel = sel_slice0_out;
 commonlib_muxn__N4__width32 muxN_0 (
     .in_data(muxN_0_in_data),
-    .in_sel(muxN_0_in_sel),
+    .in_sel(sel_slice0_out),
     .out(muxN_0_out)
 );
+wire [31:0] muxN_1_in_data [0:0];
 assign muxN_1_in_data[0] = in_data[4];
-assign muxN_1_in_sel = sel_slice1_out;
 commonlib_muxn__N1__width32 muxN_1 (
     .in_data(muxN_1_in_data),
-    .in_sel(muxN_1_in_sel),
+    .in_sel(sel_slice1_out),
     .out(muxN_1_out)
 );
-assign sel_slice0_in = in_sel;
 coreir_slice #(
     .hi(2),
     .lo(0),
     .width(3)
 ) sel_slice0 (
-    .in(sel_slice0_in),
+    .in(in_sel),
     .out(sel_slice0_out)
 );
-assign sel_slice1_in = in_sel;
 coreir_slice #(
     .hi(1),
     .lo(0),
     .width(3)
 ) sel_slice1 (
-    .in(sel_slice1_in),
+    .in(in_sel),
     .out(sel_slice1_out)
 );
 assign out = _join_out;
@@ -202,18 +178,16 @@ module MuxWrapper_5_32 (
     output [31:0] O,
     input [2:0] S
 );
-wire [31:0] Mux5x32_inst0$coreir_commonlib_mux5x32_inst0_in_data [4:0];
-wire [2:0] Mux5x32_inst0$coreir_commonlib_mux5x32_inst0_in_sel;
 wire [31:0] Mux5x32_inst0$coreir_commonlib_mux5x32_inst0_out;
+wire [31:0] Mux5x32_inst0$coreir_commonlib_mux5x32_inst0_in_data [4:0];
 assign Mux5x32_inst0$coreir_commonlib_mux5x32_inst0_in_data[4] = I[4];
 assign Mux5x32_inst0$coreir_commonlib_mux5x32_inst0_in_data[3] = I[3];
 assign Mux5x32_inst0$coreir_commonlib_mux5x32_inst0_in_data[2] = I[2];
 assign Mux5x32_inst0$coreir_commonlib_mux5x32_inst0_in_data[1] = I[1];
 assign Mux5x32_inst0$coreir_commonlib_mux5x32_inst0_in_data[0] = I[0];
-assign Mux5x32_inst0$coreir_commonlib_mux5x32_inst0_in_sel = S;
 commonlib_muxn__N5__width32 Mux5x32_inst0$coreir_commonlib_mux5x32_inst0 (
     .in_data(Mux5x32_inst0$coreir_commonlib_mux5x32_inst0_in_data),
-    .in_sel(Mux5x32_inst0$coreir_commonlib_mux5x32_inst0_in_sel),
+    .in_sel(S),
     .out(Mux5x32_inst0$coreir_commonlib_mux5x32_inst0_out)
 );
 assign O = Mux5x32_inst0$coreir_commonlib_mux5x32_inst0_out;

--- a/tests/gtest/golds/muxn_ndarray.v
+++ b/tests/gtest/golds/muxn_ndarray.v
@@ -32,18 +32,12 @@ module commonlib_muxn__N2__width32 (
     output [31:0] out
 );
 wire [31:0] _join_out;
-wire [31:0] _join_in0;
-assign _join_in0 = in_data[0];
-wire [31:0] _join_in1;
-assign _join_in1 = in_data[1];
-wire _join_sel;
-assign _join_sel = in_sel[0];
 coreir_mux #(
     .width(32)
 ) _join (
-    .in0(_join_in0),
-    .in1(_join_in1),
-    .sel(_join_sel),
+    .in0(in_data[0]),
+    .in1(in_data[1]),
+    .sel(in_sel[0]),
     .out(_join_out)
 );
 assign out = _join_out;
@@ -59,14 +53,12 @@ wire [31:0] muxN_0_out;
 wire [31:0] muxN_1_out;
 wire [0:0] sel_slice0_out;
 wire [0:0] sel_slice1_out;
-wire _join_sel;
-assign _join_sel = in_sel[1];
 coreir_mux #(
     .width(32)
 ) _join (
     .in0(muxN_0_out),
     .in1(muxN_1_out),
-    .sel(_join_sel),
+    .sel(in_sel[1]),
     .out(_join_out)
 );
 wire [31:0] muxN_0_in_data [1:0];
@@ -109,10 +101,8 @@ module commonlib_muxn__N1__width32 (
     input [0:0] in_sel,
     output [31:0] out
 );
-wire term_sel_in;
-assign term_sel_in = in_sel[0];
 corebit_term term_sel (
-    .in(term_sel_in)
+    .in(in_sel[0])
 );
 assign out = in_data[0];
 endmodule
@@ -127,14 +117,12 @@ wire [31:0] muxN_0_out;
 wire [31:0] muxN_1_out;
 wire [1:0] sel_slice0_out;
 wire [0:0] sel_slice1_out;
-wire _join_sel;
-assign _join_sel = in_sel[2];
 coreir_mux #(
     .width(32)
 ) _join (
     .in0(muxN_0_out),
     .in1(muxN_1_out),
-    .sel(_join_sel),
+    .sel(in_sel[2]),
     .out(_join_out)
 );
 wire [31:0] muxN_0_in_data [3:0];

--- a/tests/gtest/golds/rom.v
+++ b/tests/gtest/golds/rom.v
@@ -77,4 +77,5 @@ Memory Memory_inst0 (
     .RDATA(rdata),
     .CLK(clk)
 );
-endmodula
+endmodule
+

--- a/tests/gtest/golds/rom.v
+++ b/tests/gtest/golds/rom.v
@@ -45,16 +45,12 @@ module Memory (
     output [4:0] RDATA,
     input CLK
 );
-wire coreir_mem4x5_inst0_clk;
-wire [4:0] coreir_mem4x5_inst0_wdata;
-wire [1:0] coreir_mem4x5_inst0_waddr;
-wire coreir_mem4x5_inst0_wen;
-wire [1:0] coreir_mem4x5_inst0_raddr;
-assign coreir_mem4x5_inst0_clk = CLK;
-assign coreir_mem4x5_inst0_wdata = 5'h00;
-assign coreir_mem4x5_inst0_waddr = 2'h0;
-assign coreir_mem4x5_inst0_wen = 1'b0;
-assign coreir_mem4x5_inst0_raddr = RADDR;
+wire bit_const_0_None_out;
+wire [1:0] const_0_2_out;
+wire [4:0] const_0_5_out;
+assign bit_const_0_None_out = 1'b0;
+assign const_0_2_out = 2'h0;
+assign const_0_5_out = 5'h00;
 coreir_mem #(
     .init({5'd11,5'd21,5'd0,5'd5}),
     .depth(4),
@@ -62,12 +58,12 @@ coreir_mem #(
     .sync_read(1'b0),
     .width(5)
 ) coreir_mem4x5_inst0 (
-    .clk(coreir_mem4x5_inst0_clk),
-    .wdata(coreir_mem4x5_inst0_wdata),
-    .waddr(coreir_mem4x5_inst0_waddr),
-    .wen(coreir_mem4x5_inst0_wen),
+    .clk(CLK),
+    .wdata(const_0_5_out),
+    .waddr(const_0_2_out),
+    .wen(bit_const_0_None_out),
     .rdata(RDATA),
-    .raddr(coreir_mem4x5_inst0_raddr)
+    .raddr(RADDR)
 );
 endmodule
 
@@ -76,14 +72,9 @@ module test_memory_read_only (
     output [4:0] rdata,
     input clk
 );
-wire [1:0] Memory_inst0_RADDR;
-wire Memory_inst0_CLK;
-assign Memory_inst0_RADDR = raddr;
-assign Memory_inst0_CLK = clk;
 Memory Memory_inst0 (
-    .RADDR(Memory_inst0_RADDR),
+    .RADDR(raddr),
     .RDATA(rdata),
-    .CLK(Memory_inst0_CLK)
+    .CLK(clk)
 );
-endmodule
-
+endmodula

--- a/tests/gtest/golds/slice_combview.v
+++ b/tests/gtest/golds/slice_combview.v
@@ -5,14 +5,12 @@ module top (
     output [15:0] out,
     input CLK
 );
-wire value_snk_clk;
-wire [15:0] value_snk_in;
+wire [15:0] _$_U1;
 wire [15:0] value_src_out;
-assign value_snk_clk = CLK;
-assign value_snk_in = {in[7:0],in[15:8]};
+assign _$_U1 = {in[7:0],in[15:8]};
 coreir_coreir_reg__width16_snk value_snk (
-    .clk(value_snk_clk),
-    .in(value_snk_in)
+    .clk(CLK),
+    .in(_$_U1)
 );
 coreir_coreir_reg__width16_src value_src (
     .out(value_src_out)

--- a/tests/gtest/golds/uart.v
+++ b/tests/gtest/golds/uart.v
@@ -265,8 +265,6 @@ wire [1:0] UART_comb_inst0_O3;
 wire [7:0] reg_PR_inst0_out;
 wire [2:0] reg_PR_inst1_out;
 wire [1:0] reg_PR_inst2_out;
-wire [0:0] DFF_initTrue_has_ceFalse_has_resetFalse_has_async_resetTrue_inst0$reg_PR_inst0_in;
-assign DFF_initTrue_has_ceFalse_has_resetFalse_has_async_resetTrue_inst0$reg_PR_inst0_in[0] = UART_comb_inst0_O2;
 coreir_reg_arst #(
     .arst_posedge(1'b1),
     .clk_posedge(1'b1),
@@ -275,7 +273,7 @@ coreir_reg_arst #(
 ) DFF_initTrue_has_ceFalse_has_resetFalse_has_async_resetTrue_inst0$reg_PR_inst0 (
     .clk(CLK),
     .arst(ASYNCRESET),
-    .in(DFF_initTrue_has_ceFalse_has_resetFalse_has_async_resetTrue_inst0$reg_PR_inst0_in),
+    .in(UART_comb_inst0_O2),
     .out(DFF_initTrue_has_ceFalse_has_resetFalse_has_async_resetTrue_inst0$reg_PR_inst0_out)
 );
 wire UART_comb_inst0_self_tx_O;

--- a/tests/gtest/golds/uart.v
+++ b/tests/gtest/golds/uart.v
@@ -257,34 +257,15 @@ module UART (
     input ASYNCRESET,
     output O
 );
-wire DFF_initTrue_has_ceFalse_has_resetFalse_has_async_resetTrue_inst0$reg_PR_inst0_clk;
-wire DFF_initTrue_has_ceFalse_has_resetFalse_has_async_resetTrue_inst0$reg_PR_inst0_arst;
-wire [0:0] DFF_initTrue_has_ceFalse_has_resetFalse_has_async_resetTrue_inst0$reg_PR_inst0_in;
 wire [0:0] DFF_initTrue_has_ceFalse_has_resetFalse_has_async_resetTrue_inst0$reg_PR_inst0_out;
-wire UART_comb_inst0_run;
-wire [7:0] UART_comb_inst0_message;
-wire [7:0] UART_comb_inst0_self_message_O;
-wire [2:0] UART_comb_inst0_self_i_O;
-wire UART_comb_inst0_self_tx_O;
-wire [1:0] UART_comb_inst0_self_yield_state_O;
 wire [7:0] UART_comb_inst0_O0;
 wire [2:0] UART_comb_inst0_O1;
 wire UART_comb_inst0_O2;
 wire [1:0] UART_comb_inst0_O3;
-wire reg_PR_inst0_clk;
-wire reg_PR_inst0_arst;
-wire [7:0] reg_PR_inst0_in;
 wire [7:0] reg_PR_inst0_out;
-wire reg_PR_inst1_clk;
-wire reg_PR_inst1_arst;
-wire [2:0] reg_PR_inst1_in;
 wire [2:0] reg_PR_inst1_out;
-wire reg_PR_inst2_clk;
-wire reg_PR_inst2_arst;
-wire [1:0] reg_PR_inst2_in;
 wire [1:0] reg_PR_inst2_out;
-assign DFF_initTrue_has_ceFalse_has_resetFalse_has_async_resetTrue_inst0$reg_PR_inst0_clk = CLK;
-assign DFF_initTrue_has_ceFalse_has_resetFalse_has_async_resetTrue_inst0$reg_PR_inst0_arst = ASYNCRESET;
+wire [0:0] DFF_initTrue_has_ceFalse_has_resetFalse_has_async_resetTrue_inst0$reg_PR_inst0_in;
 assign DFF_initTrue_has_ceFalse_has_resetFalse_has_async_resetTrue_inst0$reg_PR_inst0_in[0] = UART_comb_inst0_O2;
 coreir_reg_arst #(
     .arst_posedge(1'b1),
@@ -292,70 +273,57 @@ coreir_reg_arst #(
     .init(1'h1),
     .width(1)
 ) DFF_initTrue_has_ceFalse_has_resetFalse_has_async_resetTrue_inst0$reg_PR_inst0 (
-    .clk(DFF_initTrue_has_ceFalse_has_resetFalse_has_async_resetTrue_inst0$reg_PR_inst0_clk),
-    .arst(DFF_initTrue_has_ceFalse_has_resetFalse_has_async_resetTrue_inst0$reg_PR_inst0_arst),
+    .clk(CLK),
+    .arst(ASYNCRESET),
     .in(DFF_initTrue_has_ceFalse_has_resetFalse_has_async_resetTrue_inst0$reg_PR_inst0_in),
     .out(DFF_initTrue_has_ceFalse_has_resetFalse_has_async_resetTrue_inst0$reg_PR_inst0_out)
 );
-assign UART_comb_inst0_run = run;
-assign UART_comb_inst0_message = message;
-assign UART_comb_inst0_self_message_O = reg_PR_inst0_out;
-assign UART_comb_inst0_self_i_O = reg_PR_inst1_out;
+wire UART_comb_inst0_self_tx_O;
 assign UART_comb_inst0_self_tx_O = DFF_initTrue_has_ceFalse_has_resetFalse_has_async_resetTrue_inst0$reg_PR_inst0_out[0];
-assign UART_comb_inst0_self_yield_state_O = reg_PR_inst2_out;
 UART_comb UART_comb_inst0 (
-    .run(UART_comb_inst0_run),
-    .message(UART_comb_inst0_message),
-    .self_message_O(UART_comb_inst0_self_message_O),
-    .self_i_O(UART_comb_inst0_self_i_O),
+    .run(run),
+    .message(message),
+    .self_message_O(reg_PR_inst0_out),
+    .self_i_O(reg_PR_inst1_out),
     .self_tx_O(UART_comb_inst0_self_tx_O),
-    .self_yield_state_O(UART_comb_inst0_self_yield_state_O),
+    .self_yield_state_O(reg_PR_inst2_out),
     .O0(UART_comb_inst0_O0),
     .O1(UART_comb_inst0_O1),
     .O2(UART_comb_inst0_O2),
     .O3(UART_comb_inst0_O3),
     .O4(O)
 );
-assign reg_PR_inst0_clk = CLK;
-assign reg_PR_inst0_arst = ASYNCRESET;
-assign reg_PR_inst0_in = UART_comb_inst0_O0;
 coreir_reg_arst #(
     .arst_posedge(1'b1),
     .clk_posedge(1'b1),
     .init(8'h00),
     .width(8)
 ) reg_PR_inst0 (
-    .clk(reg_PR_inst0_clk),
-    .arst(reg_PR_inst0_arst),
-    .in(reg_PR_inst0_in),
+    .clk(CLK),
+    .arst(ASYNCRESET),
+    .in(UART_comb_inst0_O0),
     .out(reg_PR_inst0_out)
 );
-assign reg_PR_inst1_clk = CLK;
-assign reg_PR_inst1_arst = ASYNCRESET;
-assign reg_PR_inst1_in = UART_comb_inst0_O1;
 coreir_reg_arst #(
     .arst_posedge(1'b1),
     .clk_posedge(1'b1),
     .init(3'h7),
     .width(3)
 ) reg_PR_inst1 (
-    .clk(reg_PR_inst1_clk),
-    .arst(reg_PR_inst1_arst),
-    .in(reg_PR_inst1_in),
+    .clk(CLK),
+    .arst(ASYNCRESET),
+    .in(UART_comb_inst0_O1),
     .out(reg_PR_inst1_out)
 );
-assign reg_PR_inst2_clk = CLK;
-assign reg_PR_inst2_arst = ASYNCRESET;
-assign reg_PR_inst2_in = UART_comb_inst0_O3;
 coreir_reg_arst #(
     .arst_posedge(1'b1),
     .clk_posedge(1'b1),
     .init(2'h0),
     .width(2)
 ) reg_PR_inst2 (
-    .clk(reg_PR_inst2_clk),
-    .arst(reg_PR_inst2_arst),
-    .in(reg_PR_inst2_in),
+    .clk(CLK),
+    .arst(ASYNCRESET),
+    .in(UART_comb_inst0_O3),
     .out(reg_PR_inst2_out)
 );
 endmodule

--- a/tests/gtest/golds/uart.v
+++ b/tests/gtest/golds/uart.v
@@ -265,6 +265,8 @@ wire [1:0] UART_comb_inst0_O3;
 wire [7:0] reg_PR_inst0_out;
 wire [2:0] reg_PR_inst1_out;
 wire [1:0] reg_PR_inst2_out;
+wire [0:0] DFF_initTrue_has_ceFalse_has_resetFalse_has_async_resetTrue_inst0$reg_PR_inst0_in;
+assign DFF_initTrue_has_ceFalse_has_resetFalse_has_async_resetTrue_inst0$reg_PR_inst0_in[0] = UART_comb_inst0_O2;
 coreir_reg_arst #(
     .arst_posedge(1'b1),
     .clk_posedge(1'b1),
@@ -273,17 +275,15 @@ coreir_reg_arst #(
 ) DFF_initTrue_has_ceFalse_has_resetFalse_has_async_resetTrue_inst0$reg_PR_inst0 (
     .clk(CLK),
     .arst(ASYNCRESET),
-    .in(UART_comb_inst0_O2),
+    .in(DFF_initTrue_has_ceFalse_has_resetFalse_has_async_resetTrue_inst0$reg_PR_inst0_in),
     .out(DFF_initTrue_has_ceFalse_has_resetFalse_has_async_resetTrue_inst0$reg_PR_inst0_out)
 );
-wire UART_comb_inst0_self_tx_O;
-assign UART_comb_inst0_self_tx_O = DFF_initTrue_has_ceFalse_has_resetFalse_has_async_resetTrue_inst0$reg_PR_inst0_out[0];
 UART_comb UART_comb_inst0 (
     .run(run),
     .message(message),
     .self_message_O(reg_PR_inst0_out),
     .self_i_O(reg_PR_inst1_out),
-    .self_tx_O(UART_comb_inst0_self_tx_O),
+    .self_tx_O(DFF_initTrue_has_ceFalse_has_resetFalse_has_async_resetTrue_inst0$reg_PR_inst0_out[0]),
     .self_yield_state_O(reg_PR_inst2_out),
     .O0(UART_comb_inst0_O0),
     .O1(UART_comb_inst0_O1),

--- a/tests/gtest/inline_verilog_golden.v
+++ b/tests/gtest/inline_verilog_golden.v
@@ -15,21 +15,15 @@ module Main (
     input [1:0] arr,
     input CLK
 );
-wire FF_inst0_I;
-wire FF_inst0_CLK;
 wire _magma_inline_wire0;
-wire corebit_term_inst0_in;
-assign FF_inst0_I = I;
-assign FF_inst0_CLK = CLK;
 FF FF_inst0 (
-    .I(FF_inst0_I),
+    .I(I),
     .O(O),
-    .CLK(FF_inst0_CLK)
+    .CLK(CLK)
 );
 assign _magma_inline_wire0 = O;
-assign corebit_term_inst0_in = _magma_inline_wire0;
 corebit_term corebit_term_inst0 (
-    .in(corebit_term_inst0_in)
+    .in(_magma_inline_wire0)
 );
 
 assert property (@(posedge CLK) I |-> ##1 _magma_inline_wire0);

--- a/tests/gtest/inline_verilog_top_golden.v
+++ b/tests/gtest/inline_verilog_top_golden.v
@@ -42,29 +42,23 @@ wire [3:0] _magma_inline_wire1;
 wire [3:0] _magma_inline_wire2;
 wire [3:0] arr_2d_0;
 wire [3:0] arr_2d_1;
-wire corebit_term_inst0_in;
-wire [3:0] term_inst0_in;
-wire [3:0] term_inst1_in;
 assign _magma_inline_wire0 = arr_2d_0[1];
 assign _magma_inline_wire1 = arr_2d_1;
 assign _magma_inline_wire2 = arr_2d_0;
 assign arr_2d_0 = in1;
 assign arr_2d_1 = in2;
-assign corebit_term_inst0_in = _magma_inline_wire0;
 corebit_term corebit_term_inst0 (
-    .in(corebit_term_inst0_in)
+    .in(_magma_inline_wire0)
 );
-assign term_inst0_in = _magma_inline_wire1;
 coreir_term #(
     .width(4)
 ) term_inst0 (
-    .in(term_inst0_in)
+    .in(_magma_inline_wire1)
 );
-assign term_inst1_in = _magma_inline_wire2;
 coreir_term #(
     .width(4)
 ) term_inst1 (
-    .in(term_inst1_in)
+    .in(_magma_inline_wire2)
 );
 
 logic temp1, temp2;

--- a/tests/gtest/intermediate_connection_golden.v
+++ b/tests/gtest/intermediate_connection_golden.v
@@ -9,20 +9,16 @@ module top (
     inout IO1,
     output O
 );
-wire inst0_I;
 wire inst0_IO;
 wire inst0_O;
-wire inst1_I;
 wire inst1_IO;
-assign inst0_I = I;
 foo inst0 (
-    .I(inst0_I),
+    .I(I),
     .IO(inst0_IO),
     .O(inst0_O)
 );
-assign inst1_I = inst0_O;
 foo inst1 (
-    .I(inst1_I),
+    .I(inst0_O),
     .IO(inst1_IO),
     .O(O)
 );

--- a/tests/gtest/port_order_golden.v
+++ b/tests/gtest/port_order_golden.v
@@ -12,17 +12,15 @@ module Sub8 (
     input [7:0] x,
     output [7:0] a
 );
-wire [7:0] inst1_z;
-wire [7:0] inst1_x;
-wire inst1_CIN;
-assign inst1_z = z;
-assign inst1_x = ~ x;
-assign inst1_CIN = 1'b1;
+wire bit_const_1_None_out;
+wire [7:0] inst0_out;
+assign bit_const_1_None_out = 1'b1;
+assign inst0_out = ~ x;
 Add8_cin inst1 (
-    .z(inst1_z),
-    .x(inst1_x),
+    .z(z),
+    .x(inst0_out),
     .a(a),
-    .CIN(inst1_CIN)
+    .CIN(bit_const_1_None_out)
 );
 endmodule
 
@@ -31,13 +29,11 @@ module test_two_ops (
     input [7:0] x,
     output [7:0] a
 );
-wire [7:0] inst1_z;
-wire [7:0] inst1_x;
-assign inst1_z = 8'(z + x);
-assign inst1_x = z;
+wire [7:0] inst0_out;
+assign inst0_out = 8'(z + x);
 Sub8 inst1 (
-    .z(inst1_z),
-    .x(inst1_x),
+    .z(inst0_out),
+    .x(z),
     .a(a)
 );
 endmodule

--- a/tests/gtest/register_mode_golden.v
+++ b/tests/gtest/register_mode_golden.v
@@ -41,16 +41,10 @@ module Register_comb (
     output [3:0] O0,
     output [3:0] O1
 );
-wire [3:0] Mux2xOutBits4_inst0_I0;
-wire [3:0] Mux2xOutBits4_inst0_I1;
-wire Mux2xOutBits4_inst0_S;
-assign Mux2xOutBits4_inst0_I0 = self_value_O;
-assign Mux2xOutBits4_inst0_I1 = value;
-assign Mux2xOutBits4_inst0_S = en;
 Mux2xOutBits4 Mux2xOutBits4_inst0 (
-    .I0(Mux2xOutBits4_inst0_I0),
-    .I1(Mux2xOutBits4_inst0_I1),
-    .S(Mux2xOutBits4_inst0_S),
+    .I0(self_value_O),
+    .I1(value),
+    .S(en),
     .O(O0)
 );
 assign O1 = self_value_O;
@@ -62,32 +56,22 @@ module Register (
     input CLK,
     output [3:0] O
 );
-wire [3:0] Register_comb_inst0_value;
-wire Register_comb_inst0_en;
-wire [3:0] Register_comb_inst0_self_value_O;
 wire [3:0] Register_comb_inst0_O0;
-wire reg_P_inst0_clk;
-wire [3:0] reg_P_inst0_in;
 wire [3:0] reg_P_inst0_out;
-assign Register_comb_inst0_value = value;
-assign Register_comb_inst0_en = en;
-assign Register_comb_inst0_self_value_O = reg_P_inst0_out;
 Register_comb Register_comb_inst0 (
-    .value(Register_comb_inst0_value),
-    .en(Register_comb_inst0_en),
-    .self_value_O(Register_comb_inst0_self_value_O),
+    .value(value),
+    .en(en),
+    .self_value_O(reg_P_inst0_out),
     .O0(Register_comb_inst0_O0),
     .O1(O)
 );
-assign reg_P_inst0_clk = CLK;
-assign reg_P_inst0_in = Register_comb_inst0_O0;
 coreir_reg #(
     .clk_posedge(1'b1),
     .init(4'h0),
     .width(4)
 ) reg_P_inst0 (
-    .clk(reg_P_inst0_clk),
-    .in(reg_P_inst0_in),
+    .clk(CLK),
+    .in(Register_comb_inst0_O0),
     .out(reg_P_inst0_out)
 );
 endmodule
@@ -123,275 +107,195 @@ module RegisterMode_comb (
     output [3:0] O2,
     output [3:0] O3
 );
-wire Mux2xOutBit_inst0_I0;
-wire Mux2xOutBit_inst0_I1;
-wire Mux2xOutBit_inst0_S;
 wire Mux2xOutBit_inst0_O;
-wire Mux2xOutBit_inst1_I0;
-wire Mux2xOutBit_inst1_I1;
-wire Mux2xOutBit_inst1_S;
 wire Mux2xOutBit_inst1_O;
-wire Mux2xOutBit_inst2_I0;
-wire Mux2xOutBit_inst2_I1;
-wire Mux2xOutBit_inst2_S;
 wire Mux2xOutBit_inst2_O;
-wire Mux2xOutBit_inst3_I0;
-wire Mux2xOutBit_inst3_I1;
-wire Mux2xOutBit_inst3_S;
 wire Mux2xOutBit_inst3_O;
-wire Mux2xOutBit_inst4_I0;
-wire Mux2xOutBit_inst4_I1;
-wire Mux2xOutBit_inst4_S;
 wire Mux2xOutBit_inst4_O;
-wire Mux2xOutBit_inst5_I0;
-wire Mux2xOutBit_inst5_I1;
-wire Mux2xOutBit_inst5_S;
-wire [3:0] Mux2xOutBits4_inst0_I0;
-wire [3:0] Mux2xOutBits4_inst0_I1;
-wire Mux2xOutBits4_inst0_S;
 wire [3:0] Mux2xOutBits4_inst0_O;
-wire [3:0] Mux2xOutBits4_inst1_I0;
-wire [3:0] Mux2xOutBits4_inst1_I1;
-wire Mux2xOutBits4_inst1_S;
 wire [3:0] Mux2xOutBits4_inst1_O;
-wire [3:0] Mux2xOutBits4_inst10_I0;
-wire [3:0] Mux2xOutBits4_inst10_I1;
-wire Mux2xOutBits4_inst10_S;
 wire [3:0] Mux2xOutBits4_inst10_O;
-wire [3:0] Mux2xOutBits4_inst11_I0;
-wire [3:0] Mux2xOutBits4_inst11_I1;
-wire Mux2xOutBits4_inst11_S;
 wire [3:0] Mux2xOutBits4_inst11_O;
-wire [3:0] Mux2xOutBits4_inst12_I0;
-wire [3:0] Mux2xOutBits4_inst12_I1;
-wire Mux2xOutBits4_inst12_S;
-wire [3:0] Mux2xOutBits4_inst13_I0;
-wire [3:0] Mux2xOutBits4_inst13_I1;
-wire Mux2xOutBits4_inst13_S;
-wire [3:0] Mux2xOutBits4_inst14_I0;
-wire [3:0] Mux2xOutBits4_inst14_I1;
-wire Mux2xOutBits4_inst14_S;
-wire [3:0] Mux2xOutBits4_inst2_I0;
-wire [3:0] Mux2xOutBits4_inst2_I1;
-wire Mux2xOutBits4_inst2_S;
 wire [3:0] Mux2xOutBits4_inst2_O;
-wire [3:0] Mux2xOutBits4_inst3_I0;
-wire [3:0] Mux2xOutBits4_inst3_I1;
-wire Mux2xOutBits4_inst3_S;
 wire [3:0] Mux2xOutBits4_inst3_O;
-wire [3:0] Mux2xOutBits4_inst4_I0;
-wire [3:0] Mux2xOutBits4_inst4_I1;
-wire Mux2xOutBits4_inst4_S;
 wire [3:0] Mux2xOutBits4_inst4_O;
-wire [3:0] Mux2xOutBits4_inst5_I0;
-wire [3:0] Mux2xOutBits4_inst5_I1;
-wire Mux2xOutBits4_inst5_S;
 wire [3:0] Mux2xOutBits4_inst5_O;
-wire [3:0] Mux2xOutBits4_inst6_I0;
-wire [3:0] Mux2xOutBits4_inst6_I1;
-wire Mux2xOutBits4_inst6_S;
 wire [3:0] Mux2xOutBits4_inst6_O;
-wire [3:0] Mux2xOutBits4_inst7_I0;
-wire [3:0] Mux2xOutBits4_inst7_I1;
-wire Mux2xOutBits4_inst7_S;
 wire [3:0] Mux2xOutBits4_inst7_O;
-wire [3:0] Mux2xOutBits4_inst8_I0;
-wire [3:0] Mux2xOutBits4_inst8_I1;
-wire Mux2xOutBits4_inst8_S;
 wire [3:0] Mux2xOutBits4_inst8_O;
-wire [3:0] Mux2xOutBits4_inst9_I0;
-wire [3:0] Mux2xOutBits4_inst9_I1;
-wire Mux2xOutBits4_inst9_S;
 wire [3:0] Mux2xOutBits4_inst9_O;
-assign Mux2xOutBit_inst0_I0 = clk_en;
-assign Mux2xOutBit_inst0_I1 = 1'b0;
-assign Mux2xOutBit_inst0_S = mode == 2'h1;
+wire bit_const_0_None_out;
+wire bit_const_1_None_out;
+wire magma_Bit_not_inst0_out;
+wire magma_Bit_not_inst1_out;
+wire magma_Bit_not_inst2_out;
+wire magma_Bit_not_inst3_out;
+wire magma_Bit_not_inst4_out;
+wire magma_Bit_not_inst5_out;
+wire magma_Bit_not_inst6_out;
+wire magma_Bits_2_eq_inst0_out;
+wire magma_Bits_2_eq_inst1_out;
+wire magma_Bits_2_eq_inst10_out;
+wire magma_Bits_2_eq_inst11_out;
+wire magma_Bits_2_eq_inst12_out;
+wire magma_Bits_2_eq_inst13_out;
+wire magma_Bits_2_eq_inst2_out;
+wire magma_Bits_2_eq_inst3_out;
+wire magma_Bits_2_eq_inst4_out;
+wire magma_Bits_2_eq_inst5_out;
+wire magma_Bits_2_eq_inst6_out;
+wire magma_Bits_2_eq_inst7_out;
+wire magma_Bits_2_eq_inst8_out;
+wire magma_Bits_2_eq_inst9_out;
 Mux2xOutBit Mux2xOutBit_inst0 (
-    .I0(Mux2xOutBit_inst0_I0),
-    .I1(Mux2xOutBit_inst0_I1),
-    .S(Mux2xOutBit_inst0_S),
+    .I0(clk_en),
+    .I1(bit_const_0_None_out),
+    .S(magma_Bits_2_eq_inst1_out),
     .O(Mux2xOutBit_inst0_O)
 );
-assign Mux2xOutBit_inst1_I0 = Mux2xOutBit_inst0_O;
-assign Mux2xOutBit_inst1_I1 = 1'b0;
-assign Mux2xOutBit_inst1_S = mode == 2'h0;
 Mux2xOutBit Mux2xOutBit_inst1 (
-    .I0(Mux2xOutBit_inst1_I0),
-    .I1(Mux2xOutBit_inst1_I1),
-    .S(Mux2xOutBit_inst1_S),
+    .I0(Mux2xOutBit_inst0_O),
+    .I1(bit_const_0_None_out),
+    .S(magma_Bits_2_eq_inst4_out),
     .O(Mux2xOutBit_inst1_O)
 );
-assign Mux2xOutBit_inst2_I0 = Mux2xOutBit_inst1_O;
-assign Mux2xOutBit_inst2_I1 = 1'b1;
-assign Mux2xOutBit_inst2_S = ~ (config_we ^ 1'b1);
 Mux2xOutBit Mux2xOutBit_inst2 (
-    .I0(Mux2xOutBit_inst2_I0),
-    .I1(Mux2xOutBit_inst2_I1),
-    .S(Mux2xOutBit_inst2_S),
+    .I0(Mux2xOutBit_inst1_O),
+    .I1(bit_const_1_None_out),
+    .S(magma_Bit_not_inst1_out),
     .O(Mux2xOutBit_inst2_O)
 );
-assign Mux2xOutBit_inst3_I0 = clk_en;
-assign Mux2xOutBit_inst3_I1 = 1'b0;
-assign Mux2xOutBit_inst3_S = mode == 2'h1;
 Mux2xOutBit Mux2xOutBit_inst3 (
-    .I0(Mux2xOutBit_inst3_I0),
-    .I1(Mux2xOutBit_inst3_I1),
-    .S(Mux2xOutBit_inst3_S),
+    .I0(clk_en),
+    .I1(bit_const_0_None_out),
+    .S(magma_Bits_2_eq_inst7_out),
     .O(Mux2xOutBit_inst3_O)
 );
-assign Mux2xOutBit_inst4_I0 = Mux2xOutBit_inst3_O;
-assign Mux2xOutBit_inst4_I1 = 1'b0;
-assign Mux2xOutBit_inst4_S = mode == 2'h0;
 Mux2xOutBit Mux2xOutBit_inst4 (
-    .I0(Mux2xOutBit_inst4_I0),
-    .I1(Mux2xOutBit_inst4_I1),
-    .S(Mux2xOutBit_inst4_S),
+    .I0(Mux2xOutBit_inst3_O),
+    .I1(bit_const_0_None_out),
+    .S(magma_Bits_2_eq_inst11_out),
     .O(Mux2xOutBit_inst4_O)
 );
-assign Mux2xOutBit_inst5_I0 = Mux2xOutBit_inst4_O;
-assign Mux2xOutBit_inst5_I1 = 1'b1;
-assign Mux2xOutBit_inst5_S = ~ (config_we ^ 1'b1);
 Mux2xOutBit Mux2xOutBit_inst5 (
-    .I0(Mux2xOutBit_inst5_I0),
-    .I1(Mux2xOutBit_inst5_I1),
-    .S(Mux2xOutBit_inst5_S),
+    .I0(Mux2xOutBit_inst4_O),
+    .I1(bit_const_1_None_out),
+    .S(magma_Bit_not_inst4_out),
     .O(O1)
 );
-assign Mux2xOutBits4_inst0_I0 = value;
-assign Mux2xOutBits4_inst0_I1 = value;
-assign Mux2xOutBits4_inst0_S = mode == 2'h1;
 Mux2xOutBits4 Mux2xOutBits4_inst0 (
-    .I0(Mux2xOutBits4_inst0_I0),
-    .I1(Mux2xOutBits4_inst0_I1),
-    .S(Mux2xOutBits4_inst0_S),
+    .I0(value),
+    .I1(value),
+    .S(magma_Bits_2_eq_inst0_out),
     .O(Mux2xOutBits4_inst0_O)
 );
-assign Mux2xOutBits4_inst1_I0 = self_register_O;
-assign Mux2xOutBits4_inst1_I1 = self_register_O;
-assign Mux2xOutBits4_inst1_S = mode == 2'h1;
 Mux2xOutBits4 Mux2xOutBits4_inst1 (
-    .I0(Mux2xOutBits4_inst1_I0),
-    .I1(Mux2xOutBits4_inst1_I1),
-    .S(Mux2xOutBits4_inst1_S),
+    .I0(self_register_O),
+    .I1(self_register_O),
+    .S(magma_Bits_2_eq_inst2_out),
     .O(Mux2xOutBits4_inst1_O)
 );
-assign Mux2xOutBits4_inst10_I0 = Mux2xOutBits4_inst7_O;
-assign Mux2xOutBits4_inst10_I1 = const_;
-assign Mux2xOutBits4_inst10_S = mode == 2'h0;
 Mux2xOutBits4 Mux2xOutBits4_inst10 (
-    .I0(Mux2xOutBits4_inst10_I0),
-    .I1(Mux2xOutBits4_inst10_I1),
-    .S(Mux2xOutBits4_inst10_S),
+    .I0(Mux2xOutBits4_inst7_O),
+    .I1(const_),
+    .S(magma_Bits_2_eq_inst12_out),
     .O(Mux2xOutBits4_inst10_O)
 );
-assign Mux2xOutBits4_inst11_I0 = Mux2xOutBits4_inst8_O;
-assign Mux2xOutBits4_inst11_I1 = self_register_O;
-assign Mux2xOutBits4_inst11_S = mode == 2'h0;
 Mux2xOutBits4 Mux2xOutBits4_inst11 (
-    .I0(Mux2xOutBits4_inst11_I0),
-    .I1(Mux2xOutBits4_inst11_I1),
-    .S(Mux2xOutBits4_inst11_S),
+    .I0(Mux2xOutBits4_inst8_O),
+    .I1(self_register_O),
+    .S(magma_Bits_2_eq_inst13_out),
     .O(Mux2xOutBits4_inst11_O)
 );
-assign Mux2xOutBits4_inst12_I0 = Mux2xOutBits4_inst9_O;
-assign Mux2xOutBits4_inst12_I1 = config_data;
-assign Mux2xOutBits4_inst12_S = ~ (config_we ^ 1'b1);
 Mux2xOutBits4 Mux2xOutBits4_inst12 (
-    .I0(Mux2xOutBits4_inst12_I0),
-    .I1(Mux2xOutBits4_inst12_I1),
-    .S(Mux2xOutBits4_inst12_S),
+    .I0(Mux2xOutBits4_inst9_O),
+    .I1(config_data),
+    .S(magma_Bit_not_inst3_out),
     .O(O0)
 );
-assign Mux2xOutBits4_inst13_I0 = Mux2xOutBits4_inst10_O;
-assign Mux2xOutBits4_inst13_I1 = self_register_O;
-assign Mux2xOutBits4_inst13_S = ~ (config_we ^ 1'b1);
 Mux2xOutBits4 Mux2xOutBits4_inst13 (
-    .I0(Mux2xOutBits4_inst13_I0),
-    .I1(Mux2xOutBits4_inst13_I1),
-    .S(Mux2xOutBits4_inst13_S),
+    .I0(Mux2xOutBits4_inst10_O),
+    .I1(self_register_O),
+    .S(magma_Bit_not_inst5_out),
     .O(O2)
 );
-assign Mux2xOutBits4_inst14_I0 = Mux2xOutBits4_inst11_O;
-assign Mux2xOutBits4_inst14_I1 = self_register_O;
-assign Mux2xOutBits4_inst14_S = ~ (config_we ^ 1'b1);
 Mux2xOutBits4 Mux2xOutBits4_inst14 (
-    .I0(Mux2xOutBits4_inst14_I0),
-    .I1(Mux2xOutBits4_inst14_I1),
-    .S(Mux2xOutBits4_inst14_S),
+    .I0(Mux2xOutBits4_inst11_O),
+    .I1(self_register_O),
+    .S(magma_Bit_not_inst6_out),
     .O(O3)
 );
-assign Mux2xOutBits4_inst2_I0 = Mux2xOutBits4_inst0_O;
-assign Mux2xOutBits4_inst2_I1 = value;
-assign Mux2xOutBits4_inst2_S = mode == 2'h0;
 Mux2xOutBits4 Mux2xOutBits4_inst2 (
-    .I0(Mux2xOutBits4_inst2_I0),
-    .I1(Mux2xOutBits4_inst2_I1),
-    .S(Mux2xOutBits4_inst2_S),
+    .I0(Mux2xOutBits4_inst0_O),
+    .I1(value),
+    .S(magma_Bits_2_eq_inst3_out),
     .O(Mux2xOutBits4_inst2_O)
 );
-assign Mux2xOutBits4_inst3_I0 = Mux2xOutBits4_inst1_O;
-assign Mux2xOutBits4_inst3_I1 = self_register_O;
-assign Mux2xOutBits4_inst3_S = mode == 2'h0;
 Mux2xOutBits4 Mux2xOutBits4_inst3 (
-    .I0(Mux2xOutBits4_inst3_I0),
-    .I1(Mux2xOutBits4_inst3_I1),
-    .S(Mux2xOutBits4_inst3_S),
+    .I0(Mux2xOutBits4_inst1_O),
+    .I1(self_register_O),
+    .S(magma_Bits_2_eq_inst5_out),
     .O(Mux2xOutBits4_inst3_O)
 );
-assign Mux2xOutBits4_inst4_I0 = Mux2xOutBits4_inst2_O;
-assign Mux2xOutBits4_inst4_I1 = config_data;
-assign Mux2xOutBits4_inst4_S = ~ (config_we ^ 1'b1);
 Mux2xOutBits4 Mux2xOutBits4_inst4 (
-    .I0(Mux2xOutBits4_inst4_I0),
-    .I1(Mux2xOutBits4_inst4_I1),
-    .S(Mux2xOutBits4_inst4_S),
+    .I0(Mux2xOutBits4_inst2_O),
+    .I1(config_data),
+    .S(magma_Bit_not_inst0_out),
     .O(Mux2xOutBits4_inst4_O)
 );
-assign Mux2xOutBits4_inst5_I0 = Mux2xOutBits4_inst3_O;
-assign Mux2xOutBits4_inst5_I1 = self_register_O;
-assign Mux2xOutBits4_inst5_S = ~ (config_we ^ 1'b1);
 Mux2xOutBits4 Mux2xOutBits4_inst5 (
-    .I0(Mux2xOutBits4_inst5_I0),
-    .I1(Mux2xOutBits4_inst5_I1),
-    .S(Mux2xOutBits4_inst5_S),
+    .I0(Mux2xOutBits4_inst3_O),
+    .I1(self_register_O),
+    .S(magma_Bit_not_inst2_out),
     .O(Mux2xOutBits4_inst5_O)
 );
-assign Mux2xOutBits4_inst6_I0 = value;
-assign Mux2xOutBits4_inst6_I1 = value;
-assign Mux2xOutBits4_inst6_S = mode == 2'h1;
 Mux2xOutBits4 Mux2xOutBits4_inst6 (
-    .I0(Mux2xOutBits4_inst6_I0),
-    .I1(Mux2xOutBits4_inst6_I1),
-    .S(Mux2xOutBits4_inst6_S),
+    .I0(value),
+    .I1(value),
+    .S(magma_Bits_2_eq_inst6_out),
     .O(Mux2xOutBits4_inst6_O)
 );
-assign Mux2xOutBits4_inst7_I0 = self_register_O;
-assign Mux2xOutBits4_inst7_I1 = value;
-assign Mux2xOutBits4_inst7_S = mode == 2'h1;
 Mux2xOutBits4 Mux2xOutBits4_inst7 (
-    .I0(Mux2xOutBits4_inst7_I0),
-    .I1(Mux2xOutBits4_inst7_I1),
-    .S(Mux2xOutBits4_inst7_S),
+    .I0(self_register_O),
+    .I1(value),
+    .S(magma_Bits_2_eq_inst8_out),
     .O(Mux2xOutBits4_inst7_O)
 );
-assign Mux2xOutBits4_inst8_I0 = self_register_O;
-assign Mux2xOutBits4_inst8_I1 = self_register_O;
-assign Mux2xOutBits4_inst8_S = mode == 2'h1;
 Mux2xOutBits4 Mux2xOutBits4_inst8 (
-    .I0(Mux2xOutBits4_inst8_I0),
-    .I1(Mux2xOutBits4_inst8_I1),
-    .S(Mux2xOutBits4_inst8_S),
+    .I0(self_register_O),
+    .I1(self_register_O),
+    .S(magma_Bits_2_eq_inst9_out),
     .O(Mux2xOutBits4_inst8_O)
 );
-assign Mux2xOutBits4_inst9_I0 = Mux2xOutBits4_inst6_O;
-assign Mux2xOutBits4_inst9_I1 = value;
-assign Mux2xOutBits4_inst9_S = mode == 2'h0;
 Mux2xOutBits4 Mux2xOutBits4_inst9 (
-    .I0(Mux2xOutBits4_inst9_I0),
-    .I1(Mux2xOutBits4_inst9_I1),
-    .S(Mux2xOutBits4_inst9_S),
+    .I0(Mux2xOutBits4_inst6_O),
+    .I1(value),
+    .S(magma_Bits_2_eq_inst10_out),
     .O(Mux2xOutBits4_inst9_O)
 );
+assign bit_const_0_None_out = 1'b0;
+assign bit_const_1_None_out = 1'b1;
+assign magma_Bit_not_inst0_out = ~ (config_we ^ bit_const_1_None_out);
+assign magma_Bit_not_inst1_out = ~ (config_we ^ bit_const_1_None_out);
+assign magma_Bit_not_inst2_out = ~ (config_we ^ bit_const_1_None_out);
+assign magma_Bit_not_inst3_out = ~ (config_we ^ bit_const_1_None_out);
+assign magma_Bit_not_inst4_out = ~ (config_we ^ bit_const_1_None_out);
+assign magma_Bit_not_inst5_out = ~ (config_we ^ bit_const_1_None_out);
+assign magma_Bit_not_inst6_out = ~ (config_we ^ bit_const_1_None_out);
+assign magma_Bits_2_eq_inst0_out = mode == 2'h1;
+assign magma_Bits_2_eq_inst1_out = mode == 2'h1;
+assign magma_Bits_2_eq_inst10_out = mode == 2'h0;
+assign magma_Bits_2_eq_inst11_out = mode == 2'h0;
+assign magma_Bits_2_eq_inst12_out = mode == 2'h0;
+assign magma_Bits_2_eq_inst13_out = mode == 2'h0;
+assign magma_Bits_2_eq_inst2_out = mode == 2'h1;
+assign magma_Bits_2_eq_inst3_out = mode == 2'h0;
+assign magma_Bits_2_eq_inst4_out = mode == 2'h0;
+assign magma_Bits_2_eq_inst5_out = mode == 2'h0;
+assign magma_Bits_2_eq_inst6_out = mode == 2'h1;
+assign magma_Bits_2_eq_inst7_out = mode == 2'h1;
+assign magma_Bits_2_eq_inst8_out = mode == 2'h1;
+assign magma_Bits_2_eq_inst9_out = mode == 2'h1;
 endmodule
 
 module RegisterMode (
@@ -405,46 +309,26 @@ module RegisterMode (
     output [3:0] O0,
     output [3:0] O1
 );
-wire [1:0] RegisterMode_comb_inst0_mode;
-wire [3:0] RegisterMode_comb_inst0_const_;
-wire [3:0] RegisterMode_comb_inst0_value;
-wire RegisterMode_comb_inst0_clk_en;
-wire RegisterMode_comb_inst0_config_we;
-wire [3:0] RegisterMode_comb_inst0_config_data;
-wire [3:0] RegisterMode_comb_inst0_self_register_O;
 wire [3:0] RegisterMode_comb_inst0_O0;
 wire RegisterMode_comb_inst0_O1;
-wire [3:0] Register_inst0_value;
-wire Register_inst0_en;
-wire Register_inst0_CLK;
 wire [3:0] Register_inst0_O;
-assign RegisterMode_comb_inst0_mode = mode;
-assign RegisterMode_comb_inst0_const_ = const_;
-assign RegisterMode_comb_inst0_value = value;
-assign RegisterMode_comb_inst0_clk_en = clk_en;
-assign RegisterMode_comb_inst0_config_we = config_we;
-assign RegisterMode_comb_inst0_config_data = config_data;
-assign RegisterMode_comb_inst0_self_register_O = Register_inst0_O;
 RegisterMode_comb RegisterMode_comb_inst0 (
-    .mode(RegisterMode_comb_inst0_mode),
-    .const_(RegisterMode_comb_inst0_const_),
-    .value(RegisterMode_comb_inst0_value),
-    .clk_en(RegisterMode_comb_inst0_clk_en),
-    .config_we(RegisterMode_comb_inst0_config_we),
-    .config_data(RegisterMode_comb_inst0_config_data),
-    .self_register_O(RegisterMode_comb_inst0_self_register_O),
+    .mode(mode),
+    .const_(const_),
+    .value(value),
+    .clk_en(clk_en),
+    .config_we(config_we),
+    .config_data(config_data),
+    .self_register_O(Register_inst0_O),
     .O0(RegisterMode_comb_inst0_O0),
     .O1(RegisterMode_comb_inst0_O1),
     .O2(O0),
     .O3(O1)
 );
-assign Register_inst0_value = RegisterMode_comb_inst0_O0;
-assign Register_inst0_en = RegisterMode_comb_inst0_O1;
-assign Register_inst0_CLK = CLK;
 Register Register_inst0 (
-    .value(Register_inst0_value),
-    .en(Register_inst0_en),
-    .CLK(Register_inst0_CLK),
+    .value(RegisterMode_comb_inst0_O0),
+    .en(RegisterMode_comb_inst0_O1),
+    .CLK(CLK),
     .O(Register_inst0_O)
 );
 endmodule

--- a/tests/gtest/two_ops_golden.v
+++ b/tests/gtest/two_ops_golden.v
@@ -12,17 +12,15 @@ module Sub8 (
     input [7:0] I1,
     output [7:0] O
 );
-wire [7:0] inst1_I0;
-wire [7:0] inst1_I1;
-wire inst1_CIN;
-assign inst1_I0 = I0;
-assign inst1_I1 = ~ I1;
-assign inst1_CIN = 1'b1;
+wire bit_const_1_None_out;
+wire [7:0] inst0_out;
+assign bit_const_1_None_out = 1'b1;
+assign inst0_out = ~ I1;
 Add8_cin inst1 (
-    .I0(inst1_I0),
-    .I1(inst1_I1),
+    .I0(I0),
+    .I1(inst0_out),
     .O(O),
-    .CIN(inst1_CIN)
+    .CIN(bit_const_1_None_out)
 );
 endmodule
 
@@ -31,13 +29,11 @@ module test_two_ops (
     input [7:0] I1,
     output [7:0] O
 );
-wire [7:0] inst1_I0;
-wire [7:0] inst1_I1;
-assign inst1_I0 = 8'(I0 + I1);
-assign inst1_I1 = I0;
+wire [7:0] inst0_out;
+assign inst0_out = 8'(I0 + I1);
 Sub8 inst1 (
-    .I0(inst1_I0),
-    .I1(inst1_I1),
+    .I0(inst0_out),
+    .I1(I0),
     .O(O)
 );
 endmodule

--- a/tests/gtest/two_ops_golden_no_cast.v
+++ b/tests/gtest/two_ops_golden_no_cast.v
@@ -12,17 +12,15 @@ module Sub8 (
     input [7:0] I1,
     output [7:0] O
 );
-wire [7:0] inst1_I0;
-wire [7:0] inst1_I1;
-wire inst1_CIN;
-assign inst1_I0 = I0;
-assign inst1_I1 = ~ I1;
-assign inst1_CIN = 1'b1;
+wire bit_const_1_None_out;
+wire [7:0] inst0_out;
+assign bit_const_1_None_out = 1'b1;
+assign inst0_out = ~ I1;
 Add8_cin inst1 (
-    .I0(inst1_I0),
-    .I1(inst1_I1),
+    .I0(I0),
+    .I1(inst0_out),
     .O(O),
-    .CIN(inst1_CIN)
+    .CIN(bit_const_1_None_out)
 );
 endmodule
 
@@ -31,13 +29,11 @@ module test_two_ops (
     input [7:0] I1,
     output [7:0] O
 );
-wire [7:0] inst1_I0;
-wire [7:0] inst1_I1;
-assign inst1_I0 = I0 + I1;
-assign inst1_I1 = I0;
+wire [7:0] inst0_out;
+assign inst0_out = I0 + I1;
 Sub8 inst1 (
-    .I0(inst1_I0),
-    .I1(inst1_I1),
+    .I0(inst0_out),
+    .I1(I0),
     .O(O)
 );
 endmodule

--- a/tests/unit/gold/ice40_pll_verilog.v
+++ b/tests/unit/gold/ice40_pll_verilog.v
@@ -6,14 +6,8 @@ module top (
     output out,
     output outClk
 );
-wire pll_BYPASS;
 wire pll_PLLOUTCORE;
 wire pll_PLLOUTGLOBAL;
-wire pll_REFERENCECLK;
-wire pll_RESETB;
-assign pll_BYPASS = in;
-assign pll_REFERENCECLK = clk;
-assign pll_RESETB = reset;
 SB_PLL40_CORE #(
     .DIVF(7'h21),
     .DIVQ(3'h4),
@@ -22,11 +16,11 @@ SB_PLL40_CORE #(
     .FILTER_RANGE(3'h1),
     .PLLOUT_SELECT("GENCLK")
 ) pll (
-    .BYPASS(pll_BYPASS),
+    .BYPASS(in),
     .PLLOUTCORE(pll_PLLOUTCORE),
     .PLLOUTGLOBAL(pll_PLLOUTGLOBAL),
-    .REFERENCECLK(pll_REFERENCECLK),
-    .RESETB(pll_RESETB)
+    .REFERENCECLK(clk),
+    .RESETB(reset)
 );
 assign out = pll_PLLOUTCORE;
 assign outClk = pll_PLLOUTGLOBAL;

--- a/tests/unit/gold/ice40_ram_verilog.v
+++ b/tests/unit/gold/ice40_ram_verilog.v
@@ -13,26 +13,6 @@ module top (
     input WE
 );
 wire [15:0] SB_RAM40_4K_inst0_RDATA;
-wire [10:0] SB_RAM40_4K_inst0_RADDR;
-wire SB_RAM40_4K_inst0_RCLK;
-wire SB_RAM40_4K_inst0_RCLKE;
-wire SB_RAM40_4K_inst0_RE;
-wire SB_RAM40_4K_inst0_WCLK;
-wire SB_RAM40_4K_inst0_WCLKE;
-wire SB_RAM40_4K_inst0_WE;
-wire [10:0] SB_RAM40_4K_inst0_WADDR;
-wire [15:0] SB_RAM40_4K_inst0_MASK;
-wire [15:0] SB_RAM40_4K_inst0_WDATA;
-assign SB_RAM40_4K_inst0_RADDR = RADDR;
-assign SB_RAM40_4K_inst0_RCLK = RCLK;
-assign SB_RAM40_4K_inst0_RCLKE = RCLKE;
-assign SB_RAM40_4K_inst0_RE = RE;
-assign SB_RAM40_4K_inst0_WCLK = WCLK;
-assign SB_RAM40_4K_inst0_WCLKE = WCLKE;
-assign SB_RAM40_4K_inst0_WE = WE;
-assign SB_RAM40_4K_inst0_WADDR = WADDR;
-assign SB_RAM40_4K_inst0_MASK = MASK;
-assign SB_RAM40_4K_inst0_WDATA = WDATA;
 SB_RAM40_4K #(
     .INIT_0(256'h0000000000000000000000000000000000000000000000000000000000ff00fe),
     .INIT_1(256'h0000000000000000000000000000000000000000000000000000000000000000),
@@ -54,16 +34,16 @@ SB_RAM40_4K #(
     .WRITE_MODE(0)
 ) SB_RAM40_4K_inst0 (
     .RDATA(SB_RAM40_4K_inst0_RDATA),
-    .RADDR(SB_RAM40_4K_inst0_RADDR),
-    .RCLK(SB_RAM40_4K_inst0_RCLK),
-    .RCLKE(SB_RAM40_4K_inst0_RCLKE),
-    .RE(SB_RAM40_4K_inst0_RE),
-    .WCLK(SB_RAM40_4K_inst0_WCLK),
-    .WCLKE(SB_RAM40_4K_inst0_WCLKE),
-    .WE(SB_RAM40_4K_inst0_WE),
-    .WADDR(SB_RAM40_4K_inst0_WADDR),
-    .MASK(SB_RAM40_4K_inst0_MASK),
-    .WDATA(SB_RAM40_4K_inst0_WDATA)
+    .RADDR(RADDR),
+    .RCLK(RCLK),
+    .RCLKE(RCLKE),
+    .RE(RE),
+    .WCLK(WCLK),
+    .WCLKE(WCLKE),
+    .WE(WE),
+    .WADDR(WADDR),
+    .MASK(MASK),
+    .WDATA(WDATA)
 );
 assign RDATA = SB_RAM40_4K_inst0_RDATA;
 endmodule


### PR DESCRIPTION
This improves the input connection logic for instance statements to use
an existing identifier if it's the sole driver of an input.  This avoids
having to emit an input wire for all instance inputs (this was leading
to a code size explosion compared to the old logic which would just
directly insert the driver's identifier).  We avoid the inlining issue
by marking the driver as blacklisted from inlining (the original reason
we introduced these inputs wires was so we could mark them as
blacklisted so expressions weren't inlined into the instance statement
for tool compatability, but now we can just mark the driver instead of
emitting a new wire).

This should reduce the code size explosion, since now we'll only
introduce an input wire if we encounter a non-identifier driver (e.g. a
concat for a non-bulk connection, or assignments to the input wire for
elements of a unpacked array).  This will be particularly good for the
non-inline case where all we were doing was introducing extra wires
(since inlining wasn't being run, the inline expressions issue isn't a
problem).