### PR TITLE
[verilog] omit input wire for Bit <-> Bits[1]

### DIFF
--- a/src/passes/analysis/verilog.cpp
+++ b/src/passes/analysis/verilog.cpp
@@ -839,7 +839,12 @@ processSingleArrayElementTarget(
     ArrayType* array_type = cast<ArrayType>(type);
     // Check if array is length 1, because sometimes we only have one connection
     // for a slice
-    if (array_type->getLen() == 1) {
+    //
+    // Also for bit <- bits[1] in verilog, we don't don't need to do this (but
+    // we do need to for unpacked multidimensional arrays)
+    if (
+      array_type->getLen() == 1 &&
+      !get_raw_type(array_type->getElemType())->isBaseType()) {
       target = std::make_unique<vAST::Index>(
         std::get<std::unique_ptr<vAST::Identifier>>(std::move(target)),
         vAST::make_num("0"));

--- a/tests/gtest/golds/uart.v
+++ b/tests/gtest/golds/uart.v
@@ -265,8 +265,6 @@ wire [1:0] UART_comb_inst0_O3;
 wire [7:0] reg_PR_inst0_out;
 wire [2:0] reg_PR_inst1_out;
 wire [1:0] reg_PR_inst2_out;
-wire [0:0] DFF_initTrue_has_ceFalse_has_resetFalse_has_async_resetTrue_inst0$reg_PR_inst0_in;
-assign DFF_initTrue_has_ceFalse_has_resetFalse_has_async_resetTrue_inst0$reg_PR_inst0_in[0] = UART_comb_inst0_O2;
 coreir_reg_arst #(
     .arst_posedge(1'b1),
     .clk_posedge(1'b1),
@@ -275,7 +273,7 @@ coreir_reg_arst #(
 ) DFF_initTrue_has_ceFalse_has_resetFalse_has_async_resetTrue_inst0$reg_PR_inst0 (
     .clk(CLK),
     .arst(ASYNCRESET),
-    .in(DFF_initTrue_has_ceFalse_has_resetFalse_has_async_resetTrue_inst0$reg_PR_inst0_in),
+    .in(UART_comb_inst0_O2),
     .out(DFF_initTrue_has_ceFalse_has_resetFalse_has_async_resetTrue_inst0$reg_PR_inst0_out)
 );
 UART_comb UART_comb_inst0 (


### PR DESCRIPTION
While we are technically generating correct code, this omits the input
wire if we're connecting a bits[1] to a bit since in verilog that's
allowed and that allows us to omit another wire (our previous change
still causes an out of memory error in the garnet test, so the hope is
that removing this wire will help us get under the memory usage limit)