### PR TITLE
Skip symbol table logging for generators

### DIFF
--- a/src/ir/moduledef.cpp
+++ b/src/ir/moduledef.cpp
@@ -223,7 +223,8 @@ Instance* ModuleDef::addInstance(string instname, Module* m, Values modargs) {
 
   // Log new instance for symbol table.
   const bool should_log = (getContext()->getDebug()
-                           and m->getRefName() != "_.passthrough");
+                           and m->getRefName() != "_.passthrough"
+                           and not module->isGenerated());
   if (should_log) {
     auto logger = getContext()->getPassManager()->getSymbolTable()->getLogger();
     logger->logNewInstance(getModule()->getName(), m->getName(), instname);
@@ -420,7 +421,8 @@ void ModuleDef::removeInstance(string iname) {
 
   // Log removed instance for symbol table.
   const bool should_log = (getContext()->getDebug()
-                           and module_ref->getRefName() != "_.passthrough");
+                           and module_ref->getRefName() != "_.passthrough"
+                           and not module->isGenerated());
   if (should_log) {
     auto logger = getContext()->getPassManager()->getSymbolTable()->getLogger();
     logger->logRemoveInstance(getModule()->getName(), iname);


### PR DESCRIPTION
The data structure currently isn't able to handle generators since it cant handle modules with the same name. In CoreIR when we try to log/populate the symbol table we use the module name which is the same for different instantiations of the generator. This means the symbol table needs to specifically code for this. Until then, disabling generating anything for generators.