### PR TITLE
Avoid name conflicts between instance port wires and instance names.

### DIFF
--- a/CMakeLists.txt.in
+++ b/CMakeLists.txt.in
@@ -7,7 +7,7 @@ project(verilogAST-download NONE)
 include(ExternalProject)
 ExternalProject_Add(verilogAST
   GIT_REPOSITORY    https://github.com/leonardt/verilogAST-cpp.git
-  GIT_TAG           03bf80c
+  GIT_TAG           20f0aff
   SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/verilogAST-src"
   BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/verilogAST-build"
   CONFIGURE_COMMAND ""

--- a/include/coreir/passes/analysis/verilog.h
+++ b/include/coreir/passes/analysis/verilog.h
@@ -49,7 +49,11 @@ class Verilog : public InstanceGraphPass {
   std::vector<std::variant<
     std::unique_ptr<vAST::StructuralStatement>,
     std::unique_ptr<vAST::Declaration>>>
-  declareConnections(std::map<std::string, Instance*> instances, bool _inline);
+  declareConnections(
+    std::map<std::string, Instance*> instances,
+    bool _inline,
+    std::set<std::string>& instance_names,
+    std::map<std::string, std::string>& non_input_port_map);
 
   std::vector<std::variant<
     std::unique_ptr<vAST::StructuralStatement>,

--- a/src/ir/inline.cpp
+++ b/src/ir/inline.cpp
@@ -114,23 +114,16 @@ void PTTraverse(ModuleDef* def, Wireable* from, Wireable* to) {
       // Only inline instance input wires if there's a single driver,
       // otherwise, it will generate a concat node that shouldn't be inlined
       // since we avoid inserting expressions into instance inputs
-      bool inlined_ = !(isa<Instance>(from->getTopParent()) &&
-                        from->getType()->isInput()) ||
-        from->getSelects().size() == 1;
-      std::string wire_name = makeUniqueInstanceName(def, from);
-      if (inlined_) {
-        // Fix for https://github.com/rdaly525/coreir/issues/935
-        // Makes it backwards compatible with non --inline verilog code
-        // generation (since the wire isn't inlined, we'll clobber the name of
-        // the output port wire if we don't add a suffix)
-        wire_name += "_wire";
-      }
       Context* c = def->getContext();
       Instance* wire = def->addInstance(
-        wire_name,
+        makeUniqueInstanceName(def, from),
         c->getGenerator("mantle.wire"),
         {{"type", Const::make(c, from->getType())}});
-      if (inlined_) { wire->getMetaData()["inline_verilog_wire"] = true; }
+      if (
+        !(isa<Instance>(from->getTopParent()) && from->getType()->isInput()) ||
+        from->getSelects().size() == 1) {
+        wire->getMetaData()["inline_verilog_wire"] = true;
+      }
       def->connect(to, wire->sel("in"));
       wire->getModuleRef()->runGenerator();
       to = wire->sel("out");

--- a/src/ir/inline.cpp
+++ b/src/ir/inline.cpp
@@ -119,11 +119,7 @@ void PTTraverse(ModuleDef* def, Wireable* from, Wireable* to) {
         makeUniqueInstanceName(def, from),
         c->getGenerator("mantle.wire"),
         {{"type", Const::make(c, from->getType())}});
-      if (
-        !(isa<Instance>(from->getTopParent()) && from->getType()->isInput()) ||
-        from->getSelects().size() == 1) {
-        wire->getMetaData()["inline_verilog_wire"] = true;
-      }
+      wire->getMetaData()["inline_verilog_wire"] = true;
       def->connect(to, wire->sel("in"));
       wire->getModuleRef()->runGenerator();
       to = wire->sel("out");

--- a/src/passes/analysis/verilog.cpp
+++ b/src/passes/analysis/verilog.cpp
@@ -294,7 +294,6 @@ Passes::Verilog::declareConnections(
                      ->getRecord()
                      .at("in");
       this->makeDecl(instance.first, type, declarations, false);
-      non_input_port_map[instance.first] = instance.first;
       continue;
     }
     RecordType* record_type = cast<RecordType>(
@@ -1203,20 +1202,13 @@ Passes::Verilog::compileModuleBody(
         if (
           (driver_id || driver_index || driver_slice) &&
           std::holds_alternative<std::unique_ptr<vAST::Identifier>>(target)) {
-          // If it's not a concat, we connect it directly and prevent it from
-          // being inlined
-          //
-          // slices/indices are blacklisted automatically, but identifiers need
-          // to be marked
-          if (driver_id) { wires.insert(driver_id->value); }
+          // If it's not a concat, we connect it directly
           verilog_connections->insert(field, std::move(driver));
         }
         else {
           // otherwise it's a concat, so we emit an input wire for it
           wire_name = genFreshWireName(wire_name, instance_names);
           this->makeDecl(wire_name, field_type, body, false);
-          // prevent inlining of this wire into the module instance statement
-          wires.insert(wire_name);
           verilog_connections->insert(
             field,
             std::make_unique<vAST::Identifier>(wire_name));

--- a/src/passes/analysis/verilog.cpp
+++ b/src/passes/analysis/verilog.cpp
@@ -248,6 +248,29 @@ void Passes::Verilog::makeDecl(
     this->processDecl(std::move(id), type));
 }
 
+// Make sure it doesn't conflict with any instance names
+std::string genFreshWireName(
+  std::string base_name,
+  std::set<std::string>& instance_names) {
+  if (!instance_names.count(base_name)) { return base_name; }
+  int counter = 1;
+  while (instance_names.count(base_name + "_unq" + std::to_string(counter))) {
+    counter += 1;
+  }
+  return base_name + "_unq" + std::to_string(counter);
+}
+
+// Lookup to see if port name has been remapped (to avoid name conflicts with
+// port and instance names)
+std::string getUniquifiedName(
+  std::map<std::string, std::string>& non_input_port_map,
+  std::string port_name) {
+  if (non_input_port_map.count(port_name)) {
+    return non_input_port_map[port_name];
+  }
+  return port_name;
+}
+
 // Given a map of instances, return a vector of containing declarations for all
 // the output ports of each instance.  We return a vector of a variant type for
 // compatibility with the module AST node constructor, even though we only ever
@@ -257,7 +280,9 @@ std::vector<std::variant<
   std::unique_ptr<vAST::Declaration>>>
 Passes::Verilog::declareConnections(
   std::map<std::string, Instance*> instances,
-  bool _inline) {
+  bool _inline,
+  std::set<std::string>& instance_names,
+  std::map<std::string, std::string>& non_input_port_map) {
   std::vector<std::variant<
     std::unique_ptr<vAST::StructuralStatement>,
     std::unique_ptr<vAST::Declaration>>>
@@ -269,6 +294,7 @@ Passes::Verilog::declareConnections(
                      ->getRecord()
                      .at("in");
       this->makeDecl(instance.first, type, declarations, false);
+      non_input_port_map[instance.first] = instance.first;
       continue;
     }
     RecordType* record_type = cast<RecordType>(
@@ -277,11 +303,16 @@ Passes::Verilog::declareConnections(
     for (auto field : record_type->getFields()) {
       Type* field_type = record_type->getRecord().at(field);
       if (field_type->isInput()) { continue; }
-      this->makeDecl(
-        instance.first + "_" + field,
-        field_type,
-        declarations,
-        is_reg);
+      std::string wire_name = instance.first + "_" + field;
+      // Generate a fresh name in case theres a conflict with an existing
+      // instance name
+      wire_name = genFreshWireName(wire_name, instance_names);
+      non_input_port_map[instance.first + "_" + field] = wire_name;
+      // We don't need track conflicts with other instance port names this since
+      // at this point the only identifiers introduced are inst_name + port
+      // (and instance names must be unique), so only instance names can
+      // clobber instance port names
+      this->makeDecl(wire_name, field_type, declarations, is_reg);
     }
   }
   return declarations;
@@ -612,7 +643,10 @@ std::variant<
   std::unique_ptr<vAST::Attribute>,
   std::unique_ptr<vAST::Index>,
   std::unique_ptr<vAST::Slice>>
-convert_to_verilog_connection(Wireable* value, bool _inline) {
+convert_to_verilog_connection(
+  Wireable* value,
+  bool _inline,
+  std::map<std::string, std::string>& non_input_port_map) {
   SelectPath select_path = value->getSelectPath();
   if (select_path.front() == "self") { select_path.pop_front(); }
   Wireable* parent = value->getTopParent();
@@ -636,11 +670,27 @@ convert_to_verilog_connection(Wireable* value, bool _inline) {
   for (uint i = 0; i < select_path.size(); i++) {
     auto item = select_path[i];
     if (isNumber(item)) {
+      if (std::holds_alternative<std::unique_ptr<vAST::Identifier>>(
+            curr_node)) {
+        std::unique_ptr<vAST::Identifier>
+          id = std::get<std::unique_ptr<vAST::Identifier>>(
+            std::move(curr_node));
+        id->value = getUniquifiedName(non_input_port_map, id->value);
+        curr_node = std::move(id);
+      }
       curr_node = std::make_unique<vAST::Index>(
         std::move(curr_node),
         vAST::make_num(item));
     }
     else if (isSlice(item)) {
+      if (std::holds_alternative<std::unique_ptr<vAST::Identifier>>(
+            curr_node)) {
+        std::unique_ptr<vAST::Identifier>
+          id = std::get<std::unique_ptr<vAST::Identifier>>(
+            std::move(curr_node));
+        id->value = getUniquifiedName(non_input_port_map, id->value);
+        curr_node = std::move(id);
+      }
       int low;
       int high;
       std::tie(low, high) = parseSlice(item);
@@ -713,7 +763,7 @@ convert_to_verilog_connection(Wireable* value, bool _inline) {
           // selecting off a hierarchical instance select
           curr_node = std::make_unique<vAST::Attribute>(
             std::move(std::get<std::unique_ptr<vAST::Attribute>>(curr_node)),
-            item);
+            getUniquifiedName(non_input_port_map, item));
         }
         else {
           // append to current name being constructed
@@ -731,7 +781,10 @@ convert_to_verilog_connection(Wireable* value, bool _inline) {
     return std::get<std::unique_ptr<vAST::Index>>(std::move(curr_node));
   }
   if (std::holds_alternative<std::unique_ptr<vAST::Identifier>>(curr_node)) {
-    return std::get<std::unique_ptr<vAST::Identifier>>(std::move(curr_node));
+    std::unique_ptr<vAST::Identifier>
+      id = std::get<std::unique_ptr<vAST::Identifier>>(std::move(curr_node));
+    id->value = getUniquifiedName(non_input_port_map, id->value);
+    return id;
   }
   if (std::holds_alternative<std::unique_ptr<vAST::Attribute>>(curr_node)) {
     return std::get<std::unique_ptr<vAST::Attribute>>(std::move(curr_node));
@@ -770,7 +823,8 @@ std::unique_ptr<vAST::Concat> convert_non_bulk_connection_to_concat(
     std::unique_ptr<vAST::StructuralStatement>,
     std::unique_ptr<vAST::Declaration>>>& body,
   std::string debug_prefix,
-  bool _inline) {
+  bool _inline,
+  std::map<std::string, std::string>& non_input_port_map) {
 
   // nd-args contains a flat encoding of the index space of the array
   std::vector<std::unique_ptr<vAST::Expression>> nd_args;
@@ -787,7 +841,7 @@ std::unique_ptr<vAST::Concat> convert_non_bulk_connection_to_concat(
   // construct the appropriate Concat tree to map to the multi-dimensional space
   for (auto entry : entries) {
     std::unique_ptr<vAST::Expression> verilog_conn = convert_to_expression(
-      convert_to_verilog_connection(entry.source, _inline));
+      convert_to_verilog_connection(entry.source, _inline, non_input_port_map));
     process_connection_debug_metadata(
       entry,
       verilog_conn->toString(),
@@ -907,7 +961,8 @@ void assign_module_outputs(
     std::unique_ptr<vAST::StructuralStatement>,
     std::unique_ptr<vAST::Declaration>>>& body,
   std::map<ConnMapKey, std::vector<ConnMapEntry>> connection_map,
-  bool _inline) {
+  bool _inline,
+  std::map<std::string, std::string>& non_input_port_map) {
   for (auto field : record_type->getFields()) {
     Type* field_type = record_type->getRecord().at(field);
     if (field_type->isInput()) { continue; }
@@ -920,7 +975,8 @@ void assign_module_outputs(
           entries,
           body,
           field,
-          _inline);
+          _inline,
+          non_input_port_map);
       if (concat->unpacked) {
         wireUnpackedDriver(body, std::move(concat), vAST::make_id(field));
       }
@@ -932,7 +988,10 @@ void assign_module_outputs(
     }
     else {
       std::unique_ptr<vAST::Expression> verilog_conn = convert_to_expression(
-        convert_to_verilog_connection(entries[0].source, _inline));
+        convert_to_verilog_connection(
+          entries[0].source,
+          _inline,
+          non_input_port_map));
       process_connection_debug_metadata(
         entries[0],
         verilog_conn->toString(),
@@ -959,7 +1018,8 @@ void assign_inouts(
   std::vector<std::variant<
     std::unique_ptr<vAST::StructuralStatement>,
     std::unique_ptr<vAST::Declaration>>>& body,
-  bool _inline) {
+  bool _inline,
+  std::map<std::string, std::string>& non_input_port_map) {
   for (auto connection : connections) {
     if (
       connection.first->getType()->isInOut() ||
@@ -978,8 +1038,9 @@ void assign_inouts(
       if (!order) { std::swap(target, value); }
       body.push_back(std::make_unique<vAST::ContinuousAssign>(
         convert_to_assign_target(
-          convert_to_verilog_connection(target, _inline)),
-        convert_to_expression(convert_to_verilog_connection(value, _inline))));
+          convert_to_verilog_connection(target, _inline, non_input_port_map)),
+        convert_to_expression(
+          convert_to_verilog_connection(value, _inline, non_input_port_map))));
     };
   };
 }
@@ -1004,14 +1065,29 @@ Passes::Verilog::compileModuleBody(
   bool disable_width_cast,
   std::set<std::string>& wires,
   std::set<std::string>& inlined_wires) {
+
+  std::set<std::string> instance_names;
+  std::map<std::string, std::string> non_input_port_map;
+
   std::map<std::string, Instance*> instances = definition->getInstances();
+
+  // initialize used ids with instance names
+  std::transform(
+    instances.begin(),
+    instances.end(),
+    std::inserter(instance_names, instance_names.end()),
+    [](auto pair) { return pair.first; });
 
   std::vector<std::unique_ptr<vAST::StructuralStatement>> inline_verilog_body;
 
   std::vector<std::variant<
     std::unique_ptr<vAST::StructuralStatement>,
     std::unique_ptr<vAST::Declaration>>>
-    body = this->declareConnections(instances, _inline);
+    body = this->declareConnections(
+      instances,
+      _inline,
+      instance_names,
+      non_input_port_map);
 
   std::vector<Connection> connections = definition->getSortedConnections();
 
@@ -1063,7 +1139,8 @@ Passes::Verilog::compileModuleBody(
         // connect wire
         verilog_connections->insert(
           field,
-          std::make_unique<vAST::Identifier>(wire_name));
+          std::make_unique<vAST::Identifier>(
+            getUniquifiedName(non_input_port_map, wire_name)));
         continue;
       }
 
@@ -1081,8 +1158,10 @@ Passes::Verilog::compileModuleBody(
             entries,
             body,
             instance_name + "." + field,
-            _inline);
+            _inline,
+            non_input_port_map);
         if (concat->unpacked && !is_inlined) {
+          wire_name = genFreshWireName(wire_name, instance_names);
           this->makeDecl(wire_name, field_type, body, false);
           wires.insert(wire_name);
           verilog_connections->insert(
@@ -1094,8 +1173,10 @@ Passes::Verilog::compileModuleBody(
         driver = std::move(concat);
       }
       else {
-        driver = convert_to_expression(
-          convert_to_verilog_connection(entries[0].source, _inline));
+        driver = convert_to_expression(convert_to_verilog_connection(
+          entries[0].source,
+          _inline,
+          non_input_port_map));
         process_connection_debug_metadata(
           entries[0],
           driver->toString(),
@@ -1132,6 +1213,7 @@ Passes::Verilog::compileModuleBody(
         }
         else {
           // otherwise it's a concat, so we emit an input wire for it
+          wire_name = genFreshWireName(wire_name, instance_names);
           this->makeDecl(wire_name, field_type, body, false);
           // prevent inlining of this wire into the module instance statement
           wires.insert(wire_name);
@@ -1274,8 +1356,13 @@ Passes::Verilog::compileModuleBody(
   // Wire the outputs of the module and inout connections
   // TODO: Make these object methods so we don't have to pass things aorund so
   // much (e.g. _inline flag)
-  assign_module_outputs(module_type, body, connection_map, _inline);
-  assign_inouts(connections, body, _inline);
+  assign_module_outputs(
+    module_type,
+    body,
+    connection_map,
+    _inline,
+    non_input_port_map);
+  assign_inouts(connections, body, _inline, non_input_port_map);
 
   for (auto&& it : inline_verilog_body) { body.push_back(std::move(it)); }
   return body;

--- a/src/passes/analysis/verilog.cpp
+++ b/src/passes/analysis/verilog.cpp
@@ -784,7 +784,7 @@ convert_to_verilog_connection(
     std::unique_ptr<vAST::Identifier>
       id = std::get<std::unique_ptr<vAST::Identifier>>(std::move(curr_node));
     id->value = getUniquifiedName(non_input_port_map, id->value);
-    return id;
+    return std::move(id);
   }
   if (std::holds_alternative<std::unique_ptr<vAST::Attribute>>(curr_node)) {
     return std::get<std::unique_ptr<vAST::Attribute>>(std::move(curr_node));

--- a/tests/binary/gold/flatten_slice.json
+++ b/tests/binary/gold/flatten_slice.json
@@ -20,7 +20,8 @@
           },
           "i0_in":{
             "genref":"mantle.wire",
-            "genargs":{"type":["CoreIRType",["Array",16,"BitIn"]]}
+            "genargs":{"type":["CoreIRType",["Array",16,"BitIn"]]},
+            "metadata":{"inline_verilog_wire":true}
           },
           "i1$n1":{
             "genref":"coreir.neg",
@@ -33,7 +34,8 @@
           },
           "i1_in":{
             "genref":"mantle.wire",
-            "genargs":{"type":["CoreIRType",["Array",16,"BitIn"]]}
+            "genargs":{"type":["CoreIRType",["Array",16,"BitIn"]]},
+            "metadata":{"inline_verilog_wire":true}
           }
         },
         "connections":[

--- a/tests/binary/gold/flatten_slice.json
+++ b/tests/binary/gold/flatten_slice.json
@@ -13,7 +13,7 @@
             "genref":"coreir.neg",
             "genargs":{"width":["Int",16]}
           },
-          "i0$self_in_wire":{
+          "i0$self_in":{
             "genref":"mantle.wire",
             "genargs":{"type":["CoreIRType",["Array",16,"Bit"]]},
             "metadata":{"inline_verilog_wire":true}
@@ -26,7 +26,7 @@
             "genref":"coreir.neg",
             "genargs":{"width":["Int",16]}
           },
-          "i1$self_in_wire":{
+          "i1$self_in":{
             "genref":"mantle.wire",
             "genargs":{"type":["CoreIRType",["Array",16,"Bit"]]},
             "metadata":{"inline_verilog_wire":true}
@@ -37,17 +37,17 @@
           }
         },
         "connections":[
-          ["i0$self_in_wire.out.0:10","i0$n1.in.0:10"],
-          ["i0$self_in_wire.out.10:16","i0$n1.in.10:16"],
+          ["i0$self_in.out.0:10","i0$n1.in.0:10"],
+          ["i0$self_in.out.10:16","i0$n1.in.10:16"],
           ["self.out0","i0$n1.out"],
-          ["i0_in.in","i0$self_in_wire.in"],
+          ["i0_in.in","i0$self_in.in"],
           ["self.in.3:16","i0_in.out.0:13"],
           ["self.in.1:3","i0_in.out.14:16"],
           ["self.in.0","i0_in.out.13"],
-          ["i1$self_in_wire.out.0:10","i1$n1.in.0:10"],
-          ["i1$self_in_wire.out.10:16","i1$n1.in.10:16"],
+          ["i1$self_in.out.0:10","i1$n1.in.0:10"],
+          ["i1$self_in.out.10:16","i1$n1.in.10:16"],
           ["self.out1","i1$n1.out"],
-          ["i1_in.in","i1$self_in_wire.in"],
+          ["i1_in.in","i1$self_in.in"],
           ["self.in.7:16","i1_in.out.0:9"],
           ["self.in.0:7","i1_in.out.9:16"]
         ]

--- a/tests/binary/gold/simple_mux.v
+++ b/tests/binary/gold/simple_mux.v
@@ -1,0 +1,20 @@
+module Mux2xArray3_Array2_OutBit (
+    input [1:0] I0 [2:0],
+    input [1:0] I1 [2:0],
+    input S,
+    output [1:0] O [2:0]
+);
+reg [5:0] coreir_commonlib_mux2x6_inst0_out_unq1;
+always @(*) begin
+if (S == 0) begin
+    coreir_commonlib_mux2x6_inst0_out_unq1 = {I0[2][1:0],I0[1][1:0],I0[0][1:0]};
+end else begin
+    coreir_commonlib_mux2x6_inst0_out_unq1 = {I1[2][1:0],I1[1][1:0],I1[0][1:0]};
+end
+end
+
+assign O[2] = coreir_commonlib_mux2x6_inst0_out_unq1[5:4];
+assign O[1] = coreir_commonlib_mux2x6_inst0_out_unq1[3:2];
+assign O[0] = coreir_commonlib_mux2x6_inst0_out_unq1[1:0];
+endmodule
+

--- a/tests/binary/src/name_clobber.json
+++ b/tests/binary/src/name_clobber.json
@@ -1,0 +1,40 @@
+{"top":"global.Bar",
+"namespaces":{
+  "global":{
+    "modules":{
+      "Bar":{
+        "type":["Record",[
+          ["I","BitIn"],
+          ["O","Bit"]
+        ]],
+        "instances":{
+          "Foo_inst0":{
+            "modref":"global.Foo"
+          },
+          "Foo_inst0_O":{
+            "modref":"corebit.wire"
+          },
+          "Foo_inst1":{
+            "modref":"global.Foo"
+          }
+        },
+        "connections":[
+          ["self.I","Foo_inst0.I"],
+          ["Foo_inst0_O.in","Foo_inst0.O"],
+          ["Foo_inst1.I","Foo_inst0_O.out"],
+          ["self.O","Foo_inst1.O"]
+        ]
+      },
+      "Foo":{
+        "type":["Record",[
+          ["I","BitIn"],
+          ["O","Bit"]
+        ]],
+        "connections":[
+          ["self.I","self.O"]
+        ]
+      }
+    }
+  }
+}
+}

--- a/tests/binary/src/simple_mux.json
+++ b/tests/binary/src/simple_mux.json
@@ -1,0 +1,34 @@
+{"top":"global.Mux2xArray3_Array2_OutBit",
+"namespaces":{
+  "global":{
+    "modules":{
+      "Mux2xArray3_Array2_OutBit":{
+        "type":["Record",[
+          ["I0",["Array",3,["Array",2,"BitIn"]]],
+          ["I1",["Array",3,["Array",2,"BitIn"]]],
+          ["S","BitIn"],
+          ["O",["Array",3,["Array",2,"Bit"]]]
+        ]],
+        "instances":{
+          "coreir_commonlib_mux2x6_inst0":{
+            "genref":"commonlib.muxn",
+            "genargs":{"N":["Int",2], "width":["Int",6]}
+          }
+        },
+        "connections":[
+          ["self.I0.0.0:2","coreir_commonlib_mux2x6_inst0.in.data.0.0:2"],
+          ["self.I0.1.0:2","coreir_commonlib_mux2x6_inst0.in.data.0.2:4"],
+          ["self.I0.2.0:2","coreir_commonlib_mux2x6_inst0.in.data.0.4:6"],
+          ["self.I1.0.0:2","coreir_commonlib_mux2x6_inst0.in.data.1.0:2"],
+          ["self.I1.1.0:2","coreir_commonlib_mux2x6_inst0.in.data.1.2:4"],
+          ["self.I1.2.0:2","coreir_commonlib_mux2x6_inst0.in.data.1.4:6"],
+          ["self.S","coreir_commonlib_mux2x6_inst0.in.sel.0"],
+          ["self.O.0.0:2","coreir_commonlib_mux2x6_inst0.out.0:2"],
+          ["self.O.1.0:2","coreir_commonlib_mux2x6_inst0.out.2:4"],
+          ["self.O.2.0:2","coreir_commonlib_mux2x6_inst0.out.4:6"]
+        ]
+      }
+    }
+  }
+}
+}

--- a/tests/binary/test_issues.py
+++ b/tests/binary/test_issues.py
@@ -13,3 +13,16 @@ def test_garnet_interconnect_name_clobber():
                         'tests/binary/stubs.v')
     assert not res.return_code, res.out + res.err
 
+
+def test_name_clobber():
+    # https://github.com/rdaly525/coreir/issues/954
+    res = delegator.run(
+        'coreir -i tests/binary/src/name_clobber.json'
+        '           -o tests/binary/build/out.v'
+        '           -l commonlib'
+    )
+    assert not res.return_code, res.out + res.err
+
+    res = delegator.run('verilator --lint-only tests/binary/build/out.v')
+    assert not res.return_code, res.out + res.err
+

--- a/tests/binary/test_issues.py
+++ b/tests/binary/test_issues.py
@@ -26,3 +26,15 @@ def test_name_clobber():
     res = delegator.run('verilator --lint-only tests/binary/build/out.v')
     assert not res.return_code, res.out + res.err
 
+
+def test_953():
+    res = delegator.run(
+        'coreir -i tests/binary/src/simple_mux.json'
+        '           -o tests/binary/build/out.v'
+        '           -l commonlib --inline'
+    )
+    assert not res.return_code, res.out + res.err
+
+    res = delegator.run('diff tests/binary/build/out.v  '
+                        '     tests/binary/gold/simple_mux.v')
+    assert not res.return_code, res.out + res.err

--- a/tests/gtest/golds/camera_pipeline_dse1.v
+++ b/tests/gtest/golds/camera_pipeline_dse1.v
@@ -88,8 +88,6 @@ module memory_rom2__depth255__width16 #(
     input ren
 );
 wire [15:0] mem_rdata;
-wire [7:0] raddr_slice_out;
-wire [7:0] waddr0_out;
 wire [15:0] wdata0_out;
 coreir_mem #(
     .init(init),
@@ -100,12 +98,11 @@ coreir_mem #(
 ) mem (
     .clk(clk),
     .wdata(wdata0_out),
-    .waddr(waddr0_out),
+    .waddr(8'h00),
     .wen(wdata0_out[0]),
     .rdata(mem_rdata),
-    .raddr(raddr_slice_out)
+    .raddr(raddr[8 - 1:0])
 );
-assign raddr_slice_out = raddr[8 - 1:0];
 mantle_reg__has_clrFalse__has_enTrue__has_rstFalse__width16 #(
     .init(16'h0000)
 ) readreg (
@@ -114,7 +111,6 @@ mantle_reg__has_clrFalse__has_enTrue__has_rstFalse__width16 #(
     .out(rdata),
     .en(ren)
 );
-assign waddr0_out = 8'h00;
 assign wdata0_out = 16'h0000;
 endmodule
 
@@ -139,30 +135,24 @@ module hcompute_hw_output_stencil (
     input [15:0] in0_f6_stencil_0,
     output [15:0] out_hw_output_stencil
 );
-wire [15:0] const0__1598_out;
-wire [15:0] const1023__1596_out;
-wire curve$1_ren_out;
 wire [15:0] smax_1597_1598_1599_out;
 wire [15:0] smin_f6_stencil_1_1596_1597_out;
-assign const0__1598_out = 16'h0000;
-assign const1023__1596_out = 16'h03ff;
 memory_rom2__depth255__width16 #(
     .init({16'd63,16'd63,16'd62,16'd62,16'd62,16'd62,16'd61,16'd61,16'd61,16'd61,16'd60,16'd60,16'd60,16'd60,16'd59,16'd59,16'd59,16'd59,16'd58,16'd58,16'd58,16'd58,16'd57,16'd57,16'd57,16'd57,16'd56,16'd56,16'd56,16'd56,16'd55,16'd55,16'd55,16'd55,16'd54,16'd54,16'd54,16'd54,16'd53,16'd53,16'd53,16'd53,16'd52,16'd52,16'd52,16'd52,16'd51,16'd51,16'd51,16'd51,16'd50,16'd50,16'd50,16'd50,16'd49,16'd49,16'd49,16'd49,16'd48,16'd48,16'd48,16'd48,16'd47,16'd47,16'd47,16'd47,16'd46,16'd46,16'd46,16'd46,16'd45,16'd45,16'd45,16'd45,16'd44,16'd44,16'd44,16'd44,16'd43,16'd43,16'd43,16'd43,16'd42,16'd42,16'd42,16'd42,16'd41,16'd41,16'd41,16'd41,16'd40,16'd40,16'd40,16'd40,16'd39,16'd39,16'd39,16'd39,16'd38,16'd38,16'd38,16'd38,16'd37,16'd37,16'd37,16'd37,16'd36,16'd36,16'd36,16'd36,16'd35,16'd35,16'd35,16'd35,16'd34,16'd34,16'd34,16'd34,16'd33,16'd33,16'd33,16'd33,16'd32,16'd32,16'd32,16'd32,16'd31,16'd31,16'd31,16'd31,16'd30,16'd30,16'd30,16'd30,16'd29,16'd29,16'd29,16'd29,16'd28,16'd28,16'd28,16'd28,16'd27,16'd27,16'd27,16'd27,16'd26,16'd26,16'd26,16'd26,16'd25,16'd25,16'd25,16'd25,16'd24,16'd24,16'd24,16'd24,16'd23,16'd23,16'd23,16'd23,16'd22,16'd22,16'd22,16'd22,16'd21,16'd21,16'd21,16'd21,16'd20,16'd20,16'd20,16'd20,16'd19,16'd19,16'd19,16'd19,16'd18,16'd18,16'd18,16'd18,16'd17,16'd17,16'd17,16'd17,16'd16,16'd16,16'd16,16'd16,16'd15,16'd15,16'd15,16'd15,16'd14,16'd14,16'd14,16'd14,16'd13,16'd13,16'd13,16'd13,16'd12,16'd12,16'd12,16'd12,16'd11,16'd11,16'd11,16'd11,16'd10,16'd10,16'd10,16'd10,16'd9,16'd9,16'd9,16'd9,16'd8,16'd8,16'd8,16'd8,16'd7,16'd7,16'd7,16'd7,16'd6,16'd6,16'd6,16'd6,16'd5,16'd5,16'd5,16'd5,16'd4,16'd4,16'd4,16'd4,16'd3,16'd3,16'd3,16'd3,16'd2,16'd2,16'd2,16'd2,16'd1,16'd1,16'd1,16'd1,16'd0,16'd0,16'd0,16'd0,16'd0})
 ) curve$1 (
     .clk(clk),
     .rdata(out_hw_output_stencil),
     .raddr(smax_1597_1598_1599_out),
-    .ren(curve$1_ren_out)
+    .ren(1'b1)
 );
-assign curve$1_ren_out = 1'b1;
 commonlib_smax__width16 smax_1597_1598_1599 (
     .in0(smin_f6_stencil_1_1596_1597_out),
-    .in1(const0__1598_out),
+    .in1(16'h0000),
     .out(smax_1597_1598_1599_out)
 );
 commonlib_smin__width16 smin_f6_stencil_1_1596_1597 (
     .in0(in0_f6_stencil_0),
-    .in1(const1023__1596_out),
+    .in1(16'h03ff),
     .out(smin_f6_stencil_1_1596_1597_out)
 );
 endmodule

--- a/tests/gtest/golds/rom.v
+++ b/tests/gtest/golds/rom.v
@@ -45,12 +45,6 @@ module Memory (
     output [4:0] RDATA,
     input CLK
 );
-wire bit_const_0_None_out;
-wire [1:0] const_0_2_out;
-wire [4:0] const_0_5_out;
-assign bit_const_0_None_out = 1'b0;
-assign const_0_2_out = 2'h0;
-assign const_0_5_out = 5'h00;
 coreir_mem #(
     .init({5'd11,5'd21,5'd0,5'd5}),
     .depth(4),
@@ -59,9 +53,9 @@ coreir_mem #(
     .width(5)
 ) coreir_mem4x5_inst0 (
     .clk(CLK),
-    .wdata(const_0_5_out),
-    .waddr(const_0_2_out),
-    .wen(bit_const_0_None_out),
+    .wdata(5'h00),
+    .waddr(2'h0),
+    .wen(1'b0),
     .rdata(RDATA),
     .raddr(RADDR)
 );

--- a/tests/gtest/port_order_golden.v
+++ b/tests/gtest/port_order_golden.v
@@ -12,15 +12,13 @@ module Sub8 (
     input [7:0] x,
     output [7:0] a
 );
-wire bit_const_1_None_out;
 wire [7:0] inst0_out;
-assign bit_const_1_None_out = 1'b1;
 assign inst0_out = ~ x;
 Add8_cin inst1 (
     .z(z),
     .x(inst0_out),
     .a(a),
-    .CIN(bit_const_1_None_out)
+    .CIN(1'b1)
 );
 endmodule
 

--- a/tests/gtest/register_mode_golden.v
+++ b/tests/gtest/register_mode_golden.v
@@ -124,8 +124,6 @@ wire [3:0] Mux2xOutBits4_inst6_O;
 wire [3:0] Mux2xOutBits4_inst7_O;
 wire [3:0] Mux2xOutBits4_inst8_O;
 wire [3:0] Mux2xOutBits4_inst9_O;
-wire bit_const_0_None_out;
-wire bit_const_1_None_out;
 wire magma_Bit_not_inst0_out;
 wire magma_Bit_not_inst1_out;
 wire magma_Bit_not_inst2_out;
@@ -149,37 +147,37 @@ wire magma_Bits_2_eq_inst8_out;
 wire magma_Bits_2_eq_inst9_out;
 Mux2xOutBit Mux2xOutBit_inst0 (
     .I0(clk_en),
-    .I1(bit_const_0_None_out),
+    .I1(1'b0),
     .S(magma_Bits_2_eq_inst1_out),
     .O(Mux2xOutBit_inst0_O)
 );
 Mux2xOutBit Mux2xOutBit_inst1 (
     .I0(Mux2xOutBit_inst0_O),
-    .I1(bit_const_0_None_out),
+    .I1(1'b0),
     .S(magma_Bits_2_eq_inst4_out),
     .O(Mux2xOutBit_inst1_O)
 );
 Mux2xOutBit Mux2xOutBit_inst2 (
     .I0(Mux2xOutBit_inst1_O),
-    .I1(bit_const_1_None_out),
+    .I1(1'b1),
     .S(magma_Bit_not_inst1_out),
     .O(Mux2xOutBit_inst2_O)
 );
 Mux2xOutBit Mux2xOutBit_inst3 (
     .I0(clk_en),
-    .I1(bit_const_0_None_out),
+    .I1(1'b0),
     .S(magma_Bits_2_eq_inst7_out),
     .O(Mux2xOutBit_inst3_O)
 );
 Mux2xOutBit Mux2xOutBit_inst4 (
     .I0(Mux2xOutBit_inst3_O),
-    .I1(bit_const_0_None_out),
+    .I1(1'b0),
     .S(magma_Bits_2_eq_inst11_out),
     .O(Mux2xOutBit_inst4_O)
 );
 Mux2xOutBit Mux2xOutBit_inst5 (
     .I0(Mux2xOutBit_inst4_O),
-    .I1(bit_const_1_None_out),
+    .I1(1'b1),
     .S(magma_Bit_not_inst4_out),
     .O(O1)
 );
@@ -273,15 +271,13 @@ Mux2xOutBits4 Mux2xOutBits4_inst9 (
     .S(magma_Bits_2_eq_inst10_out),
     .O(Mux2xOutBits4_inst9_O)
 );
-assign bit_const_0_None_out = 1'b0;
-assign bit_const_1_None_out = 1'b1;
-assign magma_Bit_not_inst0_out = ~ (config_we ^ bit_const_1_None_out);
-assign magma_Bit_not_inst1_out = ~ (config_we ^ bit_const_1_None_out);
-assign magma_Bit_not_inst2_out = ~ (config_we ^ bit_const_1_None_out);
-assign magma_Bit_not_inst3_out = ~ (config_we ^ bit_const_1_None_out);
-assign magma_Bit_not_inst4_out = ~ (config_we ^ bit_const_1_None_out);
-assign magma_Bit_not_inst5_out = ~ (config_we ^ bit_const_1_None_out);
-assign magma_Bit_not_inst6_out = ~ (config_we ^ bit_const_1_None_out);
+assign magma_Bit_not_inst0_out = ~ (config_we ^ 1'b1);
+assign magma_Bit_not_inst1_out = ~ (config_we ^ 1'b1);
+assign magma_Bit_not_inst2_out = ~ (config_we ^ 1'b1);
+assign magma_Bit_not_inst3_out = ~ (config_we ^ 1'b1);
+assign magma_Bit_not_inst4_out = ~ (config_we ^ 1'b1);
+assign magma_Bit_not_inst5_out = ~ (config_we ^ 1'b1);
+assign magma_Bit_not_inst6_out = ~ (config_we ^ 1'b1);
 assign magma_Bits_2_eq_inst0_out = mode == 2'h1;
 assign magma_Bits_2_eq_inst1_out = mode == 2'h1;
 assign magma_Bits_2_eq_inst10_out = mode == 2'h0;

--- a/tests/gtest/two_ops_golden.v
+++ b/tests/gtest/two_ops_golden.v
@@ -12,15 +12,13 @@ module Sub8 (
     input [7:0] I1,
     output [7:0] O
 );
-wire bit_const_1_None_out;
 wire [7:0] inst0_out;
-assign bit_const_1_None_out = 1'b1;
 assign inst0_out = ~ I1;
 Add8_cin inst1 (
     .I0(I0),
     .I1(inst0_out),
     .O(O),
-    .CIN(bit_const_1_None_out)
+    .CIN(1'b1)
 );
 endmodule
 

--- a/tests/gtest/two_ops_golden_no_cast.v
+++ b/tests/gtest/two_ops_golden_no_cast.v
@@ -12,15 +12,13 @@ module Sub8 (
     input [7:0] I1,
     output [7:0] O
 );
-wire bit_const_1_None_out;
 wire [7:0] inst0_out;
-assign bit_const_1_None_out = 1'b1;
 assign inst0_out = ~ I1;
 Add8_cin inst1 (
     .I0(I0),
     .I1(inst0_out),
     .O(O),
-    .CIN(bit_const_1_None_out)
+    .CIN(1'b1)
 );
 endmodule
 


### PR DESCRIPTION
Fixes https://github.com/rdaly525/coreir/issues/954.
Also adds a more general solution for https://github.com/rdaly525/coreir/issues/935 (so we remove that code).

When declaring connections, we now check the instance names to see if
there's a conflict, if there is, we generate a unique name.  We then
insert an entry into a map from original instance port wire names to
uniquified names.  When code generating wire references, we lookup in
this map to see if a name has been uniquified.

While this generally works, the logic inside the selectpath -> verilog
reference is a bit complicated.  Basically, we build up an identifier
incrementally (instance name, then port name, or in another case just
instance name for wires).  Sometimes these are used inside index, slice,
or attribute nodes, so we have to check all these cases and only lookup
the mapping at the appropriate time (e.g. when we're creating an index,
we know the identifier that is being indexed should be mapped, but we
don't need to map nested index nodes).  This adds a bunch of cases
inside this conversion logic making the code complex.  I will see if I
can refactor the logic to tame the complexity, I think perhaps one
option is to build a "base" reference (identifier out of instance name +
port name, or instance name) and map that, then add the extra wrappers
(index, slice, attributes).  The one challenge is the ordering of the
wrappers being inconsistent (index/slices happen at the end of the
select path, attributes from hierarchical selects happen before the
final instance/port reference) so I'm not sure if we'll be able to avoid
the two different cases there.