### PR TITLE
Add verilator compatability mode for verilog code generation

### DIFF
--- a/include/coreir/passes/analysis/verilog.h
+++ b/include/coreir/passes/analysis/verilog.h
@@ -13,6 +13,11 @@ namespace Passes {
 
 class Verilog : public InstanceGraphPass {
   bool _inline = false;
+
+  // Setting this to true will emit `/*verilator lint_off UNUSED */` around
+  // certain primitives to avoid verilator lint errors
+  bool verilator_compat = false;
+
   bool verilator_debug = false;
   bool disable_width_cast = false;
 

--- a/src/binary/coreir.cpp
+++ b/src/binary/coreir.cpp
@@ -54,7 +54,9 @@ int main(int argc, char* argv[]) {
     "z,inline",
     "inlines verilog primitives")(
     "y,verilator_debug",
-    "mark signals with /*veriltor public*/")(
+    "mark signals with /*verilator public*/")(
+    "u,verilator_compat",
+    "Emit verilog primitives with verilator compatibility")(
     "w,disable-width-cast",
     "disable verilog code generation of width casting when inlining")(
     "x,disable-ndarray",
@@ -221,6 +223,7 @@ int main(int argc, char* argv[]) {
     if (opts.count("z")) { vstr += " -i"; }
     if (opts.count("y")) { vstr += " -y"; }
     if (opts.count("w")) { vstr += " -w"; }
+    if (opts.count("u")) { vstr += " -v"; }
     std::string flattentypes_str = "flattentypes";
     if (!opts.count("x")) { flattentypes_str += " --ndarray"; }
     modified |= c->runPasses(

--- a/src/passes/analysis/verilog.cpp
+++ b/src/passes/analysis/verilog.cpp
@@ -336,8 +336,9 @@ std::unique_ptr<vAST::AbstractModule> Passes::Verilog::compileStringBodyModule(
       port_str += "/*verilator public*/";
     }
     if (
-      name == "coreir_term" || name == "coreir_slice" ||
-      name == "corebit_term") {
+      this->verilator_compat &&
+      (name == "coreir_term" || name == "coreir_slice" ||
+       name == "corebit_term")) {
       port_str = "/*verilator lint_off UNUSED */" + port_str +
         "/*verilator lint_on UNUSED */";
     }

--- a/src/passes/analysis/verilog.cpp
+++ b/src/passes/analysis/verilog.cpp
@@ -81,11 +81,14 @@ void Passes::Verilog::initialize(int argc, char** argv) {
     "y,verilator_debug",
     "Mark IO and intermediate wires as /*verilator_public*/")(
     "w,disable-width-cast",
-    "Omit width cast in generated verilog when using inline");
+    "Omit width cast in generated verilog when using inline")(
+    "v,verilator-compat",
+    "Emit primitives with verilator compatibility");
   auto opts = options.parse(argc, argv);
   if (opts.count("i")) { this->_inline = true; }
   if (opts.count("y")) { this->verilator_debug = true; }
   if (opts.count("w")) { this->disable_width_cast = true; }
+  if (opts.count("v")) { this->verilator_compat = true; }
 }
 
 // Helper function that prepends a prefix contained in json metadata if it
@@ -331,6 +334,12 @@ std::unique_ptr<vAST::AbstractModule> Passes::Verilog::compileStringBodyModule(
       // FIXME: Hack to get comment into port name, we need to design a way
       // to attach comments to expressions
       port_str += "/*verilator public*/";
+    }
+    if (
+      name == "coreir_term" || name == "coreir_slice" ||
+      name == "corebit_term") {
+      port_str = "/*verilator lint_off UNUSED */" + port_str +
+        "/*verilator lint_on UNUSED */";
     }
     ports.push_back(std::make_unique<vAST::StringPort>(port_str));
   }

--- a/tests/binary/src/verilator_compat.json
+++ b/tests/binary/src/verilator_compat.json
@@ -1,0 +1,36 @@
+{
+  "top": "global.verilator_compat",
+  "namespaces": {
+    "global": {
+      "modules": {
+        "verilator_compat": {
+          "type": ["Record",[
+            ["in", ["Array",16,"BitIn"]],
+            ["out", ["Array",4,"Bit"]]
+          ]],
+          "instances": {
+            "s": {
+              "genref": "coreir.slice",
+              "genargs": {"width":["Int", 16], "hi":["Int",16], "lo":["Int",12]}
+            },
+            "term": {
+              "genref": "coreir.term",
+              "genargs": {"width":["Int", 4]}
+            },
+            "bit_term": {
+              "modref": "corebit.term"
+            }
+          },
+          "connections": [
+            ["self.in","s.in"],
+            ["s.out","self.out"],
+            ["self.in.0","bit_term.in"],
+            ["self.in.0:4","term.in"]
+          ]
+        }
+      }
+    }
+  }
+}
+
+

--- a/tests/binary/test_issues.py
+++ b/tests/binary/test_issues.py
@@ -1,6 +1,19 @@
 import delegator
 
 
+def test_verilator_unused():
+    res = delegator.run(
+        'coreir -i tests/binary/src/verilator_compat.json'
+        '           -o tests/binary/build/out.v'
+        '           -l commonlib --verilator_compat'
+    )
+    print(res.out, res.err)
+    assert not res.return_code, res.out + res.err
+
+    res = delegator.run('verilator --lint-only -Wall -Wno-DECLFILENAME tests/binary/build/out.v')
+    assert not res.return_code, res.out + res.err
+
+
 def test_garnet_interconnect_name_clobber():
     res = delegator.run(
         'coreir -i tests/binary/src/Interconnect.json'


### PR DESCRIPTION
Improved version of https://github.com/rdaly525/coreir/pull/691

Adds a flag to enable verilator compatibility in verilog code
generation.  Currently this will just wrap certain primitives known to
trigger verilator UNUSED warnings/errors with a lint_on/lint_off
comment.  This allows users to avoid having to use a catch all
-Wno-UNUSED flag since this could silence warnings from other parts of
the code.