### PR TITLE
Fix valgrind issues

### DIFF
--- a/include/coreir/ir/wireable.h
+++ b/include/coreir/ir/wireable.h
@@ -94,7 +94,7 @@ class Wireable : public MetaData {
 std::ostream& operator<<(std::ostream&, const Wireable&);
 
 class Interface : public Wireable {
-  static const std::string instname;
+  const std::string instname = "self";
 
  public:
   Interface(ModuleDef* container, Type* type)

--- a/include/coreir/passes/transform/clock_gate.h
+++ b/include/coreir/passes/transform/clock_gate.h
@@ -7,10 +7,9 @@ namespace Passes {
 
 class ClockGate : public ModulePass {
  public:
-  static std::string ID;
   ClockGate()
       : ModulePass(
-          ID,
+          "clock_gate",
           "Find all places where a clock enable register can be inserted and "
           "insert it") {}
   bool runOnModule(Module* m) override;

--- a/include/coreir/passes/transform/inline_single_instances.h
+++ b/include/coreir/passes/transform/inline_single_instances.h
@@ -7,10 +7,9 @@ namespace Passes {
 
 class InlineSingleInstances : public InstanceGraphPass {
  public:
-  static std::string ID;
   InlineSingleInstances()
       : InstanceGraphPass(
-          ID,
+          "inline_single_instances",
           "Inlines any modules that contains a single instance") {}
   bool runOnInstanceGraphNode(InstanceGraphNode& node);
 };

--- a/include/coreir/passes/transform/isolate_primitives.h
+++ b/include/coreir/passes/transform/isolate_primitives.h
@@ -7,10 +7,9 @@ namespace Passes {
 
 class IsolatePrimitives : public ModulePass {
  public:
-  static std::string ID;
   IsolatePrimitives()
       : ModulePass(
-          ID,
+          "isolate_primitives",
           "Isolates all coreir/corebit primitives into its own module",
           false) {}
   bool runOnModule(Module* m) override;

--- a/include/coreir/passes/transform/removesinglemuxes.h
+++ b/include/coreir/passes/transform/removesinglemuxes.h
@@ -8,11 +8,9 @@ namespace Passes {
 
 class RemoveSingleMuxes : public ModulePass {
  public:
-  static std::string ID;
-
   RemoveSingleMuxes()
       : ModulePass(
-          ID,
+          "removesinglemuxes",
           "Removes single-input muxes and their control signals, if they are "
           "not "
           "used elsewhere.") {}

--- a/src/ir/moduledef.cpp
+++ b/src/ir/moduledef.cpp
@@ -25,6 +25,7 @@ ModuleDef::~ModuleDef() {
   // Delete interface, instances, cache
   delete interface;
   for (auto inst : instances) delete inst.second;
+  for (auto item : connMetaData) delete item.second;
 }
 
 //

--- a/src/ir/wireable.cpp
+++ b/src/ir/wireable.cpp
@@ -18,8 +18,6 @@ using namespace std;
 
 namespace CoreIR {
 
-const string Interface::instname = "self";
-
 Wireable::~Wireable() {
   for (auto selmap : selects) { delete selmap.second; }
 }

--- a/src/passes/transform/clock_gate.cpp
+++ b/src/passes/transform/clock_gate.cpp
@@ -1,7 +1,5 @@
 #include "coreir/passes/transform/clock_gate.h"
 
-std::string CoreIR::Passes::ClockGate::ID = "clock_gate";
-
 namespace {
 struct CEInfo {
   bool can_replace = false;

--- a/src/passes/transform/inline_single_instances.cpp
+++ b/src/passes/transform/inline_single_instances.cpp
@@ -4,7 +4,6 @@
 using namespace std;
 using namespace CoreIR;
 
-string Passes::InlineSingleInstances::ID = "inline_single_instances";
 bool Passes::InlineSingleInstances::runOnInstanceGraphNode(
   InstanceGraphNode& node) {
   auto m = node.getModule();

--- a/src/passes/transform/isolate_primitives.cpp
+++ b/src/passes/transform/isolate_primitives.cpp
@@ -1,7 +1,5 @@
 #include "coreir/passes/transform/isolate_primitives.h"
 
-std::string CoreIR::Passes::IsolatePrimitives::ID = "isolate_primitives";
-
 // Creates a separate module that isolates all the primitive (coreir/corebit)
 // instances
 

--- a/src/passes/transform/removesinglemuxes.cpp
+++ b/src/passes/transform/removesinglemuxes.cpp
@@ -8,7 +8,6 @@ namespace CoreIR {
 
 namespace Passes {
 
-string Passes::RemoveSingleMuxes::ID = "removesinglemuxes";
 bool RemoveSingleMuxes::runOnModule(Module* m) {
   if (!m->hasDef()) { return false; }
 


### PR DESCRIPTION
Found some minor leaks when running valgrind on the binary
* Cleanup memory allocated here:
https://github.com/rdaly525/coreir/blob/038cc82f5e8e0eb8b3d8b7d08be430bed71f9e95/src/ir/moduledef.cpp#L388
* Remove some lingering static ID logic (this is needed to avoid the double free issue, but I think this new code got merged after we did the cleanup on all the passes)
* Remove static std::string (this isn't necessarily a problem, but valgrind reports it as an issue and I don't think there's any value in having it, so I just simplified it to use a const std::string.  If we really wanted to optimize it, I think we should be using static const char* since that will have one copy of the c-string, whereas using a static std::string is slightly different, but I don't think this optimization is necessary)

Here's the valgrind report I got:
```
lenny@kiwi:/nobackup/lenny/garnet$ valgrind --leak-check=full /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir -i garnet.json -l commonlib -o garnet.v
==27694== Memcheck, a memory error detector
==27694== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==27694== Using Valgrind-3.13.0 and LibVEX; rerun with -h for copyright info
==27694== Command: /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir -i garnet.json -l commonlib -o garnet.v
==27694==
==27694== Invalid read of size 4
==27694==    at 0x784199: __gnu_cxx::__exchange_and_add_single(int*, int) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x784213: __gnu_cxx::__exchange_and_add_dispatch(int*, int) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7BB7B5: std::string::_Rep::_M_dispose(std::allocator<char> const&) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7B36F5: std::basic_string<char, std::char_traits<char>, std::allocator<char> >::~basic_string() (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x5AC60F0: __run_exit_handlers (exit.c:108)
==27694==    by 0x5AC61E9: exit (exit.c:139)
==27694==    by 0x5AA4B9D: (below main) (libc-start.c:344)
==27694==  Address 0x7718fe0 is 16 bytes inside a block of size 42 free'd
==27694==    at 0x4C3123B: operator delete(void*) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==27694==    by 0x7CB8FD: __gnu_cxx::new_allocator<char>::deallocate(char*, unsigned long) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7C2BFD: std::string::_Rep::_M_destroy(std::allocator<char> const&) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7BB7D1: std::string::_Rep::_M_dispose(std::allocator<char> const&) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7B36F5: std::basic_string<char, std::char_traits<char>, std::allocator<char> >::~basic_string() (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x5AC66C4: __cxa_finalize (cxa_finalize.c:83)
==27694==    by 0x6AA2462: ???
==27694==    by 0x4015CCB: _dl_close_worker.part.0 (dl-close.c:288)
==27694==    by 0x4016AF9: _dl_close_worker (dl-close.c:125)
==27694==    by 0x4016AF9: _dl_close (dl-close.c:842)
==27694==    by 0x5BEA51E: _dl_catch_exception (dl-error-skeleton.c:196)
==27694==    by 0x5BEA5AE: _dl_catch_error (dl-error-skeleton.c:215)
==27694==    by 0x4E3D744: _dlerror_run (dlerror.c:162)
==27694==  Block was alloc'd at
==27694==    at 0x4C3017F: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==27694==    by 0x7D3A93: __gnu_cxx::new_allocator<char>::allocate(unsigned long, void const*) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7CA0AF: std::string::_Rep::_S_create(unsigned long, unsigned long, std::allocator<char> const&) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7CB9E4: char* std::string::_S_construct<char const*>(char const*, char const*, std::allocator<char> const&, std::forward_iterator_tag) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7C2C37: char* std::string::_S_construct_aux<char const*>(char const*, char const*, std::allocator<char> const&, std::__false_type) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7BB7FF: char* std::string::_S_construct<char const*>(char const*, char const*, std::allocator<char> const&) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7B3B46: std::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string(char const*, std::allocator<char> const&) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x6CF766B: ???
==27694==    by 0x6CF7AFE: ???
==27694==    by 0x4010782: call_init (dl-init.c:72)
==27694==    by 0x4010782: _dl_init (dl-init.c:119)
==27694==    by 0x401524E: dl_open_worker (dl-open.c:522)
==27694==    by 0x5BEA51E: _dl_catch_exception (dl-error-skeleton.c:196)
==27694==
==27694== Invalid read of size 4
==27694==    at 0x7841A2: __gnu_cxx::__exchange_and_add_single(int*, int) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x784213: __gnu_cxx::__exchange_and_add_dispatch(int*, int) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7BB7B5: std::string::_Rep::_M_dispose(std::allocator<char> const&) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7B36F5: std::basic_string<char, std::char_traits<char>, std::allocator<char> >::~basic_string() (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x5AC60F0: __run_exit_handlers (exit.c:108)
==27694==    by 0x5AC61E9: exit (exit.c:139)
==27694==    by 0x5AA4B9D: (below main) (libc-start.c:344)
==27694==  Address 0x7718fe0 is 16 bytes inside a block of size 42 free'd
==27694==    at 0x4C3123B: operator delete(void*) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==27694==    by 0x7CB8FD: __gnu_cxx::new_allocator<char>::deallocate(char*, unsigned long) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7C2BFD: std::string::_Rep::_M_destroy(std::allocator<char> const&) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7BB7D1: std::string::_Rep::_M_dispose(std::allocator<char> const&) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7B36F5: std::basic_string<char, std::char_traits<char>, std::allocator<char> >::~basic_string() (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x5AC66C4: __cxa_finalize (cxa_finalize.c:83)
==27694==    by 0x6AA2462: ???
==27694==    by 0x4015CCB: _dl_close_worker.part.0 (dl-close.c:288)
==27694==    by 0x4016AF9: _dl_close_worker (dl-close.c:125)
==27694==    by 0x4016AF9: _dl_close (dl-close.c:842)
==27694==    by 0x5BEA51E: _dl_catch_exception (dl-error-skeleton.c:196)
==27694==    by 0x5BEA5AE: _dl_catch_error (dl-error-skeleton.c:215)
==27694==    by 0x4E3D744: _dlerror_run (dlerror.c:162)
==27694==  Block was alloc'd at
==27694==    at 0x4C3017F: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==27694==    by 0x7D3A93: __gnu_cxx::new_allocator<char>::allocate(unsigned long, void const*) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7CA0AF: std::string::_Rep::_S_create(unsigned long, unsigned long, std::allocator<char> const&) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7CB9E4: char* std::string::_S_construct<char const*>(char const*, char const*, std::allocator<char> const&, std::forward_iterator_tag) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7C2C37: char* std::string::_S_construct_aux<char const*>(char const*, char const*, std::allocator<char> const&, std::__false_type) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7BB7FF: char* std::string::_S_construct<char const*>(char const*, char const*, std::allocator<char> const&) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7B3B46: std::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string(char const*, std::allocator<char> const&) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x6CF766B: ???
==27694==    by 0x6CF7AFE: ???
==27694==    by 0x4010782: call_init (dl-init.c:72)
==27694==    by 0x4010782: _dl_init (dl-init.c:119)
==27694==    by 0x401524E: dl_open_worker (dl-open.c:522)
==27694==    by 0x5BEA51E: _dl_catch_exception (dl-error-skeleton.c:196)
==27694==
==27694== Invalid write of size 4
==27694==    at 0x7841AD: __gnu_cxx::__exchange_and_add_single(int*, int) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x784213: __gnu_cxx::__exchange_and_add_dispatch(int*, int) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7BB7B5: std::string::_Rep::_M_dispose(std::allocator<char> const&) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7B36F5: std::basic_string<char, std::char_traits<char>, std::allocator<char> >::~basic_string() (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x5AC60F0: __run_exit_handlers (exit.c:108)
==27694==    by 0x5AC61E9: exit (exit.c:139)
==27694==    by 0x5AA4B9D: (below main) (libc-start.c:344)
==27694==  Address 0x7718fe0 is 16 bytes inside a block of size 42 free'd
==27694==    at 0x4C3123B: operator delete(void*) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==27694==    by 0x7CB8FD: __gnu_cxx::new_allocator<char>::deallocate(char*, unsigned long) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7C2BFD: std::string::_Rep::_M_destroy(std::allocator<char> const&) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7BB7D1: std::string::_Rep::_M_dispose(std::allocator<char> const&) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7B36F5: std::basic_string<char, std::char_traits<char>, std::allocator<char> >::~basic_string() (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x5AC66C4: __cxa_finalize (cxa_finalize.c:83)
==27694==    by 0x6AA2462: ???
==27694==    by 0x4015CCB: _dl_close_worker.part.0 (dl-close.c:288)
==27694==    by 0x4016AF9: _dl_close_worker (dl-close.c:125)
==27694==    by 0x4016AF9: _dl_close (dl-close.c:842)
==27694==    by 0x5BEA51E: _dl_catch_exception (dl-error-skeleton.c:196)
==27694==    by 0x5BEA5AE: _dl_catch_error (dl-error-skeleton.c:215)
==27694==    by 0x4E3D744: _dlerror_run (dlerror.c:162)
==27694==  Block was alloc'd at
==27694==    at 0x4C3017F: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==27694==    by 0x7D3A93: __gnu_cxx::new_allocator<char>::allocate(unsigned long, void const*) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7CA0AF: std::string::_Rep::_S_create(unsigned long, unsigned long, std::allocator<char> const&) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7CB9E4: char* std::string::_S_construct<char const*>(char const*, char const*, std::allocator<char> const&, std::forward_iterator_tag) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7C2C37: char* std::string::_S_construct_aux<char const*>(char const*, char const*, std::allocator<char> const&, std::__false_type) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7BB7FF: char* std::string::_S_construct<char const*>(char const*, char const*, std::allocator<char> const&) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7B3B46: std::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string(char const*, std::allocator<char> const&) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x6CF766B: ???
==27694==    by 0x6CF7AFE: ???
==27694==    by 0x4010782: call_init (dl-init.c:72)
==27694==    by 0x4010782: _dl_init (dl-init.c:119)
==27694==    by 0x401524E: dl_open_worker (dl-open.c:522)
==27694==    by 0x5BEA51E: _dl_catch_exception (dl-error-skeleton.c:196)
==27694==
==27694== Invalid read of size 8
==27694==    at 0x7C2BC8: std::string::_Rep::_M_destroy(std::allocator<char> const&) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7BB7D1: std::string::_Rep::_M_dispose(std::allocator<char> const&) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7B36F5: std::basic_string<char, std::char_traits<char>, std::allocator<char> >::~basic_string() (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x5AC60F0: __run_exit_handlers (exit.c:108)
==27694==    by 0x5AC61E9: exit (exit.c:139)
==27694==    by 0x5AA4B9D: (below main) (libc-start.c:344)
==27694==  Address 0x7718fd8 is 8 bytes inside a block of size 42 free'd
==27694==    at 0x4C3123B: operator delete(void*) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==27694==    by 0x7CB8FD: __gnu_cxx::new_allocator<char>::deallocate(char*, unsigned long) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7C2BFD: std::string::_Rep::_M_destroy(std::allocator<char> const&) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7BB7D1: std::string::_Rep::_M_dispose(std::allocator<char> const&) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7B36F5: std::basic_string<char, std::char_traits<char>, std::allocator<char> >::~basic_string() (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x5AC66C4: __cxa_finalize (cxa_finalize.c:83)
==27694==    by 0x6AA2462: ???
==27694==    by 0x4015CCB: _dl_close_worker.part.0 (dl-close.c:288)
==27694==    by 0x4016AF9: _dl_close_worker (dl-close.c:125)
==27694==    by 0x4016AF9: _dl_close (dl-close.c:842)
==27694==    by 0x5BEA51E: _dl_catch_exception (dl-error-skeleton.c:196)
==27694==    by 0x5BEA5AE: _dl_catch_error (dl-error-skeleton.c:215)
==27694==    by 0x4E3D744: _dlerror_run (dlerror.c:162)
==27694==  Block was alloc'd at
==27694==    at 0x4C3017F: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==27694==    by 0x7D3A93: __gnu_cxx::new_allocator<char>::allocate(unsigned long, void const*) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7CA0AF: std::string::_Rep::_S_create(unsigned long, unsigned long, std::allocator<char> const&) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7CB9E4: char* std::string::_S_construct<char const*>(char const*, char const*, std::allocator<char> const&, std::forward_iterator_tag) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7C2C37: char* std::string::_S_construct_aux<char const*>(char const*, char const*, std::allocator<char> const&, std::__false_type) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7BB7FF: char* std::string::_S_construct<char const*>(char const*, char const*, std::allocator<char> const&) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7B3B46: std::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string(char const*, std::allocator<char> const&) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x6CF766B: ???
==27694==    by 0x6CF7AFE: ???
==27694==    by 0x4010782: call_init (dl-init.c:72)
==27694==    by 0x4010782: _dl_init (dl-init.c:119)
==27694==    by 0x401524E: dl_open_worker (dl-open.c:522)
==27694==    by 0x5BEA51E: _dl_catch_exception (dl-error-skeleton.c:196)
==27694==
==27694== Invalid free() / delete / delete[] / realloc()
==27694==    at 0x4C3123B: operator delete(void*) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==27694==    by 0x7CB8FD: __gnu_cxx::new_allocator<char>::deallocate(char*, unsigned long) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7C2BFD: std::string::_Rep::_M_destroy(std::allocator<char> const&) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7BB7D1: std::string::_Rep::_M_dispose(std::allocator<char> const&) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7B36F5: std::basic_string<char, std::char_traits<char>, std::allocator<char> >::~basic_string() (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x5AC60F0: __run_exit_handlers (exit.c:108)
==27694==    by 0x5AC61E9: exit (exit.c:139)
==27694==    by 0x5AA4B9D: (below main) (libc-start.c:344)
==27694==  Address 0x7718fd0 is 0 bytes inside a block of size 42 free'd
==27694==    at 0x4C3123B: operator delete(void*) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==27694==    by 0x7CB8FD: __gnu_cxx::new_allocator<char>::deallocate(char*, unsigned long) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7C2BFD: std::string::_Rep::_M_destroy(std::allocator<char> const&) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7BB7D1: std::string::_Rep::_M_dispose(std::allocator<char> const&) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7B36F5: std::basic_string<char, std::char_traits<char>, std::allocator<char> >::~basic_string() (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x5AC66C4: __cxa_finalize (cxa_finalize.c:83)
==27694==    by 0x6AA2462: ???
==27694==    by 0x4015CCB: _dl_close_worker.part.0 (dl-close.c:288)
==27694==    by 0x4016AF9: _dl_close_worker (dl-close.c:125)
==27694==    by 0x4016AF9: _dl_close (dl-close.c:842)
==27694==    by 0x5BEA51E: _dl_catch_exception (dl-error-skeleton.c:196)
==27694==    by 0x5BEA5AE: _dl_catch_error (dl-error-skeleton.c:215)
==27694==    by 0x4E3D744: _dlerror_run (dlerror.c:162)
==27694==  Block was alloc'd at
==27694==    at 0x4C3017F: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==27694==    by 0x7D3A93: __gnu_cxx::new_allocator<char>::allocate(unsigned long, void const*) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7CA0AF: std::string::_Rep::_S_create(unsigned long, unsigned long, std::allocator<char> const&) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7CB9E4: char* std::string::_S_construct<char const*>(char const*, char const*, std::allocator<char> const&, std::forward_iterator_tag) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7C2C37: char* std::string::_S_construct_aux<char const*>(char const*, char const*, std::allocator<char> const&, std::__false_type) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7BB7FF: char* std::string::_S_construct<char const*>(char const*, char const*, std::allocator<char> const&) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7B3B46: std::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string(char const*, std::allocator<char> const&) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x6CF766B: ???
==27694==    by 0x6CF7AFE: ???
==27694==    by 0x4010782: call_init (dl-init.c:72)
==27694==    by 0x4010782: _dl_init (dl-init.c:119)
==27694==    by 0x401524E: dl_open_worker (dl-open.c:522)
==27694==    by 0x5BEA51E: _dl_catch_exception (dl-error-skeleton.c:196)
==27694==
==27694==
==27694== HEAP SUMMARY:
==27694==     in use at exit: 1,628,549 bytes in 50,891 blocks
==27694==   total heap usage: 28,476,050 allocs, 28,425,164 frees, 2,990,957,521 bytes allocated
==27694==
==27694== 29 bytes in 1 blocks are definitely lost in loss record 1 of 13
==27694==    at 0x4C3017F: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==27694==    by 0x7D3A93: __gnu_cxx::new_allocator<char>::allocate(unsigned long, void const*) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7CA0AF: std::string::_Rep::_S_create(unsigned long, unsigned long, std::allocator<char> const&) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7CB9E4: char* std::string::_S_construct<char const*>(char const*, char const*, std::allocator<char> const&, std::forward_iterator_tag) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7C2C37: char* std::string::_S_construct_aux<char const*>(char const*, char const*, std::allocator<char> const&, std::__false_type) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7BB7FF: char* std::string::_S_construct<char const*>(char const*, char const*, std::allocator<char> const&) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7B3B46: std::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string(char const*, std::allocator<char> const&) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x8E800F: __static_initialization_and_destruction_0(int, int) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x8E84A2: _GLOBAL__sub_I_wireable.cpp (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0xA6151E: __libc_csu_init (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x5AA4B27: (below main) (libc-start.c:266)
==27694==
==27694== 35 bytes in 1 blocks are definitely lost in loss record 2 of 13
==27694==    at 0x4C3017F: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==27694==    by 0x7D3A93: __gnu_cxx::new_allocator<char>::allocate(unsigned long, void const*) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7CA0AF: std::string::_Rep::_S_create(unsigned long, unsigned long, std::allocator<char> const&) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7CB9E4: char* std::string::_S_construct<char const*>(char const*, char const*, std::allocator<char> const&, std::forward_iterator_tag) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7C2C37: char* std::string::_S_construct_aux<char const*>(char const*, char const*, std::allocator<char> const&, std::__false_type) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7BB7FF: char* std::string::_S_construct<char const*>(char const*, char const*, std::allocator<char> const&) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7B3B46: std::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string(char const*, std::allocator<char> const&) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x9C33B1: __static_initialization_and_destruction_0(int, int) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x9C3844: _GLOBAL__sub_I_clock_gate.cpp (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0xA6151E: __libc_csu_init (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x5AA4B27: (below main) (libc-start.c:266)
==27694==
==27694== 42 bytes in 1 blocks are definitely lost in loss record 3 of 13
==27694==    at 0x4C3017F: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==27694==    by 0x7D3A93: __gnu_cxx::new_allocator<char>::allocate(unsigned long, void const*) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7CA0AF: std::string::_Rep::_S_create(unsigned long, unsigned long, std::allocator<char> const&) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7CB9E4: char* std::string::_S_construct<char const*>(char const*, char const*, std::allocator<char> const&, std::forward_iterator_tag) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7C2C37: char* std::string::_S_construct_aux<char const*>(char const*, char const*, std::allocator<char> const&, std::__false_type) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7BB7FF: char* std::string::_S_construct<char const*>(char const*, char const*, std::allocator<char> const&) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7B3B46: std::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string(char const*, std::allocator<char> const&) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x9FEAA3: __static_initialization_and_destruction_0(int, int) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x9FEF36: _GLOBAL__sub_I_removesinglemuxes.cpp (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0xA6151E: __libc_csu_init (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x5AA4B27: (below main) (libc-start.c:266)
==27694==
==27694== 43 bytes in 1 blocks are definitely lost in loss record 4 of 13
==27694==    at 0x4C3017F: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==27694==    by 0x7D3A93: __gnu_cxx::new_allocator<char>::allocate(unsigned long, void const*) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7CA0AF: std::string::_Rep::_S_create(unsigned long, unsigned long, std::allocator<char> const&) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7CB9E4: char* std::string::_S_construct<char const*>(char const*, char const*, std::allocator<char> const&, std::forward_iterator_tag) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7C2C37: char* std::string::_S_construct_aux<char const*>(char const*, char const*, std::allocator<char> const&, std::__false_type) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7BB7FF: char* std::string::_S_construct<char const*>(char const*, char const*, std::allocator<char> const&) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7B3B46: std::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string(char const*, std::allocator<char> const&) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x9E7B27: __static_initialization_and_destruction_0(int, int) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x9E7FBA: _GLOBAL__sub_I_isolate_primitives.cpp (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0xA6151E: __libc_csu_init (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x5AA4B27: (below main) (libc-start.c:266)
==27694==
==27694== 48 bytes in 1 blocks are definitely lost in loss record 5 of 13
==27694==    at 0x4C3017F: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==27694==    by 0x7D3A93: __gnu_cxx::new_allocator<char>::allocate(unsigned long, void const*) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7CA0AF: std::string::_Rep::_S_create(unsigned long, unsigned long, std::allocator<char> const&) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7CB9E4: char* std::string::_S_construct<char const*>(char const*, char const*, std::allocator<char> const&, std::forward_iterator_tag) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7C2C37: char* std::string::_S_construct_aux<char const*>(char const*, char const*, std::allocator<char> const&, std::__false_type) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7BB7FF: char* std::string::_S_construct<char const*>(char const*, char const*, std::allocator<char> const&) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x7B3B46: std::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string(char const*, std::allocator<char> const&) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x9E522E: __static_initialization_and_destruction_0(int, int) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x9E56C1: _GLOBAL__sub_I_inline_single_instances.cpp (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0xA6151E: __libc_csu_init (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x5AA4B27: (below main) (libc-start.c:266)
==27694==
==27694== 21,312 (5,328 direct, 15,984 indirect) bytes in 333 blocks are definitely lost in loss record 7 of 13
==27694==    at 0x4C3017F: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==27694==    by 0x892C2A: CoreIR::ModuleDef::getMetaData(CoreIR::Wireable*, CoreIR::Wireable*) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x97C5CD: CoreIR::addConnectionMapEntry(std::string, CoreIR::Wireable*, CoreIR::Wireable*, std::map<CoreIR::ConnMapKey, std::vector<CoreIR::ConnMapEntry, std::allocator<CoreIR::ConnMapEntry> >, std::less<CoreIR::ConnMapKey>, std::allocator<std::pair<CoreIR::ConnMapKey const, std::vector<CoreIR::ConnMapEntry, std::allocator<CoreIR::ConnMapEntry> > > > >&, CoreIR::ModuleDef*) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x97CAF4: CoreIR::build_connection_map(CoreIR::ModuleDef*, std::map<std::string, CoreIR::Instance*, std::less<std::string>, std::allocator<std::pair<std::string const, CoreIR::Instance*> > >) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x9804B1: CoreIR::Passes::Verilog::compileModuleBody(CoreIR::RecordType*, CoreIR::ModuleDef*, bool, bool, std::set<std::string, std::less<std::string>, std::allocator<std::string> >&) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x984C3B: CoreIR::Passes::Verilog::compileModule(CoreIR::Module*) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x9859B6: CoreIR::Passes::Verilog::runOnInstanceGraphNode(CoreIR::InstanceGraphNode&) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x8AEF88: CoreIR::PassManager::runInstanceGraphPass(CoreIR::Pass*) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x8AF2FE: CoreIR::PassManager::runPass(CoreIR::Pass*, std::vector<std::string, std::allocator<std::string> >&) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x8B0150: CoreIR::PassManager::run(std::vector<std::string, std::allocator<std::string> >&, std::vector<std::string, std::allocator<std::string> >) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x834D3A: CoreIR::Context::runPasses(std::vector<std::string, std::allocator<std::string> >, std::vector<std::string, std::allocator<std::string> >) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x79E29B: main (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==
==27694== 32,256 (8,064 direct, 24,192 indirect) bytes in 504 blocks are definitely lost in loss record 9 of 13
==27694==    at 0x4C3017F: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==27694==    by 0x892C2A: CoreIR::ModuleDef::getMetaData(CoreIR::Wireable*, CoreIR::Wireable*) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x97C5CD: CoreIR::addConnectionMapEntry(std::string, CoreIR::Wireable*, CoreIR::Wireable*, std::map<CoreIR::ConnMapKey, std::vector<CoreIR::ConnMapEntry, std::allocator<CoreIR::ConnMapEntry> >, std::less<CoreIR::ConnMapKey>, std::allocator<std::pair<CoreIR::ConnMapKey const, std::vector<CoreIR::ConnMapEntry, std::allocator<CoreIR::ConnMapEntry> > > > >&, CoreIR::ModuleDef*) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x97CA32: CoreIR::build_connection_map(CoreIR::ModuleDef*, std::map<std::string, CoreIR::Instance*, std::less<std::string>, std::allocator<std::pair<std::string const, CoreIR::Instance*> > >) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x9804B1: CoreIR::Passes::Verilog::compileModuleBody(CoreIR::RecordType*, CoreIR::ModuleDef*, bool, bool, std::set<std::string, std::less<std::string>, std::allocator<std::string> >&) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x984C3B: CoreIR::Passes::Verilog::compileModule(CoreIR::Module*) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x9859B6: CoreIR::Passes::Verilog::runOnInstanceGraphNode(CoreIR::InstanceGraphNode&) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x8AEF88: CoreIR::PassManager::runInstanceGraphPass(CoreIR::Pass*) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x8AF2FE: CoreIR::PassManager::runPass(CoreIR::Pass*, std::vector<std::string, std::allocator<std::string> >&) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x8B0150: CoreIR::PassManager::run(std::vector<std::string, std::allocator<std::string> >&, std::vector<std::string, std::allocator<std::string> >) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x834D3A: CoreIR::Context::runPasses(std::vector<std::string, std::allocator<std::string> >, std::vector<std::string, std::allocator<std::string> >) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x79E29B: main (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==
==27694== 695,616 (173,904 direct, 521,712 indirect) bytes in 10,869 blocks are definitely lost in loss record 12 of 13
==27694==    at 0x4C3017F: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==27694==    by 0x892C2A: CoreIR::ModuleDef::getMetaData(CoreIR::Wireable*, CoreIR::Wireable*) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x97C5CD: CoreIR::addConnectionMapEntry(std::string, CoreIR::Wireable*, CoreIR::Wireable*, std::map<CoreIR::ConnMapKey, std::vector<CoreIR::ConnMapEntry, std::allocator<CoreIR::ConnMapEntry> >, std::less<CoreIR::ConnMapKey>, std::allocator<std::pair<CoreIR::ConnMapKey const, std::vector<CoreIR::ConnMapEntry, std::allocator<CoreIR::ConnMapEntry> > > > >&, CoreIR::ModuleDef*) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x97C8C6: CoreIR::build_connection_map(CoreIR::ModuleDef*, std::map<std::string, CoreIR::Instance*, std::less<std::string>, std::allocator<std::pair<std::string const, CoreIR::Instance*> > >) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x9804B1: CoreIR::Passes::Verilog::compileModuleBody(CoreIR::RecordType*, CoreIR::ModuleDef*, bool, bool, std::set<std::string, std::less<std::string>, std::allocator<std::string> >&) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x984C3B: CoreIR::Passes::Verilog::compileModule(CoreIR::Module*) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x9859B6: CoreIR::Passes::Verilog::runOnInstanceGraphNode(CoreIR::InstanceGraphNode&) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x8AEF88: CoreIR::PassManager::runInstanceGraphPass(CoreIR::Pass*) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x8AF2FE: CoreIR::PassManager::runPass(CoreIR::Pass*, std::vector<std::string, std::allocator<std::string> >&) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x8B0150: CoreIR::PassManager::run(std::vector<std::string, std::allocator<std::string> >&, std::vector<std::string, std::allocator<std::string> >) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x834D3A: CoreIR::Context::runPasses(std::vector<std::string, std::allocator<std::string> >, std::vector<std::string, std::allocator<std::string> >) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x79E29B: main (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==
==27694== 879,168 (219,792 direct, 659,376 indirect) bytes in 13,737 blocks are definitely lost in loss record 13 of 13
==27694==    at 0x4C3017F: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==27694==    by 0x892C2A: CoreIR::ModuleDef::getMetaData(CoreIR::Wireable*, CoreIR::Wireable*) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x97C5CD: CoreIR::addConnectionMapEntry(std::string, CoreIR::Wireable*, CoreIR::Wireable*, std::map<CoreIR::ConnMapKey, std::vector<CoreIR::ConnMapEntry, std::allocator<CoreIR::ConnMapEntry> >, std::less<CoreIR::ConnMapKey>, std::allocator<std::pair<CoreIR::ConnMapKey const, std::vector<CoreIR::ConnMapEntry, std::allocator<CoreIR::ConnMapEntry> > > > >&, CoreIR::ModuleDef*) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x97C95E: CoreIR::build_connection_map(CoreIR::ModuleDef*, std::map<std::string, CoreIR::Instance*, std::less<std::string>, std::allocator<std::pair<std::string const, CoreIR::Instance*> > >) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x9804B1: CoreIR::Passes::Verilog::compileModuleBody(CoreIR::RecordType*, CoreIR::ModuleDef*, bool, bool, std::set<std::string, std::less<std::string>, std::allocator<std::string> >&) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x984C3B: CoreIR::Passes::Verilog::compileModule(CoreIR::Module*) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x9859B6: CoreIR::Passes::Verilog::runOnInstanceGraphNode(CoreIR::InstanceGraphNode&) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x8AEF88: CoreIR::PassManager::runInstanceGraphPass(CoreIR::Pass*) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x8AF2FE: CoreIR::PassManager::runPass(CoreIR::Pass*, std::vector<std::string, std::allocator<std::string> >&) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x8B0150: CoreIR::PassManager::run(std::vector<std::string, std::allocator<std::string> >&, std::vector<std::string, std::allocator<std::string> >) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x834D3A: CoreIR::Context::runPasses(std::vector<std::string, std::allocator<std::string> >, std::vector<std::string, std::allocator<std::string> >) (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==    by 0x79E29B: main (in /nobackup/lenny/miniconda3/envs/garnet/lib/python3.8/site-packages/coreir/coreir)
==27694==
==27694== LEAK SUMMARY:
==27694==    definitely lost: 407,285 bytes in 25,448 blocks
==27694==    indirectly lost: 1,221,264 bytes in 25,443 blocks
==27694==      possibly lost: 0 bytes in 0 blocks
==27694==    still reachable: 0 bytes in 0 blocks
==27694==         suppressed: 0 bytes in 0 blocks
==27694==
==27694== For counts of detected and suppressed errors, rerun with: -v
==27694== ERROR SUMMARY: 34 errors from 14 contexts (suppressed: 0 from 0)
```