### PR TITLE
Avoid u wires

### DIFF
--- a/include/coreir/passes/analysis/verilog.h
+++ b/include/coreir/passes/analysis/verilog.h
@@ -59,7 +59,8 @@ class Verilog : public InstanceGraphPass {
     CoreIR::ModuleDef* definition,
     bool _inline,
     bool disable_width_cast,
-    std::set<std::string>& wires);
+    std::set<std::string>& wires,
+    std::set<std::string>& inlined_wires);
 
   std::unique_ptr<vAST::AbstractModule> compileStringBodyModule(
     json verilog_json,

--- a/include/coreir/passes/analysis/verilog.h
+++ b/include/coreir/passes/analysis/verilog.h
@@ -30,9 +30,6 @@ class Verilog : public InstanceGraphPass {
   // modules, but we only need to compile the verilog definition once
   std::set<Generator*> verilog_generators_seen;
 
-  // Keep track of wire primitive instances, we do not inline these
-  std::set<std::string> wires;
-
   void compileModule(Module* module);
 
   std::vector<std::unique_ptr<vAST::AbstractPort>> compilePorts(
@@ -88,7 +85,6 @@ class Verilog : public InstanceGraphPass {
     TModule().swap(modules);
     extern_modules.clear();
     verilog_generators_seen.clear();
-    wires.clear();
   }
 
   void writeToStream(std::ostream& os) override;

--- a/tests/gtest/golds/mux_with_default.v
+++ b/tests/gtest/golds/mux_with_default.v
@@ -1,0 +1,33 @@
+
+module MuxWithDefaultWrapper_9_32_8_0 (
+    input [31:0] I [8:0],
+    input [7:0] S,
+    input [0:0] EN,
+    output [31:0] O
+);
+reg [31:0] MuxWrapper_9_32_inst0$Mux9x32_inst0$coreir_commonlib_mux9x32_inst0_out;
+always @(*) begin
+if (S[3:0] == 0) begin
+    MuxWrapper_9_32_inst0$Mux9x32_inst0$coreir_commonlib_mux9x32_inst0_out = I[0];
+end else if (S[3:0] == 1) begin
+    MuxWrapper_9_32_inst0$Mux9x32_inst0$coreir_commonlib_mux9x32_inst0_out = I[1];
+end else if (S[3:0] == 2) begin
+    MuxWrapper_9_32_inst0$Mux9x32_inst0$coreir_commonlib_mux9x32_inst0_out = I[2];
+end else if (S[3:0] == 3) begin
+    MuxWrapper_9_32_inst0$Mux9x32_inst0$coreir_commonlib_mux9x32_inst0_out = I[3];
+end else if (S[3:0] == 4) begin
+    MuxWrapper_9_32_inst0$Mux9x32_inst0$coreir_commonlib_mux9x32_inst0_out = I[4];
+end else if (S[3:0] == 5) begin
+    MuxWrapper_9_32_inst0$Mux9x32_inst0$coreir_commonlib_mux9x32_inst0_out = I[5];
+end else if (S[3:0] == 6) begin
+    MuxWrapper_9_32_inst0$Mux9x32_inst0$coreir_commonlib_mux9x32_inst0_out = I[6];
+end else if (S[3:0] == 7) begin
+    MuxWrapper_9_32_inst0$Mux9x32_inst0$coreir_commonlib_mux9x32_inst0_out = I[7];
+end else begin
+    MuxWrapper_9_32_inst0$Mux9x32_inst0$coreir_commonlib_mux9x32_inst0_out = I[8];
+end
+end
+
+assign O = (S < 8'h09) & EN[0] ? MuxWrapper_9_32_inst0$Mux9x32_inst0$coreir_commonlib_mux9x32_inst0_out : 32'h00000000;
+endmodule
+

--- a/tests/gtest/golds/slice_combview.v
+++ b/tests/gtest/golds/slice_combview.v
@@ -5,12 +5,10 @@ module top (
     output [15:0] out,
     input CLK
 );
-wire [15:0] _$_U1;
 wire [15:0] value_src_out;
-assign _$_U1 = {in[7:0],in[15:8]};
 coreir_coreir_reg__width16_snk value_snk (
     .clk(CLK),
-    .in(_$_U1)
+    .in({in[7:0],in[15:8]})
 );
 coreir_coreir_reg__width16_src value_src (
     .out(value_src_out)

--- a/tests/gtest/srcs/mux_with_default.json
+++ b/tests/gtest/srcs/mux_with_default.json
@@ -1,0 +1,71 @@
+
+{"top":"global.MuxWithDefaultWrapper_9_32_8_0",
+"namespaces":{
+  "global":{
+    "modules":{
+      "MuxWithDefaultWrapper_9_32_8_0":{
+        "type":["Record",[
+          ["I",["Array",9,["Array",32,"BitIn"]]],
+          ["S",["Array",8,"BitIn"]],
+          ["EN",["Array",1,"BitIn"]],
+          ["O",["Array",32,"Bit"]]
+        ]],
+        "instances":{
+          "MuxWrapper_2_32_inst0$Mux2x32_inst0$coreir_commonlib_mux2x32_inst0$_join":{
+            "genref":"coreir.mux",
+            "genargs":{"width":["Int",32]}
+          },
+          "MuxWrapper_9_32_inst0$Mux9x32_inst0$coreir_commonlib_mux9x32_inst0":{
+            "genref":"commonlib.muxn",
+            "genargs":{"N":["Int",9], "width":["Int",32]}
+          },
+          "_$_U592":{
+            "genref":"mantle.wire",
+            "genargs":{"type":["CoreIRType",["Array",4,"BitIn"]]},
+            "metadata":{"inline_verilog_wire":true}
+          },
+          "and_inst0":{
+            "modref":"corebit.and"
+          },
+          "const_0_32":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",32]},
+            "modargs":{"value":[["BitVector",32],"32'h00000000"]}
+          },
+          "const_9_8":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",8]},
+            "modargs":{"value":[["BitVector",8],"8'h09"]}
+          },
+          "coreir_ult8_inst0":{
+            "genref":"coreir.ult",
+            "genargs":{"width":["Int",8]}
+          }
+        },
+        "connections":[
+          ["const_0_32.out","MuxWrapper_2_32_inst0$Mux2x32_inst0$coreir_commonlib_mux2x32_inst0$_join.in0"],
+          ["MuxWrapper_9_32_inst0$Mux9x32_inst0$coreir_commonlib_mux9x32_inst0.out","MuxWrapper_2_32_inst0$Mux2x32_inst0$coreir_commonlib_mux2x32_inst0$_join.in1"],
+          ["self.O","MuxWrapper_2_32_inst0$Mux2x32_inst0$coreir_commonlib_mux2x32_inst0$_join.out"],
+          ["and_inst0.out","MuxWrapper_2_32_inst0$Mux2x32_inst0$coreir_commonlib_mux2x32_inst0$_join.sel"],
+          ["self.I.0","MuxWrapper_9_32_inst0$Mux9x32_inst0$coreir_commonlib_mux9x32_inst0.in.data.0"],
+          ["self.I.1","MuxWrapper_9_32_inst0$Mux9x32_inst0$coreir_commonlib_mux9x32_inst0.in.data.1"],
+          ["self.I.2","MuxWrapper_9_32_inst0$Mux9x32_inst0$coreir_commonlib_mux9x32_inst0.in.data.2"],
+          ["self.I.3","MuxWrapper_9_32_inst0$Mux9x32_inst0$coreir_commonlib_mux9x32_inst0.in.data.3"],
+          ["self.I.4","MuxWrapper_9_32_inst0$Mux9x32_inst0$coreir_commonlib_mux9x32_inst0.in.data.4"],
+          ["self.I.5","MuxWrapper_9_32_inst0$Mux9x32_inst0$coreir_commonlib_mux9x32_inst0.in.data.5"],
+          ["self.I.6","MuxWrapper_9_32_inst0$Mux9x32_inst0$coreir_commonlib_mux9x32_inst0.in.data.6"],
+          ["self.I.7","MuxWrapper_9_32_inst0$Mux9x32_inst0$coreir_commonlib_mux9x32_inst0.in.data.7"],
+          ["self.I.8","MuxWrapper_9_32_inst0$Mux9x32_inst0$coreir_commonlib_mux9x32_inst0.in.data.8"],
+          ["_$_U592.in","MuxWrapper_9_32_inst0$Mux9x32_inst0$coreir_commonlib_mux9x32_inst0.in.sel"],
+          ["self.S.0:4","_$_U592.out.0:4"],
+          ["coreir_ult8_inst0.out","and_inst0.in0"],
+          ["self.EN.0","and_inst0.in1"],
+          ["coreir_ult8_inst0.in1","const_9_8.out"],
+          ["self.S","coreir_ult8_inst0.in0"]
+        ]
+      }
+    }
+  }
+}
+}
+


### PR DESCRIPTION
In some cases, we were still generating the `_$_U` wires introduced during the inlinePassThrough logic even though we were marking with metadata that they should be inlined, here's one instance:
```verilog
module MuxWithDefaultWrapper_9_32_8_0 (
    input [31:0] I [8:0],
    input [7:0] S,
    input [0:0] EN,
    output [31:0] O
);
reg [31:0] MuxWrapper_9_32_inst0$Mux9x32_inst0$coreir_commonlib_mux9x32_inst0_out;
wire [3:0] _$_U592;
always @(*) begin
if (_$_U592 == 0) begin
    MuxWrapper_9_32_inst0$Mux9x32_inst0$coreir_commonlib_mux9x32_inst0_out = I[0];
end else if (_$_U592 == 1) begin
    MuxWrapper_9_32_inst0$Mux9x32_inst0$coreir_commonlib_mux9x32_inst0_out = I[1];
end else if (_$_U592 == 2) begin
    MuxWrapper_9_32_inst0$Mux9x32_inst0$coreir_commonlib_mux9x32_inst0_out = I[2];
end else if (_$_U592 == 3) begin
    MuxWrapper_9_32_inst0$Mux9x32_inst0$coreir_commonlib_mux9x32_inst0_out = I[3];
end else if (_$_U592 == 4) begin
    MuxWrapper_9_32_inst0$Mux9x32_inst0$coreir_commonlib_mux9x32_inst0_out = I[4];
end else if (_$_U592 == 5) begin
    MuxWrapper_9_32_inst0$Mux9x32_inst0$coreir_commonlib_mux9x32_inst0_out = I[5];
end else if (_$_U592 == 6) begin
    MuxWrapper_9_32_inst0$Mux9x32_inst0$coreir_commonlib_mux9x32_inst0_out = I[6];
end else if (_$_U592 == 7) begin
    MuxWrapper_9_32_inst0$Mux9x32_inst0$coreir_commonlib_mux9x32_inst0_out = I[7];
end else begin
    MuxWrapper_9_32_inst0$Mux9x32_inst0$coreir_commonlib_mux9x32_inst0_out = I[8];
end
end

assign _$_U592 = S[3:0];
assign O = (S < 8'h09) & EN[0] ? MuxWrapper_9_32_inst0$Mux9x32_inst0$coreir_commonlib_mux9x32_inst0_out : 32'h00000000;
endmodule
```

The issue is that the recent change the introduced blocking of inlining for instance inputs (so we didn't get expressions inside the instance statements) was marking instance input identifiers as "do not inline".  This was overriding the metadata forcing the inlining of these mantle wires introduced by inlinePassThrough.

This change improves the logic to ensure that the inline wire metadata overrides this default "do not inline" behavior.  However, this isn't quite perfect yet since it causes a concat expression to be inlined into a module instance statement (see the change in `tests/gtest/golds/slice_combview.v`).  Fortunately, this doesn't present a semantic problem since the tools we've been encountering don't seem to mind this syntax, so I propose for now we add this change (in order to reduce the amount of code noise in the generated output, this is immediately annoying for debugging for our current users, while the prevention of inlining into instance inputs isn't problematic for anyone yet), and do a followup change to improve the inlining logic to avoid this case where a mantle wire is inlined into an instance input with a concat expression (in this case, I think we should introduce a temporary "<instance>_<in_port_name>" wire instead of the generic unique mantle wire name that is confusing).

Also, in the process of this change, I changed the `wires` set to be per-module, rather than global, which is actually how it should be (since two modules with the same wire names could clobber each other).