### PR TITLE
Use improved verilogAST logic to manage inlining

### DIFF
--- a/CMakeLists.txt.in
+++ b/CMakeLists.txt.in
@@ -7,7 +7,7 @@ project(verilogAST-download NONE)
 include(ExternalProject)
 ExternalProject_Add(verilogAST
   GIT_REPOSITORY    https://github.com/leonardt/verilogAST-cpp.git
-  GIT_TAG           03bf80c
+  GIT_TAG           20f0aff
   SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/verilogAST-src"
   BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/verilogAST-build"
   CONFIGURE_COMMAND ""

--- a/src/ir/inline.cpp
+++ b/src/ir/inline.cpp
@@ -119,11 +119,7 @@ void PTTraverse(ModuleDef* def, Wireable* from, Wireable* to) {
         makeUniqueInstanceName(def, from),
         c->getGenerator("mantle.wire"),
         {{"type", Const::make(c, from->getType())}});
-      if (
-        !(isa<Instance>(from->getTopParent()) && from->getType()->isInput()) ||
-        from->getSelects().size() == 1) {
-        wire->getMetaData()["inline_verilog_wire"] = true;
-      }
+      wire->getMetaData()["inline_verilog_wire"] = true;
       def->connect(to, wire->sel("in"));
       wire->getModuleRef()->runGenerator();
       to = wire->sel("out");

--- a/src/passes/analysis/verilog.cpp
+++ b/src/passes/analysis/verilog.cpp
@@ -294,7 +294,6 @@ Passes::Verilog::declareConnections(
                      ->getRecord()
                      .at("in");
       this->makeDecl(instance.first, type, declarations, false);
-      non_input_port_map[instance.first] = instance.first;
       continue;
     }
     RecordType* record_type = cast<RecordType>(
@@ -1203,20 +1202,13 @@ Passes::Verilog::compileModuleBody(
         if (
           (driver_id || driver_index || driver_slice) &&
           std::holds_alternative<std::unique_ptr<vAST::Identifier>>(target)) {
-          // If it's not a concat, we connect it directly and prevent it from
-          // being inlined
-          //
-          // slices/indices are blacklisted automatically, but identifiers need
-          // to be marked
-          if (driver_id) { wires.insert(driver_id->value); }
+          // If it's not a concat, we connect it directly
           verilog_connections->insert(field, std::move(driver));
         }
         else {
           // otherwise it's a concat, so we emit an input wire for it
           wire_name = genFreshWireName(wire_name, instance_names);
           this->makeDecl(wire_name, field_type, body, false);
-          // prevent inlining of this wire into the module instance statement
-          wires.insert(wire_name);
           verilog_connections->insert(
             field,
             std::make_unique<vAST::Identifier>(wire_name));

--- a/tests/binary/gold/flatten_slice.json
+++ b/tests/binary/gold/flatten_slice.json
@@ -20,7 +20,8 @@
           },
           "i0_in":{
             "genref":"mantle.wire",
-            "genargs":{"type":["CoreIRType",["Array",16,"BitIn"]]}
+            "genargs":{"type":["CoreIRType",["Array",16,"BitIn"]]},
+            "metadata":{"inline_verilog_wire":true}
           },
           "i1$n1":{
             "genref":"coreir.neg",
@@ -33,7 +34,8 @@
           },
           "i1_in":{
             "genref":"mantle.wire",
-            "genargs":{"type":["CoreIRType",["Array",16,"BitIn"]]}
+            "genargs":{"type":["CoreIRType",["Array",16,"BitIn"]]},
+            "metadata":{"inline_verilog_wire":true}
           }
         },
         "connections":[

--- a/tests/binary/gold/simple_mux.v
+++ b/tests/binary/gold/simple_mux.v
@@ -1,0 +1,20 @@
+module Mux2xArray3_Array2_OutBit (
+    input [1:0] I0 [2:0],
+    input [1:0] I1 [2:0],
+    input S,
+    output [1:0] O [2:0]
+);
+reg [5:0] coreir_commonlib_mux2x6_inst0_out_unq1;
+always @(*) begin
+if (S == 0) begin
+    coreir_commonlib_mux2x6_inst0_out_unq1 = {I0[2][1:0],I0[1][1:0],I0[0][1:0]};
+end else begin
+    coreir_commonlib_mux2x6_inst0_out_unq1 = {I1[2][1:0],I1[1][1:0],I1[0][1:0]};
+end
+end
+
+assign O[2] = coreir_commonlib_mux2x6_inst0_out_unq1[5:4];
+assign O[1] = coreir_commonlib_mux2x6_inst0_out_unq1[3:2];
+assign O[0] = coreir_commonlib_mux2x6_inst0_out_unq1[1:0];
+endmodule
+

--- a/tests/binary/src/simple_mux.json
+++ b/tests/binary/src/simple_mux.json
@@ -1,0 +1,34 @@
+{"top":"global.Mux2xArray3_Array2_OutBit",
+"namespaces":{
+  "global":{
+    "modules":{
+      "Mux2xArray3_Array2_OutBit":{
+        "type":["Record",[
+          ["I0",["Array",3,["Array",2,"BitIn"]]],
+          ["I1",["Array",3,["Array",2,"BitIn"]]],
+          ["S","BitIn"],
+          ["O",["Array",3,["Array",2,"Bit"]]]
+        ]],
+        "instances":{
+          "coreir_commonlib_mux2x6_inst0":{
+            "genref":"commonlib.muxn",
+            "genargs":{"N":["Int",2], "width":["Int",6]}
+          }
+        },
+        "connections":[
+          ["self.I0.0.0:2","coreir_commonlib_mux2x6_inst0.in.data.0.0:2"],
+          ["self.I0.1.0:2","coreir_commonlib_mux2x6_inst0.in.data.0.2:4"],
+          ["self.I0.2.0:2","coreir_commonlib_mux2x6_inst0.in.data.0.4:6"],
+          ["self.I1.0.0:2","coreir_commonlib_mux2x6_inst0.in.data.1.0:2"],
+          ["self.I1.1.0:2","coreir_commonlib_mux2x6_inst0.in.data.1.2:4"],
+          ["self.I1.2.0:2","coreir_commonlib_mux2x6_inst0.in.data.1.4:6"],
+          ["self.S","coreir_commonlib_mux2x6_inst0.in.sel.0"],
+          ["self.O.0.0:2","coreir_commonlib_mux2x6_inst0.out.0:2"],
+          ["self.O.1.0:2","coreir_commonlib_mux2x6_inst0.out.2:4"],
+          ["self.O.2.0:2","coreir_commonlib_mux2x6_inst0.out.4:6"]
+        ]
+      }
+    }
+  }
+}
+}

--- a/tests/binary/test_issues.py
+++ b/tests/binary/test_issues.py
@@ -26,3 +26,15 @@ def test_name_clobber():
     res = delegator.run('verilator --lint-only tests/binary/build/out.v')
     assert not res.return_code, res.out + res.err
 
+
+def test_953():
+    res = delegator.run(
+        'coreir -i tests/binary/src/simple_mux.json'
+        '           -o tests/binary/build/out.v'
+        '           -l commonlib --inline'
+    )
+    assert not res.return_code, res.out + res.err
+
+    res = delegator.run('diff tests/binary/build/out.v  '
+                        '     tests/binary/gold/simple_mux.v')
+    assert not res.return_code, res.out + res.err

--- a/tests/gtest/golds/camera_pipeline_dse1.v
+++ b/tests/gtest/golds/camera_pipeline_dse1.v
@@ -88,8 +88,6 @@ module memory_rom2__depth255__width16 #(
     input ren
 );
 wire [15:0] mem_rdata;
-wire [7:0] raddr_slice_out;
-wire [7:0] waddr0_out;
 wire [15:0] wdata0_out;
 coreir_mem #(
     .init(init),
@@ -100,12 +98,11 @@ coreir_mem #(
 ) mem (
     .clk(clk),
     .wdata(wdata0_out),
-    .waddr(waddr0_out),
+    .waddr(8'h00),
     .wen(wdata0_out[0]),
     .rdata(mem_rdata),
-    .raddr(raddr_slice_out)
+    .raddr(raddr[8 - 1:0])
 );
-assign raddr_slice_out = raddr[8 - 1:0];
 mantle_reg__has_clrFalse__has_enTrue__has_rstFalse__width16 #(
     .init(16'h0000)
 ) readreg (
@@ -114,7 +111,6 @@ mantle_reg__has_clrFalse__has_enTrue__has_rstFalse__width16 #(
     .out(rdata),
     .en(ren)
 );
-assign waddr0_out = 8'h00;
 assign wdata0_out = 16'h0000;
 endmodule
 
@@ -139,30 +135,24 @@ module hcompute_hw_output_stencil (
     input [15:0] in0_f6_stencil_0,
     output [15:0] out_hw_output_stencil
 );
-wire [15:0] const0__1598_out;
-wire [15:0] const1023__1596_out;
-wire curve$1_ren_out;
 wire [15:0] smax_1597_1598_1599_out;
 wire [15:0] smin_f6_stencil_1_1596_1597_out;
-assign const0__1598_out = 16'h0000;
-assign const1023__1596_out = 16'h03ff;
 memory_rom2__depth255__width16 #(
     .init({16'd63,16'd63,16'd62,16'd62,16'd62,16'd62,16'd61,16'd61,16'd61,16'd61,16'd60,16'd60,16'd60,16'd60,16'd59,16'd59,16'd59,16'd59,16'd58,16'd58,16'd58,16'd58,16'd57,16'd57,16'd57,16'd57,16'd56,16'd56,16'd56,16'd56,16'd55,16'd55,16'd55,16'd55,16'd54,16'd54,16'd54,16'd54,16'd53,16'd53,16'd53,16'd53,16'd52,16'd52,16'd52,16'd52,16'd51,16'd51,16'd51,16'd51,16'd50,16'd50,16'd50,16'd50,16'd49,16'd49,16'd49,16'd49,16'd48,16'd48,16'd48,16'd48,16'd47,16'd47,16'd47,16'd47,16'd46,16'd46,16'd46,16'd46,16'd45,16'd45,16'd45,16'd45,16'd44,16'd44,16'd44,16'd44,16'd43,16'd43,16'd43,16'd43,16'd42,16'd42,16'd42,16'd42,16'd41,16'd41,16'd41,16'd41,16'd40,16'd40,16'd40,16'd40,16'd39,16'd39,16'd39,16'd39,16'd38,16'd38,16'd38,16'd38,16'd37,16'd37,16'd37,16'd37,16'd36,16'd36,16'd36,16'd36,16'd35,16'd35,16'd35,16'd35,16'd34,16'd34,16'd34,16'd34,16'd33,16'd33,16'd33,16'd33,16'd32,16'd32,16'd32,16'd32,16'd31,16'd31,16'd31,16'd31,16'd30,16'd30,16'd30,16'd30,16'd29,16'd29,16'd29,16'd29,16'd28,16'd28,16'd28,16'd28,16'd27,16'd27,16'd27,16'd27,16'd26,16'd26,16'd26,16'd26,16'd25,16'd25,16'd25,16'd25,16'd24,16'd24,16'd24,16'd24,16'd23,16'd23,16'd23,16'd23,16'd22,16'd22,16'd22,16'd22,16'd21,16'd21,16'd21,16'd21,16'd20,16'd20,16'd20,16'd20,16'd19,16'd19,16'd19,16'd19,16'd18,16'd18,16'd18,16'd18,16'd17,16'd17,16'd17,16'd17,16'd16,16'd16,16'd16,16'd16,16'd15,16'd15,16'd15,16'd15,16'd14,16'd14,16'd14,16'd14,16'd13,16'd13,16'd13,16'd13,16'd12,16'd12,16'd12,16'd12,16'd11,16'd11,16'd11,16'd11,16'd10,16'd10,16'd10,16'd10,16'd9,16'd9,16'd9,16'd9,16'd8,16'd8,16'd8,16'd8,16'd7,16'd7,16'd7,16'd7,16'd6,16'd6,16'd6,16'd6,16'd5,16'd5,16'd5,16'd5,16'd4,16'd4,16'd4,16'd4,16'd3,16'd3,16'd3,16'd3,16'd2,16'd2,16'd2,16'd2,16'd1,16'd1,16'd1,16'd1,16'd0,16'd0,16'd0,16'd0,16'd0})
 ) curve$1 (
     .clk(clk),
     .rdata(out_hw_output_stencil),
     .raddr(smax_1597_1598_1599_out),
-    .ren(curve$1_ren_out)
+    .ren(1'b1)
 );
-assign curve$1_ren_out = 1'b1;
 commonlib_smax__width16 smax_1597_1598_1599 (
     .in0(smin_f6_stencil_1_1596_1597_out),
-    .in1(const0__1598_out),
+    .in1(16'h0000),
     .out(smax_1597_1598_1599_out)
 );
 commonlib_smin__width16 smin_f6_stencil_1_1596_1597 (
     .in0(in0_f6_stencil_0),
-    .in1(const1023__1596_out),
+    .in1(16'h03ff),
     .out(smin_f6_stencil_1_1596_1597_out)
 );
 endmodule

--- a/tests/gtest/golds/rom.v
+++ b/tests/gtest/golds/rom.v
@@ -45,12 +45,6 @@ module Memory (
     output [4:0] RDATA,
     input CLK
 );
-wire bit_const_0_None_out;
-wire [1:0] const_0_2_out;
-wire [4:0] const_0_5_out;
-assign bit_const_0_None_out = 1'b0;
-assign const_0_2_out = 2'h0;
-assign const_0_5_out = 5'h00;
 coreir_mem #(
     .init({5'd11,5'd21,5'd0,5'd5}),
     .depth(4),
@@ -59,9 +53,9 @@ coreir_mem #(
     .width(5)
 ) coreir_mem4x5_inst0 (
     .clk(CLK),
-    .wdata(const_0_5_out),
-    .waddr(const_0_2_out),
-    .wen(bit_const_0_None_out),
+    .wdata(5'h00),
+    .waddr(2'h0),
+    .wen(1'b0),
     .rdata(RDATA),
     .raddr(RADDR)
 );

--- a/tests/gtest/port_order_golden.v
+++ b/tests/gtest/port_order_golden.v
@@ -12,15 +12,13 @@ module Sub8 (
     input [7:0] x,
     output [7:0] a
 );
-wire bit_const_1_None_out;
 wire [7:0] inst0_out;
-assign bit_const_1_None_out = 1'b1;
 assign inst0_out = ~ x;
 Add8_cin inst1 (
     .z(z),
     .x(inst0_out),
     .a(a),
-    .CIN(bit_const_1_None_out)
+    .CIN(1'b1)
 );
 endmodule
 

--- a/tests/gtest/register_mode_golden.v
+++ b/tests/gtest/register_mode_golden.v
@@ -124,8 +124,6 @@ wire [3:0] Mux2xOutBits4_inst6_O;
 wire [3:0] Mux2xOutBits4_inst7_O;
 wire [3:0] Mux2xOutBits4_inst8_O;
 wire [3:0] Mux2xOutBits4_inst9_O;
-wire bit_const_0_None_out;
-wire bit_const_1_None_out;
 wire magma_Bit_not_inst0_out;
 wire magma_Bit_not_inst1_out;
 wire magma_Bit_not_inst2_out;
@@ -149,37 +147,37 @@ wire magma_Bits_2_eq_inst8_out;
 wire magma_Bits_2_eq_inst9_out;
 Mux2xOutBit Mux2xOutBit_inst0 (
     .I0(clk_en),
-    .I1(bit_const_0_None_out),
+    .I1(1'b0),
     .S(magma_Bits_2_eq_inst1_out),
     .O(Mux2xOutBit_inst0_O)
 );
 Mux2xOutBit Mux2xOutBit_inst1 (
     .I0(Mux2xOutBit_inst0_O),
-    .I1(bit_const_0_None_out),
+    .I1(1'b0),
     .S(magma_Bits_2_eq_inst4_out),
     .O(Mux2xOutBit_inst1_O)
 );
 Mux2xOutBit Mux2xOutBit_inst2 (
     .I0(Mux2xOutBit_inst1_O),
-    .I1(bit_const_1_None_out),
+    .I1(1'b1),
     .S(magma_Bit_not_inst1_out),
     .O(Mux2xOutBit_inst2_O)
 );
 Mux2xOutBit Mux2xOutBit_inst3 (
     .I0(clk_en),
-    .I1(bit_const_0_None_out),
+    .I1(1'b0),
     .S(magma_Bits_2_eq_inst7_out),
     .O(Mux2xOutBit_inst3_O)
 );
 Mux2xOutBit Mux2xOutBit_inst4 (
     .I0(Mux2xOutBit_inst3_O),
-    .I1(bit_const_0_None_out),
+    .I1(1'b0),
     .S(magma_Bits_2_eq_inst11_out),
     .O(Mux2xOutBit_inst4_O)
 );
 Mux2xOutBit Mux2xOutBit_inst5 (
     .I0(Mux2xOutBit_inst4_O),
-    .I1(bit_const_1_None_out),
+    .I1(1'b1),
     .S(magma_Bit_not_inst4_out),
     .O(O1)
 );
@@ -273,15 +271,13 @@ Mux2xOutBits4 Mux2xOutBits4_inst9 (
     .S(magma_Bits_2_eq_inst10_out),
     .O(Mux2xOutBits4_inst9_O)
 );
-assign bit_const_0_None_out = 1'b0;
-assign bit_const_1_None_out = 1'b1;
-assign magma_Bit_not_inst0_out = ~ (config_we ^ bit_const_1_None_out);
-assign magma_Bit_not_inst1_out = ~ (config_we ^ bit_const_1_None_out);
-assign magma_Bit_not_inst2_out = ~ (config_we ^ bit_const_1_None_out);
-assign magma_Bit_not_inst3_out = ~ (config_we ^ bit_const_1_None_out);
-assign magma_Bit_not_inst4_out = ~ (config_we ^ bit_const_1_None_out);
-assign magma_Bit_not_inst5_out = ~ (config_we ^ bit_const_1_None_out);
-assign magma_Bit_not_inst6_out = ~ (config_we ^ bit_const_1_None_out);
+assign magma_Bit_not_inst0_out = ~ (config_we ^ 1'b1);
+assign magma_Bit_not_inst1_out = ~ (config_we ^ 1'b1);
+assign magma_Bit_not_inst2_out = ~ (config_we ^ 1'b1);
+assign magma_Bit_not_inst3_out = ~ (config_we ^ 1'b1);
+assign magma_Bit_not_inst4_out = ~ (config_we ^ 1'b1);
+assign magma_Bit_not_inst5_out = ~ (config_we ^ 1'b1);
+assign magma_Bit_not_inst6_out = ~ (config_we ^ 1'b1);
 assign magma_Bits_2_eq_inst0_out = mode == 2'h1;
 assign magma_Bits_2_eq_inst1_out = mode == 2'h1;
 assign magma_Bits_2_eq_inst10_out = mode == 2'h0;

--- a/tests/gtest/two_ops_golden.v
+++ b/tests/gtest/two_ops_golden.v
@@ -12,15 +12,13 @@ module Sub8 (
     input [7:0] I1,
     output [7:0] O
 );
-wire bit_const_1_None_out;
 wire [7:0] inst0_out;
-assign bit_const_1_None_out = 1'b1;
 assign inst0_out = ~ I1;
 Add8_cin inst1 (
     .I0(I0),
     .I1(inst0_out),
     .O(O),
-    .CIN(bit_const_1_None_out)
+    .CIN(1'b1)
 );
 endmodule
 

--- a/tests/gtest/two_ops_golden_no_cast.v
+++ b/tests/gtest/two_ops_golden_no_cast.v
@@ -12,15 +12,13 @@ module Sub8 (
     input [7:0] I1,
     output [7:0] O
 );
-wire bit_const_1_None_out;
 wire [7:0] inst0_out;
-assign bit_const_1_None_out = 1'b1;
 assign inst0_out = ~ I1;
 Add8_cin inst1 (
     .I0(I0),
     .I1(inst0_out),
     .O(O),
-    .CIN(bit_const_1_None_out)
+    .CIN(1'b1)
 );
 endmodule
 


### PR DESCRIPTION
verilogAST has been improved to handle preventing non-basic expressions
(things that are not ids, index, slice, numbers) from being inlined into
module instance statements.  This allows us to simplify the logic in
CoreIR and avoid the regression in
https://github.com/rdaly525/coreir/issues/953

Fixes https://github.com/rdaly525/coreir/issues/953

Pulling into https://github.com/rdaly525/coreir/pull/955 to avoid merge conflicts since they touch the same portions of the code base.