### PR TITLE
Add SyncReadMemory primitive

### DIFF
--- a/include/coreir/definitions/coreVerilog.hpp
+++ b/include/coreir/definitions/coreVerilog.hpp
@@ -777,6 +777,7 @@ void CoreIRLoadVerilog_coreir(Context* c) {
       "    if (ren) rdata_reg <= data[raddr];\n"
       "  end\n"
       "  assign rdata = rdata_reg;\n";
-    core->getGenerator("sync_read_mem")->getMetaData()["verilog"] = vjson;
+    Namespace* memory = c->getNamespace("memory");
+    memory->getGenerator("sync_read_mem")->getMetaData()["verilog"] = vjson;
   }
 }

--- a/include/coreir/definitions/coreVerilog.hpp
+++ b/include/coreir/definitions/coreVerilog.hpp
@@ -531,6 +531,18 @@ void CoreIRLoadVerilog_coreir(Context* c) {
         "input [$clog2(depth)-1:0] raddr",
       },
     },
+    {
+      "sync_read_mem",
+      {
+        "input clk",
+        "input [width-1:0] wdata",
+        "input [$clog2(depth)-1:0] waddr",
+        "input wen",
+        "output [width-1:0] rdata",
+        "input [$clog2(depth)-1:0] raddr",
+        "input ren"
+      },
+    },
   };
 
   Namespace* core = c->getNamespace("coreir");
@@ -704,5 +716,67 @@ void CoreIRLoadVerilog_coreir(Context* c) {
       "  end\n"
       "  endgenerate\n";
     core->getGenerator("mem")->getMetaData()["verilog"] = vjson;
+  }
+  {
+    // sync_read_mem
+    json vjson;
+    vjson["prefix"] = "coreir_";
+    vjson["interface"] = coreIMap["sync_read_mem"];
+    vjson["parameters"] = {"has_init"};
+    vjson["definition"] =
+      ""
+      "  reg [width-1:0] data [depth-1:0];\n"
+      ""
+      // verilator doesn't support 2d array parameter, so we pack it into a 1d
+      // array
+      "  generate if (has_init) begin\n"
+      "    genvar j;\n"
+      "    for (j = 0; j < depth; j = j + 1) begin\n"
+      "      initial begin\n"
+      "        data[j] = init[(j+1)*width-1:j*width];\n"
+      "      end\n"
+      "    end\n"
+      "  end\n"
+      "  endgenerate\n"
+      ""
+      "  always @(posedge clk) begin\n"
+      "    if (wen) begin\n"
+      "      data[waddr] <= wdata;\n"
+      "    end\n"
+      "  end\n"
+      ""
+      "  reg [width-1:0] rdata_reg;\n"
+      "  always @(posedge clk) begin\n"
+      "    if (ren) rdata_reg <= data[raddr];\n"
+      "  end\n"
+      "  assign rdata = rdata_reg;\n";
+    vjson["verilator_debug_definition"] =
+      ""
+      "  reg [width-1:0] data [depth-1:0];/*verilator public*/;\n"
+      ""
+      // verilator doesn't support 2d array parameter, so we pack it into a 1d
+      // array
+      "  generate if (has_init) begin\n"
+      "    genvar j;\n"
+      "    for (j = 0; j < depth; j = j + 1) begin\n"
+      "      initial begin\n"
+      "        data[j] = init[(j+1)*width-1:j*width];\n"
+      "      end\n"
+      "    end\n"
+      "  end\n"
+      "  endgenerate\n"
+      ""
+      "  always @(posedge clk) begin\n"
+      "    if (wen) begin\n"
+      "      data[waddr] <= wdata;\n"
+      "    end\n"
+      "  end\n"
+      ""
+      "  reg [width-1:0] rdata_reg;\n"
+      "  always @(posedge clk) begin\n"
+      "    if (ren) rdata_reg <= data[raddr];\n"
+      "  end\n"
+      "  assign rdata = rdata_reg;\n";
+    core->getGenerator("sync_read_mem")->getMetaData()["verilog"] = vjson;
   }
 }

--- a/include/coreir/definitions/coreVerilog.hpp
+++ b/include/coreir/definitions/coreVerilog.hpp
@@ -531,18 +531,6 @@ void CoreIRLoadVerilog_coreir(Context* c) {
         "input [$clog2(depth)-1:0] raddr",
       },
     },
