### PR TITLE
Add support for verilog body string

### DIFF
--- a/src/passes/analysis/verilog.cpp
+++ b/src/passes/analysis/verilog.cpp
@@ -1439,6 +1439,26 @@ void Passes::Verilog::compileModule(Module* module) {
       modules.push_back(
         std::make_pair(module->getName(), compile_string_module(verilog_json)));
     }
+    else if (verilog_json.count("verilog_body") > 0) {
+      std::vector<std::unique_ptr<vAST::AbstractPort>> ports = compilePorts(
+        cast<RecordType>(module->getType()));
+
+      std::vector<std::variant<
+        std::unique_ptr<vAST::StructuralStatement>,
+        std::unique_ptr<vAST::Declaration>>>
+        body;
+
+      body.push_back(std::make_unique<vAST::InlineVerilog>(
+        verilog_json["verilog_body"].get<std::string>()));
+
+      std::string name = module->getName();
+      modules.push_back(std::make_pair(
+        name,
+        std::make_unique<vAST::Module>(
+          name,
+          std::move(ports),
+          std::move(body))));
+    }
     else {
       std::string name = make_name(module->getName(), verilog_json);
       modules.push_back(std::make_pair(

--- a/tests/gtest/golds/verilog_body.v
+++ b/tests/gtest/golds/verilog_body.v
@@ -1,0 +1,12 @@
+module Foo (
+    input I,
+    output O
+);
+
+always @(*) begin
+    O = I;
+    $display("%d\n", I);
+end
+
+endmodule
+

--- a/tests/gtest/srcs/verilog_body.json
+++ b/tests/gtest/srcs/verilog_body.json
@@ -1,0 +1,15 @@
+{"top":"global.Foo",
+"namespaces":{
+  "global":{
+    "modules":{
+      "Foo":{
+        "type":["Record",[
+          ["I","BitIn"],
+          ["O","Bit"]
+        ]],
+        "metadata":{"verilog":{"verilog_body":"\nalways @(*) begin\n    O = I;\n    $display(\"%d\\n\", I);\nend\n"}}
+      }
+    }
+  }
+}
+}

--- a/tests/gtest/test_verilog.cpp
+++ b/tests/gtest/test_verilog.cpp
@@ -365,6 +365,24 @@ TEST(VerilogTests, TestCompileGuard) {
   assertPassEq(c, "verilog", "golds/compile_guard.v");
   deleteContext(c);
 }
+
+TEST(VerilogTests, TestVerilogBody) {
+  Context* c = newContext();
+  Module* top;
+
+  if (!loadFromFile(c, "srcs/verilog_body.json", &top)) { c->die(); }
+  assert(top != nullptr);
+  c->setTop(top->getRefName());
+
+  const std::vector<std::string> passes = {
+    "rungenerators",
+    "removebulkconnections",
+    "flattentypes --ndarray",
+    "verilog --inline"};
+  c->runPasses(passes, {});
+  assertPassEq(c, "verilog", "golds/verilog_body.v");
+  deleteContext(c);
+}
 }  // namespace
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
This was a feature we used to support in magma (see first example
https://github.com/phanrahan/magmathon/blob/master/notebooks/advanced/verilog.ipynb)
that used the verilog backend.  This adds support for the same feature
in the coreir backend.

This simply allows the user to define circuit interface in magma/coreir,
but the body in verilog.  This is slightly different than inline verilog
in that we allow the user to drive signals from the verilog body string.
Otherwise, if we drove a signal from inline_verilog, we'd get an
undriven error in magma/coreir since we aren't aware of the driver from
the string.