### PR TITLE
Bump verilogAST to resolve include error

### DIFF
--- a/CMakeLists.txt.in
+++ b/CMakeLists.txt.in
@@ -7,7 +7,7 @@ project(verilogAST-download NONE)
 include(ExternalProject)
 ExternalProject_Add(verilogAST
   GIT_REPOSITORY    https://github.com/leonardt/verilogAST-cpp.git
-  GIT_TAG           b23b95325f8c711c2b8ab9b91f07ba18c21ed1fd
+  GIT_TAG           54a121f
   SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/verilogAST-src"
   BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/verilogAST-build"
   CONFIGURE_COMMAND ""


### PR DESCRIPTION
Not sure why this is now showing up on pycoreir travis but not here or verilogAST or in the past, but we're getting this error:
```
/pycoreir/coreir-cpp/build/verilogAST-src/include/verilogAST.hpp:610:16: error: ‘runtime_error’ is not a member of ‘std’
  610 |     throw std::runtime_error("Could not find '" + name + "'");
```
See https://travis-ci.org/github/leonardt/pycoreir/jobs/739451881 for more details (this is breaking the pycoreir wheel distribution)

This bumps verilogAST to include the stdexcept header (https://github.com/leonardt/verilogAST-cpp/commit/54a121fee3e18930d007219526b6fee5da92fe5b)