-    {
-      "sync_read_mem",
-      {
-        "input clk",
-        "input [width-1:0] wdata",
-        "input [$clog2(depth)-1:0] waddr",
-        "input wen",
-        "output [width-1:0] rdata",
-        "input [$clog2(depth)-1:0] raddr",
-        "input ren"
-      },
-    },
   };
 
   Namespace* core = c->getNamespace("coreir");
@@ -716,68 +704,5 @@ void CoreIRLoadVerilog_coreir(Context* c) {
       "  end\n"
       "  endgenerate\n";
     core->getGenerator("mem")->getMetaData()["verilog"] = vjson;
-  }
-  {
-    // sync_read_mem
-    json vjson;
-    vjson["prefix"] = "coreir_";
-    vjson["interface"] = coreIMap["sync_read_mem"];
-    vjson["parameters"] = {"has_init"};
-    vjson["definition"] =
-      ""
-      "  reg [width-1:0] data [depth-1:0];\n"
-      ""
-      // verilator doesn't support 2d array parameter, so we pack it into a 1d
-      // array
-      "  generate if (has_init) begin\n"
-      "    genvar j;\n"
-      "    for (j = 0; j < depth; j = j + 1) begin\n"
-      "      initial begin\n"
-      "        data[j] = init[(j+1)*width-1:j*width];\n"
-      "      end\n"
-      "    end\n"
-      "  end\n"
-      "  endgenerate\n"
-      ""
-      "  always @(posedge clk) begin\n"
-      "    if (wen) begin\n"
-      "      data[waddr] <= wdata;\n"
-      "    end\n"
-      "  end\n"
-      ""
-      "  reg [width-1:0] rdata_reg;\n"
-      "  always @(posedge clk) begin\n"
-      "    if (ren) rdata_reg <= data[raddr];\n"
-      "  end\n"
-      "  assign rdata = rdata_reg;\n";
-    vjson["verilator_debug_definition"] =
-      ""
-      "  reg [width-1:0] data [depth-1:0];/*verilator public*/;\n"
-      ""
-      // verilator doesn't support 2d array parameter, so we pack it into a 1d
-      // array
-      "  generate if (has_init) begin\n"
-      "    genvar j;\n"
-      "    for (j = 0; j < depth; j = j + 1) begin\n"
-      "      initial begin\n"
-      "        data[j] = init[(j+1)*width-1:j*width];\n"
-      "      end\n"
-      "    end\n"
-      "  end\n"
-      "  endgenerate\n"
-      ""
-      "  always @(posedge clk) begin\n"
-      "    if (wen) begin\n"
-      "      data[waddr] <= wdata;\n"
-      "    end\n"
-      "  end\n"
-      ""
-      "  reg [width-1:0] rdata_reg;\n"
-      "  always @(posedge clk) begin\n"
-      "    if (ren) rdata_reg <= data[raddr];\n"
-      "  end\n"
-      "  assign rdata = rdata_reg;\n";
-    Namespace* memory = c->getNamespace("memory");
-    memory->getGenerator("sync_read_mem")->getMetaData()["verilog"] = vjson;
   }
 }

