### PR TITLE
Use module longmame for symbol table

### DIFF
--- a/src/ir/inline.cpp
+++ b/src/ir/inline.cpp
@@ -231,7 +231,7 @@ bool inlineInstanceImpl(
     if (record_out != nullptr &&
         instpair.second->getModuleRef()->getRefName() != "_.passthrough") {
       std::array record = {
-        instpair.first, instpair.second->getModuleRef()->getName(), iname};
+        instpair.first, instpair.second->getModuleRef()->getLongName(), iname};
       record_out->emplace_back(record);
     }
   }
@@ -361,20 +361,17 @@ bool inlineInstance(Instance* inst) {
     const auto [context, container, inst_name, inst_type] = inst_info;
     auto logger = context->getPassManager()->getSymbolTable()->getLogger();
     logger->logInlineInstance(
-        container->getModule()->getName(),
+        container->getModule()->getLongName(),
         inst_name,
-        inst_type->getName(),
+        inst_type->getLongName(),
         sub_inst_name,
         sub_inst_type,
         new_name);
   };
   auto record_ptr = debug ? &record : nullptr;
   const bool ret = inlineInstanceImpl(inst, record_ptr);
-  const bool module_is_generated = std::get<1>(inst_info)->
-      getModule()->isGenerated();
-  const bool should_log = debug and not module_is_generated;
   // Log the inlined instances.
-  if (should_log) {
+  if (debug) {
     for (auto& [sub_inst_name, sub_inst_type, new_name] : record) {
       log(sub_inst_name, sub_inst_type, new_name);
     }

--- a/src/ir/moduledef.cpp
+++ b/src/ir/moduledef.cpp
@@ -223,11 +223,10 @@ Instance* ModuleDef::addInstance(string instname, Module* m, Values modargs) {
 
   // Log new instance for symbol table.
   const bool should_log = (getContext()->getDebug()
-                           and m->getRefName() != "_.passthrough"
-                           and not module->isGenerated());
+                           and m->getRefName() != "_.passthrough");
   if (should_log) {
     auto logger = getContext()->getPassManager()->getSymbolTable()->getLogger();
-    logger->logNewInstance(getModule()->getName(), m->getName(), instname);
+    logger->logNewInstance(getModule()->getLongName(), m->getLongName(), instname);
   }
 
   return inst;
@@ -421,11 +420,10 @@ void ModuleDef::removeInstance(string iname) {
 
   // Log removed instance for symbol table.
   const bool should_log = (getContext()->getDebug()
-                           and module_ref->getRefName() != "_.passthrough"
-                           and not module->isGenerated());
+                           and module_ref->getRefName() != "_.passthrough");
   if (should_log) {
     auto logger = getContext()->getPassManager()->getSymbolTable()->getLogger();
-    logger->logRemoveInstance(getModule()->getName(), iname);
+    logger->logRemoveInstance(getModule()->getLongName(), iname);
   }
 }
 

--- a/src/passes/analysis/verilog.cpp
+++ b/src/passes/analysis/verilog.cpp
@@ -1586,7 +1586,7 @@ void Passes::Verilog::compileModule(Module* module) {
   std::string name = module->getLongName();
   // NOTE(rsetaluri): This is an example of updating an entry in the symbol
   // table.
-  this->getSymbolTable()->setModuleName(module->getName(), name);
+  this->getSymbolTable()->setModuleName(module->getLongName(), name);
   std::unique_ptr<vAST::AbstractModule>
     verilog_module = std::make_unique<vAST::Module>(
       name,

--- a/src/passes/transform/flattentypes.cpp
+++ b/src/passes/transform/flattentypes.cpp
@@ -80,7 +80,8 @@ bool Passes::FlattenTypes::runOnInstanceGraphNode(InstanceGraphNode& node) {
     newports.push_back({newport, type});
     verifyUnique.insert(newport);
     if (getContext()->getDebug()) {
-      this->getSymbolTable()->setPortName(mod->getName(), ::toString(sp), newport);
+      this->getSymbolTable()->setPortName(
+          mod->getLongName(), ::toString(sp), newport);
     }
   }
 


### PR DESCRIPTION
Using a module's longname allows us to include generators and circuits
across namespaces.