### PR TITLE
Add undriven off lint flag for verilator compat

### DIFF
--- a/src/passes/analysis/verilog.cpp
+++ b/src/passes/analysis/verilog.cpp
@@ -382,6 +382,12 @@ std::unique_ptr<vAST::AbstractModule> Passes::Verilog::compileStringBodyModule(
       port_str = "/*verilator lint_off UNUSED */" + port_str +
         "/*verilator lint_on UNUSED */";
     }
+    if (
+      this->verilator_compat &&
+      (name == "coreir_undriven" || name == "corebit_undriven")) {
+      port_str = "/*verilator lint_off UNDRIVEN */" + port_str +
+        "/*verilator lint_on UNDRIVEN */";
+    }
     ports.push_back(std::make_unique<vAST::StringPort>(port_str));
   }
   vAST::Parameters parameters;

--- a/tests/binary/src/verilator_compat.json
+++ b/tests/binary/src/verilator_compat.json
@@ -6,7 +6,9 @@
         "verilator_compat": {
           "type": ["Record",[
             ["in", ["Array",16,"BitIn"]],
-            ["out", ["Array",4,"Bit"]]
+            ["out", ["Array",4,"Bit"]],
+            ["out_undriven", ["Array",4,"Bit"]],
+            ["out_undriven_bit", "Bit"]
           ]],
           "instances": {
             "s": {
@@ -19,13 +21,22 @@
             },
             "bit_term": {
               "modref": "corebit.term"
+            },
+            "undriven": {
+              "genref": "coreir.undriven",
+              "genargs": {"width":["Int", 4]}
+            },
+            "bit_undriven": {
+              "modref": "corebit.undriven"
             }
           },
           "connections": [
             ["self.in","s.in"],
             ["s.out","self.out"],
             ["self.in.0","bit_term.in"],
-            ["self.in.0:4","term.in"]
+            ["self.in.0:4","term.in"],
+            ["self.out_undriven.0:4","undriven.out"],
+            ["self.out_undriven_bit","bit_undriven.out"]
           ]
         }
       }

--- a/tests/binary/test_issues.py
+++ b/tests/binary/test_issues.py
@@ -1,16 +1,16 @@
 import delegator
 
 
-def test_verilator_unused():
+def test_verilator_compat():
     res = delegator.run(
         'coreir -i tests/binary/src/verilator_compat.json'
         '           -o tests/binary/build/out.v'
         '           -l commonlib --verilator_compat'
     )
-    print(res.out, res.err)
     assert not res.return_code, res.out + res.err
 
-    res = delegator.run('verilator --lint-only -Wall -Wno-DECLFILENAME tests/binary/build/out.v')
+    res = delegator.run('verilator --lint-only -Wall -Wno-DECLFILENAME '
+                        'tests/binary/build/out.v')
     assert not res.return_code, res.out + res.err
 
 


### PR DESCRIPTION
Similar to the comments we use for the `term` primitives to silence the
verilator unused warnings, this adds comments to silence verilator
undriven warnings when using the `undriven` primitie.