--- a/include/coreir/definitions/memoryVerilog.hpp
+++ b/include/coreir/definitions/memoryVerilog.hpp
@@ -1,0 +1,87 @@
+#pragma once
+
+json generateMemoryVerilogInterface(bool with_ren) {
+  json result = {
+    "input clk",
+    "input [width-1:0] wdata",
+    "input [$clog2(depth)-1:0] waddr",
+    "input wen",
+    "output [width-1:0] rdata",
+    "input [$clog2(depth)-1:0] raddr"};
+  if (with_ren) { result.push_back("input ren"); }
+  return result;
+}
+
+std::string generateMemoryVerilogBody(
+  bool verilator_debug,
+  bool with_ren,
+  bool with_sync_read_param) {
+  std::string verilog_str = "  reg [width-1:0] data [depth-1:0]";
+  if (verilator_debug) { verilog_str += "/*verilator public*/"; }
+  verilog_str += ";\n";
+  verilog_str +=
+    // verilator doesn't support 2d array parameter, so we pack it into a 1d
+    // array
+    "  generate if (has_init) begin\n"
+    "    genvar j;\n"
+    "    for (j = 0; j < depth; j = j + 1) begin\n"
+    "      initial begin\n"
+    "        data[j] = init[(j+1)*width-1:j*width];\n"
+    "      end\n"
+    "    end\n"
+    "  end\n"
+    "  endgenerate\n"
+    ""
+    "  always @(posedge clk) begin\n"
+    "    if (wen) begin\n"
+    "      data[waddr] <= wdata;\n"
+    "    end\n"
+    "  end\n"
+    "";
+  if (with_sync_read_param) {
+    // coreir.mem
+    ASSERT(!with_ren, "Cannot use ren with sync_read_param");
+    verilog_str +=
+      "  generate if (sync_read) begin\n"
+      "  reg [width-1:0] rdata_reg;\n"
+      "  always @(posedge clk) begin\n"
+      "    rdata_reg <= data[raddr];\n"
+      "  end\n"
+      "  assign rdata = rdata_reg;\n"
+      "  end else begin\n"
+      "  assign rdata = data[raddr];\n"
+      "  end\n"
+      "  endgenerate\n";
+  }
+  else {
+    // for memory.sync_read_mem
+    verilog_str +=
+      "  reg [width-1:0] rdata_reg;\n"
+      "  always @(posedge clk) begin\n";
+    if (with_ren) { verilog_str += "    if (ren) rdata_reg <= data[raddr];\n"; }
+    else {
+      verilog_str += "    rdata_reg <= data[raddr];\n";
+    }
+    verilog_str +=
+      "  end\n"
+      "  assign rdata = rdata_reg;\n";
+  }
+  return verilog_str;
+}
+
+void CoreIRLoadVerilog_memory(CoreIR::Context* c) {
+  {
+    // sync_read_mem
+    json vjson;
+    vjson["prefix"] = "coreir_";
+    vjson["interface"] = generateMemoryVerilogInterface(true);
+    vjson["parameters"] = {"has_init"};
+    vjson["definition"] = generateMemoryVerilogBody(false, true, false);
+    vjson["verilator_debug_definition"] = generateMemoryVerilogBody(
+      true,
+      true,
+      false);
+    CoreIR::Namespace* memory = c->getNamespace("memory");
+    memory->getGenerator("sync_read_mem")->getMetaData()["verilog"] = vjson;
+  }
+}

--- a/src/binary/coreir.cpp
+++ b/src/binary/coreir.cpp
@@ -6,6 +6,7 @@
 #include "coreir/definitions/coreVerilog.hpp"
 #include "coreir/definitions/corebitFirrtl.hpp"
 #include "coreir/definitions/corebitVerilog.hpp"
+#include "coreir/definitions/memoryVerilog.hpp"
 #include "coreir/passes/analysis/coreirjson.h"
 #include "coreir/passes/analysis/firrtl.h"
 #include "coreir/passes/analysis/magma.h"
