### PR TITLE
Cache getTopParent logic

### DIFF
--- a/include/coreir/ir/wireable.h
+++ b/include/coreir/ir/wireable.h
@@ -16,6 +16,7 @@ class Wireable : public MetaData {
   WireableKind kind;
   ModuleDef* container;  // ModuleDef which it is contained in
   Type* type;
+  Wireable* topParent = NULL;
 
   std::set<Wireable*> connected;
 

--- a/include/coreir/ir/wireable.h
+++ b/include/coreir/ir/wireable.h
@@ -16,7 +16,7 @@ class Wireable : public MetaData {
   WireableKind kind;
   ModuleDef* container;  // ModuleDef which it is contained in
   Type* type;
-  Wireable* topParent = NULL;
+  Wireable* topParent = nullptr;
 
   std::set<Wireable*> connected;
 

--- a/include/coreir/ir/wireable.h
+++ b/include/coreir/ir/wireable.h
@@ -80,6 +80,7 @@ class Wireable : public MetaData {
   // Get all the connections from self and all the selects
   LocalConnections getLocalConnections();
 
+  // NOTE: Will cache the result, assumes that the parent never change
   Wireable* getTopParent();
 
   // removes the select from this wireble.

--- a/src/ir/wireable.cpp
+++ b/src/ir/wireable.cpp
@@ -199,16 +199,20 @@ LocalConnections Wireable::getLocalConnections() {
 }
 
 Wireable* Wireable::getTopParent() {
-  Wireable* top = this;
-  while (isa<Select>(top) || isa<InstanceSelect>(top)) {
-    Select* s;
-    if (isa<Select>(top)) { s = cast<Select>(top); }
-    else {
-      s = cast<InstanceSelect>(top);
+  if (this->topParent == NULL) {
+    if (isa<Select>(this) || isa<InstanceSelect>(this)) {
+      Select* s;
+      if (isa<Select>(this)) { s = cast<Select>(this); }
+      else {
+        s = cast<InstanceSelect>(this);
+      }
+      this->topParent = s->getParent()->getTopParent();
     }
-    top = s->getParent();
+    else {
+      this->topParent = this;
+    }
   }
-  return top;
+  return this->topParent;
 }
 
 string Interface::toString() const { return "self"; }

--- a/src/ir/wireable.cpp
+++ b/src/ir/wireable.cpp
@@ -199,20 +199,17 @@ LocalConnections Wireable::getLocalConnections() {
 }
 
 Wireable* Wireable::getTopParent() {
-  if (this->topParent == NULL) {
-    if (isa<Select>(this) || isa<InstanceSelect>(this)) {
-      Select* s;
-      if (isa<Select>(this)) { s = cast<Select>(this); }
-      else {
-        s = cast<InstanceSelect>(this);
-      }
-      this->topParent = s->getParent()->getTopParent();
-    }
-    else {
-      this->topParent = this;
-    }
+  if (topParent != nullptr) return topParent;
+  if (isa<Select>(this) || isa<InstanceSelect>(this)) {
+    Select* s = isa<Select>(this) ?
+        cast<Select>(this) :
+        cast<InstanceSelect>(this);
+    topParent = s->getParent()->getTopParent();
   }
-  return this->topParent;
+  else {
+    topParent = this;
+  }
+  return topParent;
 }
 
 string Interface::toString() const { return "self"; }

--- a/src/passes/analysis/verilog.cpp
+++ b/src/passes/analysis/verilog.cpp
@@ -634,7 +634,7 @@ convert_to_verilog_connection(Wireable* value, bool _inline) {
   }
 
   // Used to track the current select so we can see if it's an instance
-  Wireable* curr_wireable = value->getTopParent();
+  Wireable* curr_wireable = parent;
 
   std::variant<
     std::unique_ptr<vAST::Identifier>,


### PR DESCRIPTION
This shaves 5-7 seconds off the garnet compile time (17ish vs 22ish) by cacheing the getTopParent logic.  This function came up in the profile because I believe when we're dealing with low-level selects, we're repeatedly traversing the select path to get to the top parent.  @rdaly525 I believe this is safe since with selects, the parent shouldn't ever change.  This way, if we call getTopParent on two array children, they should share a cached parent rather than recomputing the select path.

Also a minor related change in verilog.cpp where we call getTopParent() twice, the compiler may already be optimizing this out, but just in case we reuse the result of the first invocation.