### PR TITLE
Add suport for .sv extension

### DIFF
--- a/include/coreir/passes/analysis/verilog.h
+++ b/include/coreir/passes/analysis/verilog.h
@@ -100,7 +100,8 @@ class Verilog : public InstanceGraphPass {
   void writeToStream(std::ostream& os) override;
   void writeToFiles(
     const std::string& dir,
-    std::unique_ptr<std::string> product_file);
+    std::unique_ptr<std::string> product_file,
+    std::string outExt);
 };
 
 }  // namespace Passes

--- a/src/binary/coreir.cpp
+++ b/src/binary/coreir.cpp
@@ -165,7 +165,7 @@ int main(int argc, char* argv[]) {
       ASSERT(
         outExt == "json" || outExt == "txt" || outExt == "fir" ||
           outExt == "py" || outExt == "smt2" || outExt == "smv" ||
-          outExt == "v",
+          outExt == "v" || outExt == "sv" ,
         "Cannot support out extention: " + outExt);
       if (!split_files) {
         std::unique_ptr<std::ofstream> fout(new std::ofstream(outfile));
@@ -176,7 +176,7 @@ int main(int argc, char* argv[]) {
     }
     if (split_files) {
       ASSERT(
-        outExt == "v",
+        outExt == "v" || outExt == "sv",
         "Split files option is only supported in verilog mode currently: "
         "ext = " +
           outExt);
@@ -214,7 +214,7 @@ int main(int argc, char* argv[]) {
     // Create file here.
     fpass->writeToStream(*sout);
   }
-  else if (outExt == "v") {
+  else if (outExt == "v" || outExt == "sv") {
     // TODO: Have option to output this or not
     CoreIRLoadVerilog_coreir(c);
     CoreIRLoadVerilog_corebit(c);
@@ -242,7 +242,7 @@ int main(int argc, char* argv[]) {
         const auto val = opts["product"].as<std::string>();
         product_file.reset(new std::string(val));
       }
-      vpass->writeToFiles(output_dir, std::move(product_file));
+      vpass->writeToFiles(output_dir, std::move(product_file), outExt);
     }
     else {
       vpass->writeToStream(*sout);

--- a/src/coreir-c/coreir-c.cpp
+++ b/src/coreir-c/coreir-c.cpp
@@ -179,7 +179,7 @@ bool CORECompileToVerilog(
     if (product_file != "") {
       product_file_ptr.reset(new std::string(product));
     }
-    pass->writeToFiles(output_dir, std::move(product_file_ptr));
+    pass->writeToFiles(output_dir, std::move(product_file_ptr), "v");
     return true;
   }
   // Do not split; write to filename.

--- a/src/passes/analysis/verilog.cpp
+++ b/src/passes/analysis/verilog.cpp
@@ -1567,10 +1567,14 @@ void Passes::Verilog::writeToStream(std::ostream& os) {
 
 void Passes::Verilog::writeToFiles(
   const std::string& dir,
-  std::unique_ptr<std::string> product_file) {
+  std::unique_ptr<std::string> product_file,
+  std::string outExt) {
   std::vector<std::string> products;
+  ASSERT(
+    outExt == "v" || outExt == "sv",
+    "Expect outext to be v or sv, not " + outExt);
   for (auto& module : modules) {
-    const std::string filename = module.first + ".v";
+    const std::string filename = module.first + "." + outExt;
     products.push_back(filename);
     const std::string full_filename = dir + "/" + filename;
     std::ofstream output_file(full_filename);

--- a/tests/binary/test_examples.py
+++ b/tests/binary/test_examples.py
@@ -24,11 +24,11 @@ def test_examples(example):
         assert not res.return_code, res.out + res.err
 
         #Test serializing to verilog
-        res = delegator.run(f"bin/coreir -i examples/{example} {libs} -p wireclocks-clk -o examples/build/{name}.v")
+        res = delegator.run(f"bin/coreir -i examples/{example} {libs} -p wireclocks-clk -o examples/build/{name}.sv")
         assert not res.return_code, res.out + res.err
 
         #Verify verilog syntax
-        res = delegator.run(f"verilator --lint-only examples/build/{name}.v")
+        res = delegator.run(f"verilator --lint-only examples/build/{name}.sv")
         assert not res.return_code, res.out + res.err
 
         #Test serializing to verilog (inlined)

--- a/tests/unit/split_files.cpp
+++ b/tests/unit/split_files.cpp
@@ -59,7 +59,7 @@ bool FileExists(std::string filename) {
 void TestSplitFiles() {
   SplitFilesFixture fixture("split_files_in.json");
   auto verilog_pass = fixture.RunVerilogPass();
-  verilog_pass->writeToFiles("./", {});
+  verilog_pass->writeToFiles("./", {}, "v");
   for (int i = 0; i < kNumExpectedFiles; i++) {
     const std::string expected = std::string(kExpectedFilenames[i]);
     ASSERT(FileExists(expected), "File '" + expected + "' does not exist");
@@ -70,7 +70,7 @@ void TestProductList() {
   SplitFilesFixture fixture("split_files_in.json");
   auto verilog_pass = fixture.RunVerilogPass();
   std::unique_ptr<std::string> product_file(new std::string("product.txt"));
-  verilog_pass->writeToFiles("./", std::move(product_file));
+  verilog_pass->writeToFiles("./", std::move(product_file), "v");
   std::ifstream infile("product.txt");
   std::string filename;
   for (int i = 0; i < kNumExpectedFiles; i++) {


### PR DESCRIPTION
Needed for https://github.com/phanrahan/magma/issues/880

Allows the user to choose `.sv` as an output.  In the future, we should
consider forcing the `disable-ndarray` option when `.v` is used (i.e.
choosing `.sv` enables this feature since it should be compatible with
tools that support `.sv`).   However, for backwards compatability, I
think we should leave the behavior as is (or else various downstream
users will have different code generated by default since everyone is
using `.v` right now but some are expected the ndarray feature enabled
for `.v`).