@@ -217,6 +218,7 @@ int main(int argc, char* argv[]) {
     // TODO: Have option to output this or not
     CoreIRLoadVerilog_coreir(c);
     CoreIRLoadVerilog_corebit(c);
+    CoreIRLoadVerilog_memory(c);
 
     LOG(DEBUG) << "Running Runningvpasses";
     string vstr = "verilog";

--- a/src/coreir-c/coreir-c.cpp
+++ b/src/coreir-c/coreir-c.cpp
@@ -7,6 +7,7 @@
 #include "coreir/common/logging_lite.hpp"
 #include "coreir/definitions/coreVerilog.hpp"
 #include "coreir/definitions/corebitVerilog.hpp"
+#include "coreir/definitions/memoryVerilog.hpp"
 #include "coreir/ir/json.h"
 #include "coreir/passes/analysis/verilog.h"
 

--- a/src/ir/headers/core.hpp
+++ b/src/ir/headers/core.hpp
@@ -181,38 +181,6 @@ void core_state(Context* c, Namespace* core) {
   mem->setModParamsGen(memModParamFun);
   mem->addDefaultGenArgs({{"has_init", Const::make(c, false)},
                           {"sync_read", Const::make(c, false)}});
-
-  // SyncReadMemory
-  Params syncReadMemGenParams(
-    {{"width", c->Int()}, {"depth", c->Int()}, {"has_init", c->Bool()}});
-  auto syncReadMemFun = [](Context* c, Values genargs) {
-    int width = genargs.at("width")->get<int>();
-    int depth = genargs.at("depth")->get<int>();
-    int awidth = std::max((int)ceil(std::log2(depth)), 1);
-    return c->Record(
-      {{"clk", c->Named("coreir.clkIn")},
-       {"wdata", c->BitIn()->Arr(width)},
-       {"waddr", c->BitIn()->Arr(awidth)},
-       {"wen", c->BitIn()},
-       {"rdata", c->Bit()->Arr(width)},
-       {"ren", c->BitIn()},
-       {"raddr", c->BitIn()->Arr(awidth)}});
-  };
-
-  // can reuse normal mem fun
-  auto syncReadMemModParamFun = memModParamFun;
-
-  TypeGen* syncReadMemTypeGen = core->newTypeGen(
-    "syncReadMemType",
-    syncReadMemGenParams,
-    syncReadMemFun);
-
-  Generator* syncReadMem = core->newGeneratorDecl(
-    "sync_read_mem",
-    syncReadMemTypeGen,
-    syncReadMemGenParams);
-  syncReadMem->setModParamsGen(syncReadMemModParamFun);
-  syncReadMem->addDefaultGenArgs({{"has_init", Const::make(c, false)}});
 }
 
 Namespace* CoreIRLoadHeader_core(Context* c) {

--- a/src/passes/analysis/verilog.cpp
+++ b/src/passes/analysis/verilog.cpp
@@ -345,6 +345,16 @@ std::unique_ptr<vAST::AbstractModule> compile_string_module(json verilog_json) {
     verilog_json["verilog_string"].get<std::string>());
 }
 
+// These memory modules have special handling for the verilog code generation
+// of the `init` parameter in definitions
+bool isVerilogMemPrimitive(Module* module) {
+  return module->isGenerated() &&
+    ((module->getGenerator()->getNamespace()->getName() == "coreir" &&
+      module->getGenerator()->getName() == "mem") ||
+     (module->getGenerator()->getNamespace()->getName() == "memory" &&
+      module->getGenerator()->getName() == "sync_read_mem"));
+}
+
 // Compiles a module defined by the following entries in the `verilog` metadata
 // field
 // * "interface" -> used to define the module interface
@@ -1049,24 +1059,15 @@ void assign_inouts(
   };
 }
 
-// These memory modules have special handling for the verilog code generation
-// of the `init` parameter in definitions
-bool isVerilogMemPrimitive(Module* module) {
-  return module->isGenerated() &&
-    module->getGenerator()->getNamespace()->getName() == "coreir" &&
-    (module->getGenerator()->getName() == "mem" ||
-     module->getGenerator()->getName() == "sync_read_mem");
-}
-
 // These memory modules have special handling for the `init` parameter in
 // verilog code generation of instances
 bool isMemModule(Module* module) {
   return module->isGenerated() &&
     ((module->getGenerator()->getNamespace()->getName() == "coreir" &&
-      (module->getGenerator()->getName() == "mem" ||
-       module->getGenerator()->getName() == "sync_read_mem")) ||
-     (module->getGenerator()->getName() == "rom2" &&
-      module->getGenerator()->getNamespace()->getName() == "memory"));
+      (module->getGenerator()->getName() == "mem")) ||
+     (module->getGenerator()->getNamespace()->getName() == "memory" &&
+      (module->getGenerator()->getName() == "rom2" ||
+       module->getGenerator()->getName() == "sync_read_mem")));
 }
 
 // Traverses the instance map and creates a vector of module instantiations

