### PR TITLE
Fix CORENamedTypeToString c-API

### DIFF
--- a/include/coreir/ir/context.h
+++ b/include/coreir/ir/context.h
@@ -48,6 +48,8 @@ class Context {
   std::vector<DirectedConnection**> directedConnectionPtrArrays;
   std::vector<DirectedInstance**> directedInstancePtrArrays;
 
+  std::vector<void*> scratchPad;
+
  public:
   Context();
   ~Context();
@@ -75,6 +77,15 @@ class Context {
   bool hasGenerator(std::string ref);
   bool hasModule(std::string ref);
   bool hasGlobalValue(std::string ref);
+
+  // This function provides scratch memory managed by this context. The memory
+  // will be free'd upon deletion of this context.
+  // NOTE(rsetaluri): Using memory provided by this function is a *slight*
+  // improvment over a true memory leak. Likely, the lifetime of the context
+  // will be the lifetime of the program. However, it is preferred to use this
+  // function over a true memory leak, sine all such allocations can be
+  // localized to calls of this function (and therefore easier to find and fix).
+  void* getScratchMemory(size_t size);
 
   std::map<std::string, Namespace*> getNamespaces();
   void addPass(Pass* p);

--- a/include/coreir/ir/types.h
+++ b/include/coreir/ir/types.h
@@ -112,6 +112,10 @@ class NamedType : public Type, public GlobalValue {
   TypeGen* getTypegen() const { return typegen; }
   Values getGenArgs() const { return genargs; }
   uint getSize() const override { return raw->getSize(); }
+
+  // NOTE(rsetaluri): This is needed to avoid ambiguity between the member
+  // getContext, inherited multiply through Type and GlobalValue.
+  using Type::getContext;
 };
 
 class ArrayType : public Type {

--- a/src/coreir-c/types-c.cpp
+++ b/src/coreir-c/types-c.cpp
@@ -71,8 +71,14 @@ COREType* COREArrayTypeGetElemType(COREType* arrayType) {
 }
 
 const char* CORENamedTypeToString(COREType* namedType) {
-  return rcast<NamedType*>(namedType)->toString().c_str();
+  auto named_type = rcast<NamedType*>(namedType);
+  auto str = named_type->toString();
+  auto copy = static_cast<char*>(
+      named_type->getContext()->getScratchMemory(str.size() + 1));
+  strcpy(copy, str.c_str());
+  return copy;
 }
-}
+
+}  // extern "C"
 
 }  // namespace CoreIR

--- a/src/ir/context.cpp
+++ b/src/ir/context.cpp
@@ -1,3 +1,4 @@
+#include <stdlib.h>
 #include "coreir/ir/context.h"
 #include "coreir/ir/common.h"
 #include "coreir/ir/coreirlib.h"
@@ -73,6 +74,9 @@ Context::~Context() {
   for (auto it : namespaces) delete it.second;
   delete valuecache;
   delete libmanager;
+
+  // Free up scratch pad memory.
+  for (void* ptr : scratchPad) free(ptr);
 }
 
 std::map<std::string, Namespace*> Context::getNamespaces() {
@@ -401,6 +405,12 @@ DirectedInstance** Context::newDirectedInstancePtrArray(int size) {
     sizeof(DirectedInstance*) * size);
   directedInstancePtrArrays.push_back(arr);
   return arr;
+}
+
+void* Context::getScratchMemory(size_t size) {
+  auto buf = malloc(size);
+  scratchPad.emplace_back(buf);
+  return buf;
 }
 
 Context* newContext() {


### PR DESCRIPTION
This change adds a context-managed scratch-pad memory which can be used
safely, without risk of a memory leak. The c-API CORENamedTypeToString
previously returned a pointer to a temporary, which is unsafe. Instead,
we allocate context-managed memory and return a buffer contained there.

See https://github.com/rdaly525/coreir/pull/969.