--- a/src/passes/analysis/verilog.cpp
+++ b/src/passes/analysis/verilog.cpp
@@ -398,8 +398,10 @@ std::unique_ptr<vAST::AbstractModule> Passes::Verilog::compileStringBodyModule(
   // verilog code expects it for syntax (just use a default value since the
   // generate if statement will not be run)
   if (
-    module->isGenerated() && module->getGenerator()->getName() == "mem" &&
-    module->getGenerator()->getNamespace()->getName() == "coreir") {
+    module->isGenerated() &&
+    module->getGenerator()->getNamespace()->getName() == "coreir" &&
+    (module->getGenerator()->getName() == "mem" ||
+     module->getGenerator()->getName() == "sync_read_mem")) {
     ASSERT(
       parameters_seen.count("init") == 0,
       "Did not expect to see init param already");
@@ -418,8 +420,10 @@ std::unique_ptr<vAST::AbstractModule> Passes::Verilog::compileStringBodyModule(
   }
   for (auto parameter : module->getModParams()) {
     if (
-      module->isGenerated() && module->getGenerator()->getName() == "mem" &&
+      module->isGenerated() &&
       module->getGenerator()->getNamespace()->getName() == "coreir" &&
+      (module->getGenerator()->getName() == "mem" ||
+       module->getGenerator()->getName() == "sync_read_mem") &&
       parameter.first == "init") {
       // Handled above, we always generate this parameter
       continue;
@@ -1056,8 +1060,9 @@ void assign_inouts(
 
 bool isMemModule(Module* module) {
   return module->isGenerated() &&
-    ((module->getGenerator()->getName() == "mem" &&
-      module->getGenerator()->getNamespace()->getName() == "coreir") ||
+    ((module->getGenerator()->getNamespace()->getName() == "coreir" && 
+      (module->getGenerator()->getName() == "mem" ||
+       module->getGenerator()->getName() == "sync_read_mem")) ||
      (module->getGenerator()->getName() == "rom2" &&
       module->getGenerator()->getNamespace()->getName() == "memory"));
 }

--- a/tests/gtest/golds/sync_read_mem.v
+++ b/tests/gtest/golds/sync_read_mem.v
@@ -1,0 +1,59 @@
+module coreir_sync_read_mem #(
+    parameter has_init = 1'b0,
+    parameter depth = 1,
+    parameter width = 1,
+    parameter [(width * depth) - 1:0] init = 0
+) (
+    input clk,
+    input [width-1:0] wdata,
+    input [$clog2(depth)-1:0] waddr,
+    input wen,
+    output [width-1:0] rdata,
+    input [$clog2(depth)-1:0] raddr,
+    input ren
+);
+  reg [width-1:0] data [depth-1:0];
+  generate if (has_init) begin
+    genvar j;
+    for (j = 0; j < depth; j = j + 1) begin
+      initial begin
+        data[j] = init[(j+1)*width-1:j*width];
+      end
+    end
+  end
+  endgenerate
+  always @(posedge clk) begin
+    if (wen) begin
+      data[waddr] <= wdata;
+    end
+  end
+  reg [width-1:0] rdata_reg;
+  always @(posedge clk) begin
+    if (ren) rdata_reg <= data[raddr];
+  end
+  assign rdata = rdata_reg;
+
+endmodule
+
+module Memory (
+    input [1:0] RADDR,
+    input RE,
+    output [4:0] RDATA,
+    input CLK
+);
+coreir_sync_read_mem #(
+    .init({5'd11,5'd21,5'd0,5'd5}),
+    .depth(4),
+    .has_init(1'b1),
+    .width(5)
+) coreir_sync_read_mem4x5_inst0 (
+    .clk(CLK),
+    .wdata(5'h00),
+    .waddr(2'h0),
+    .wen(1'b0),
+    .rdata(RDATA),
+    .ren(RE),
+    .raddr(RADDR)
+);
+endmodule
+

--- a/tests/gtest/srcs/sync_read_mem.json
+++ b/tests/gtest/srcs/sync_read_mem.json
@@ -25,7 +25,7 @@
             "modargs":{"value":[["BitVector",5],"5'h00"]}
           },
           "coreir_sync_read_mem4x5_inst0":{
-            "genref":"coreir.sync_read_mem",
+            "genref":"memory.sync_read_mem",
             "genargs":{"depth":["Int",4], "has_init":["Bool",true], "width":["Int",5]},
             "modargs":{"init":["Json",[5,0,21,11]]}
           }

--- a/tests/gtest/srcs/sync_read_mem.json
+++ b/tests/gtest/srcs/sync_read_mem.json
@@ -1,0 +1,46 @@
+{"top":"global.Memory",
+"namespaces":{
+  "global":{
+    "modules":{
+      "Memory":{
+        "type":["Record",[
+          ["RADDR",["Array",2,"BitIn"]],
+          ["RE","BitIn"],
+          ["RDATA",["Array",5,"Bit"]],
+          ["CLK",["Named","coreir.clkIn"]]
+        ]],
+        "instances":{
+          "bit_const_0_None":{
+            "modref":"corebit.const",
+            "modargs":{"value":["Bool",false]}
+          },
+          "const_0_2":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",2]},
+            "modargs":{"value":[["BitVector",2],"2'h0"]}
+          },
+          "const_0_5":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",5]},
+            "modargs":{"value":[["BitVector",5],"5'h00"]}
+          },
+          "coreir_sync_read_mem4x5_inst0":{
+            "genref":"coreir.sync_read_mem",
+            "genargs":{"depth":["Int",4], "has_init":["Bool",true], "width":["Int",5]},
+            "modargs":{"init":["Json",[5,0,21,11]]}
+          }
+        },
+        "connections":[
+          ["coreir_sync_read_mem4x5_inst0.wen","bit_const_0_None.out"],
+          ["coreir_sync_read_mem4x5_inst0.waddr","const_0_2.out"],
+          ["coreir_sync_read_mem4x5_inst0.wdata","const_0_5.out"],
+          ["coreir_sync_read_mem4x5_inst0.ren","self.RE"],
+          ["self.CLK","coreir_sync_read_mem4x5_inst0.clk"],
+          ["self.RADDR","coreir_sync_read_mem4x5_inst0.raddr"],
+          ["self.RDATA","coreir_sync_read_mem4x5_inst0.rdata"]
+        ]
+      }
+    }
+  }
+}
+}

--- a/tests/gtest/test_memory.cpp
+++ b/tests/gtest/test_memory.cpp
@@ -3,6 +3,7 @@
 #include "coreir.h"
 #include "coreir/definitions/coreVerilog.hpp"
 #include "coreir/definitions/corebitVerilog.hpp"
+#include "coreir/definitions/memoryVerilog.hpp"
 #include "coreir/libs/commonlib.h"
 
 using namespace CoreIR;
@@ -53,6 +54,7 @@ TEST(MemoryTests, TestSyncReadMem) {
   Context* c = newContext();
   CoreIRLoadVerilog_coreir(c);
   CoreIRLoadVerilog_corebit(c);
+  CoreIRLoadVerilog_memory(c);
   Module* top;
 
   if (!loadFromFile(c, "srcs/sync_read_mem.json", &top)) { c->die(); }

--- a/tests/gtest/test_memory.cpp
+++ b/tests/gtest/test_memory.cpp
@@ -49,6 +49,25 @@ TEST(MemoryTests, TestIssue932) {
   deleteContext(c);
 }
 
+TEST(MemoryTests, TestSyncReadMem) {
+  Context* c = newContext();
+  CoreIRLoadVerilog_coreir(c);
+  CoreIRLoadVerilog_corebit(c);
+  Module* top;
+
+  if (!loadFromFile(c, "srcs/sync_read_mem.json", &top)) { c->die(); }
+  assert(top != nullptr);
+  c->setTop(top->getRefName());
+
+  const std::vector<std::string> passes = {"rungenerators",
+                                           "removebulkconnections",
+                                           "flattentypes",
+                                           "verilog --inline"};
+  c->runPasses(passes, {});
+  assertPassEq(c, "verilog", "golds/sync_read_mem.v");
+  deleteContext(c);
+}
+
 }  // namespace
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
This adds a SyncReadMemory primitive that is similar to coreir.mem with
the sync_read parameter enabled, except that it also supports a read
enable port.

The motivation is that we want to generate the `ren` logic in the
verilog using the `if` inside the `always` block for synthesis.
However, we can't smash this inside the existing memory generator since
it would require an "optional" `ren` port that isn't used when sync_read
is disabled.  It doesn't seem like verilog supports this optional port
pattern.

One alternative to defining a separate primitive would be to always
generate a `ren` port in the verilog and ignore it if `sync_read` is
disabled.

Ideally we'd have this in place of the sync_read parameter, but I left
the old logic in for backwards compatability.  With sync_read, if the
user doesn't want to use the enable logic, we can just set the input to
1 and presumably the downstream tool can optimize that out.

Setting ren to a constant 1 when the enable logic is not desired seemed
like a better pattern than having a dangling `ren` port when there's a
combinational read, but the downside is we have to use a separate
primitive.

Perhaps an alternative long-term solution would be to add a
`sync_read_enable` argument to the memory and have it generate different
verilog code based on the parameter.  This might be a good effort for
other cases, e.g. where we use `generate if` for the verilog memory init
logic (instead we could just generate the `init` code if the parameter
is enabled), but this requires quite a bit of work since the verilog
primitive code generation wasn't designed to support this (right now we
just store a static verilog string to emit, rather than generating the
string dynamically, we'd need to create some API for this).