### PR TITLE
Prototype linked definitions flow

### DIFF
--- a/CMakeLists.txt.in
+++ b/CMakeLists.txt.in
@@ -7,7 +7,7 @@ project(verilogAST-download NONE)
 include(ExternalProject)
 ExternalProject_Add(verilogAST
   GIT_REPOSITORY    https://github.com/leonardt/verilogAST-cpp.git
-  GIT_TAG           ifdef-decl
+  GIT_TAG           master
   SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/verilogAST-src"
   BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/verilogAST-build"
   CONFIGURE_COMMAND ""

--- a/CMakeLists.txt.in
+++ b/CMakeLists.txt.in
@@ -7,7 +7,7 @@ project(verilogAST-download NONE)
 include(ExternalProject)
 ExternalProject_Add(verilogAST
   GIT_REPOSITORY    https://github.com/leonardt/verilogAST-cpp.git
-  GIT_TAG           dc7610b
+  GIT_TAG           ifdef-decl
   SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/verilogAST-src"
   BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/verilogAST-build"
   CONFIGURE_COMMAND ""

--- a/include/coreir-c/coreir.h
+++ b/include/coreir-c/coreir.h
@@ -134,6 +134,10 @@ extern COREModuleDef* COREModuleNewDef(COREModule* m);
 // extern COREModuleDef* COREModuleGetDef(COREModule* m);
 void COREModuleSetDef(COREModule* module, COREModuleDef* module_def);
 extern COREDirectedModule* COREModuleGetDirectedModule(COREModule* module);
+extern bool COREModuleLinkModule(
+    char* key, COREModule* source, COREModule* target);
+extern bool COREModuleGetLinkedModules(
+    COREModule* source, char*** keys, COREModule*** targets, int* size);
 
 // Errors:
 //  Invalid arg: instance name already exists

--- a/include/coreir-c/coreir.h
+++ b/include/coreir-c/coreir.h
@@ -138,6 +138,9 @@ extern bool COREModuleLinkModule(
     char* key, COREModule* source, COREModule* target);
 extern bool COREModuleGetLinkedModules(
     COREModule* source, char*** keys, COREModule*** targets, int* size);
+extern bool COREModuleLinkDefaultModule(COREModule* source, COREModule* target);
+extern bool COREModuleHasDefaultLinkedModule(COREModule* source);
+extern COREModule* COREModuleGetDefaultLinkedModule(COREModule* source);
 
 // Errors:
 //  Invalid arg: instance name already exists

--- a/include/coreir/ir/instancegraph.h
+++ b/include/coreir/ir/instancegraph.h
@@ -57,7 +57,7 @@ class InstanceGraphNode {
   int mark = 0;  // unmarked=0, temp=1,perm=2
   void addInstance(Instance* i, InstanceGraphNode* ign) {
     instanceList.push_back(i);
-    ignList.push_back(ign);
+    addInstanceGraphNode(ign);
   }
 
   void addInstanceGraphNode(InstanceGraphNode* ign) {

--- a/include/coreir/ir/instancegraph.h
+++ b/include/coreir/ir/instancegraph.h
@@ -60,6 +60,10 @@ class InstanceGraphNode {
     ignList.push_back(ign);
   }
 
+  void addInstanceGraphNode(InstanceGraphNode* ign) {
+    ignList.push_back(ign);
+  }
+
   friend class InstanceGraph;
 };
 

--- a/include/coreir/ir/module.h
+++ b/include/coreir/ir/module.h
@@ -11,6 +11,7 @@ namespace CoreIR {
 class Module : public GlobalValue, public Args, public VerilogPrimitive {
   RecordType* type;
   ModuleDef* def = nullptr;
+  std::map<std::string,ModuleDef*> linkedDefinitions;
 
   const Params modparams;
   Values defaultModArgs;
@@ -43,6 +44,8 @@ class Module : public GlobalValue, public Args, public VerilogPrimitive {
   ModuleDef* getDef() const;
   // This will validate def
   void setDef(ModuleDef* def, bool validate = true);
+
+  void linkDefinition(std::string key, ModuleDef* def, bool validate = true);
 
   bool hasVerilogDef();
 

--- a/include/coreir/ir/module.h
+++ b/include/coreir/ir/module.h
@@ -11,7 +11,7 @@ namespace CoreIR {
 class Module : public GlobalValue, public Args, public VerilogPrimitive {
   RecordType* type;
   ModuleDef* def = nullptr;
-  std::map<std::string,ModuleDef*> linkedDefinitions;
+  std::map<std::string,Module*> linkedModules;
 
   const Params modparams;
   Values defaultModArgs;
@@ -45,7 +45,14 @@ class Module : public GlobalValue, public Args, public VerilogPrimitive {
   // This will validate def
   void setDef(ModuleDef* def, bool validate = true);
 
-  void linkDefinition(std::string key, ModuleDef* def, bool validate = true);
+  void linkModule(std::string key, Module* mod) {
+    // TODO: Should we raise en error if a key is used twice?
+    this->linkedModules[key] = mod;
+  };
+
+  std::map<std::string,Module*> getLinkedModules() const {
+    return linkedModules;
+  };
 
   bool hasVerilogDef();
 

--- a/include/coreir/ir/module.h
+++ b/include/coreir/ir/module.h
@@ -11,6 +11,7 @@ namespace CoreIR {
 class Module : public GlobalValue, public Args, public VerilogPrimitive {
   RecordType* type;
   ModuleDef* def = nullptr;
+  Module* defaultLinkedModule = nullptr;
   std::map<std::string,Module*> linkedModules;
 
   const Params modparams;
@@ -45,13 +46,38 @@ class Module : public GlobalValue, public Args, public VerilogPrimitive {
   // This will validate def
   void setDef(ModuleDef* def, bool validate = true);
 
+  void linkDefaultModule(Module* mod) {
+    if (this->hasDef()) {
+      throw std::runtime_error("Cannot link to definition");
+    }
+    this->defaultLinkedModule = mod;
+  };
+
+  bool hasDefaultLinkedModule() {
+    return this->defaultLinkedModule != nullptr;
+  };
+
+  Module* getDefaultLinkedModule() const {
+    return this->defaultLinkedModule;
+  };
+
+  bool hasLinkedModule() const {
+    return this->defaultLinkedModule != nullptr ||
+           this->linkedModules.size() > 0;
+  };
+
   void linkModule(std::string key, Module* mod) {
-    // TODO: Should we raise en error if a key is used twice?
+    if (this->hasDef()) {
+      throw std::runtime_error("Cannot link to definition");
+    }
+    if (this->linkedModules.count(key) > 0) {
+      throw std::runtime_error("Key: " + key + "has already been linked");
+    }
     this->linkedModules[key] = mod;
   };
 
   std::map<std::string,Module*> getLinkedModules() const {
-    return linkedModules;
+    return this->linkedModules;
   };
 
   bool hasVerilogDef();

--- a/include/coreir/passes/analysis/verilog.h
+++ b/include/coreir/passes/analysis/verilog.h
@@ -28,6 +28,7 @@ class Verilog : public InstanceGraphPass {
   // serializing to a single or multiple files
   std::vector<std::pair<std::string, std::unique_ptr<vAST::AbstractModule>>>
     modules;
+  std::map<Module*, std::string> linked_module_map;
 
   // Externally defined modules (no moduleDef), for now we just emit comments
   // listing them when compiling to a single file

--- a/include/coreir/passes/analysis/verilog.h
+++ b/include/coreir/passes/analysis/verilog.h
@@ -75,6 +75,11 @@ class Verilog : public InstanceGraphPass {
     std::set<std::string>& wires,
     std::set<std::string>& inlined_wires);
 
+  std::vector<std::variant<
+    std::unique_ptr<vAST::StructuralStatement>,
+    std::unique_ptr<vAST::Declaration>>>
+  compileLinkedModuleBody(Module* module);
+
   std::unique_ptr<vAST::AbstractModule> compileStringBodyModule(
     json verilog_json,
     std::string name,

--- a/src/coreir-c/coreir-c.cpp
+++ b/src/coreir-c/coreir-c.cpp
@@ -581,6 +581,24 @@ bool COREModuleGetLinkedModules(
   return true;
 }
 
+bool COREModuleLinkDefaultModule(COREModule* source, COREModule* target) {
+  auto s = rcast<Module*>(source);
+  auto t = rcast<Module*>(target);
+  s->linkDefaultModule(t);
+  return true;
+}
+
+bool COREModuleHasDefaultLinkedModule(COREModule* source) {
+  auto s = rcast<Module*>(source);
+  return s->hasDefaultLinkedModule();
+}
+
+COREModule* COREModuleGetDefaultLinkedModule(COREModule* source) {
+  auto s = rcast<Module*>(source);
+  auto linked = s->getDefaultLinkedModule();
+  return rcast<COREModule*>(linked);
+}
+
 void COREModuleDefConnect(
   COREModuleDef* module_def,
   COREWireable* a,

--- a/src/coreir-c/coreir-c.cpp
+++ b/src/coreir-c/coreir-c.cpp
@@ -14,6 +14,28 @@
 using namespace std;
 namespace CoreIR {
 
+namespace {
+
+void lowerModuleMap(
+    const std::map<std::string, Module*>& modules,
+    char*** keys,
+    COREModule*** values,
+    int* size) {
+  *size = modules.size();
+  *keys = static_cast<char**>(malloc((*size) * sizeof(char*)));
+  *values = static_cast<COREModule**>(malloc((*size) * sizeof(COREModule*)));
+  int i = 0;
+  for (auto const& item : modules) {
+    const char* key = item.first.c_str();
+    (*keys)[i] = static_cast<char*>(malloc(strlen(key) + 1));
+    strcpy((*keys)[i], key);
+    (*values)[i] = rcast<COREModule*>(item.second);
+    i++;
+  }
+}
+
+}  // namespace
+
 extern "C" {
 
 void* CORENewMap(
@@ -544,6 +566,21 @@ COREDirectedModule* COREModuleGetDirectedModule(COREModule* module) {
     rcast<Module*>(module)->newDirectedModule());
 }
 
+bool COREModuleLinkModule(char* key, COREModule* source, COREModule* target) {
+  auto s = rcast<Module*>(source);
+  auto t = rcast<Module*>(target);
+  s->linkModule(std::string(key), t);
+  return true;
+}
+
+bool COREModuleGetLinkedModules(
+    COREModule* source, char*** keys, COREModule*** targets, int* size) {
+  auto s = rcast<Module*>(source);
+  auto ts = s->getLinkedModules();
+  lowerModuleMap(ts, keys, targets, size);
+  return true;
+}
+
 void COREModuleDefConnect(
   COREModuleDef* module_def,
   COREWireable* a,
@@ -708,20 +745,8 @@ void CORENamespaceGetModules(
   COREModule*** values,
   int* num_items) {
 
-  std::map<std::string, Module*> modules = rcast<Namespace*>(core_namespace)
-                                             ->getModules();
-
-  *num_items = modules.size();
-  *keys = (char**)malloc(*num_items * sizeof(char*));
-  *values = (COREModule**)malloc(*num_items * sizeof(COREModule*));
-  int i = 0;
-  for (auto const& item : modules) {
-    const char* key = item.first.c_str();
-    (*keys)[i] = (char*)malloc(strlen(key) + 1);
-    strcpy((*keys)[i], key);
-    (*values)[i] = rcast<COREModule*>(item.second);
-    i++;
-  }
+  auto modules = rcast<Namespace*>(core_namespace)->getModules();
+  lowerModuleMap(modules, keys, values, num_items);
 }
 
 void CORENamespaceGetGenerators(

--- a/src/ir/context.cpp
+++ b/src/ir/context.cpp
@@ -289,7 +289,8 @@ JsonType* Context::Json() { return JsonType::make(this); }
 
 void Context::setTop(Module* top) {
   ASSERT(
-    top && (top->hasDef() || top->hasVerilogDef()),
+    top && (top->hasDef() || top->hasVerilogDef() ||
+            top->hasLinkedModule()),
     top->toString() + " has no def!");
   this->top = top;
 }
@@ -302,7 +303,8 @@ void Context::setTop(string topRef) {
   ASSERT(topns->hasModule(topsplit[1]), "Missing module " + topRef);
   this->top = topns->getModule(topsplit[1]);
   ASSERT(
-    this->top->hasDef() || this->top->hasVerilogDef(),
+    this->top->hasDef() || this->top->hasVerilogDef() ||
+      top->hasLinkedModule(),
     topRef + " has no def!");
 }
 

--- a/src/ir/fileReader.cpp
+++ b/src/ir/fileReader.cpp
@@ -377,6 +377,13 @@ bool load(Context* c, string filename, Module** top, std::vector<Module*>& loade
       makeDef(jmod, mdef, c);
       // Add Def back in
       m->setDef(mdef);
+      if (jmod.count("linked_definitions")) {
+        for (auto entry : jmod.at("linked_definitions").get<jsonmap>()) {
+          ModuleDef* mdef = m->newModuleDef();
+          makeDef(entry.second, mdef, c);
+          m->linkDefinition(entry.first, mdef);
+        }
+      }
     }  // End Module loop
 
     // If top exists return it

--- a/src/ir/fileReader.cpp
+++ b/src/ir/fileReader.cpp
@@ -379,9 +379,9 @@ bool load(Context* c, string filename, Module** top, std::vector<Module*>& loade
       m->setDef(mdef);
       if (jmod.count("linked_definitions")) {
         for (auto entry : jmod.at("linked_definitions").get<jsonmap>()) {
-          ModuleDef* mdef = m->newModuleDef();
-          makeDef(entry.second, mdef, c);
-          m->linkDefinition(entry.first, mdef);
+          Module* linked_module = getModSymbol(c, entry.second);
+          // Requries that linked modules referenced come first in the json
+          m->linkModule(entry.first, linked_module);
         }
       }
     }  // End Module loop

--- a/src/ir/fileReader.cpp
+++ b/src/ir/fileReader.cpp
@@ -68,6 +68,68 @@ bool hasDef(json& jmod) {
   return jmod.count("connections") || jmod.count("instances");
 }
 
+void makeDef(json jmod, ModuleDef* mdef, Context* c) {
+  if (jmod.count("instances")) {
+    for (auto jinstmap : jmod.at("instances").get<jsonmap>()) {
+      string instname = jinstmap.first;
+      json jinst = jinstmap.second;
+      checkJson(
+        jinst,
+        set<string>(),
+        {
+          "modref",
+          "genref",
+          "genargs",
+          "modargs",
+          "metadata",
+        });
+      // This function can throw an error
+      Instance* inst;
+      if (jinst.count("modref")) {
+        assert(jinst.count("genref") == 0);
+        assert(jinst.count("genargs") == 0);
+        Module* modRef = getModSymbol(c, jinst.at("modref").get<string>());
+        Values modargs;
+        if (jinst.count("modargs")) {
+          modargs = json2Values(c, jinst.at("modargs"), modRef);
+        }
+        inst = mdef->addInstance(instname, modRef, modargs);
+      }
+      else if (
+        jinst.count("genargs") &&
+        jinst.count("genref")) {  // This is a generator
+        auto gref = getRef(jinst.at("genref").get<string>());
+        Generator* genRef = getGenSymbol(c, gref[0], gref[1]);
+        Values genargs = json2Values(c, jinst.at("genargs"));
+        Values modargs;
+        if (jinst.count("modargs")) {
+          modargs = json2Values(c, jinst.at("modargs"));
+        }
+        inst = mdef->addInstance(instname, genRef, genargs, modargs);
+      }
+      else {
+        assert_throw(
+          0,
+          "Bad Instance. Need (modref || (genref && genargs)) " + instname);
+      }
+      if (jinst.count("metadata")) { inst->setMetaData(jinst["metadata"]); }
+    }  // End Instances
+  }
+
+  // Connections
+  if (jmod.count("connections")) {
+    for (auto jcon : jmod.at("connections").get<vector<jsonvector>>()) {
+      assert_throw(
+        jcon.size() == 2 || jcon.size() == 3,
+        "Connection invalid");
+      Wireable* a = mdef->sel(jcon[0].get<string>());
+      Wireable* b = mdef->sel(jcon[1].get<string>());
+      mdef->connect(a, b);
+      if (jcon.size() == 3) { mdef->getMetaData(a, b) = jcon[2]; }
+    }
+  }
+}
+
 //If there is a top module "top" will be loaded with it. loaded_modules will always contain an unordered list of the modules (included generated ones) from this file
 bool load(Context* c, string filename, Module** top, std::vector<Module*>& loaded_modules) {
   std::fstream file;
@@ -206,7 +268,8 @@ bool load(Context* c, string filename, Module** top, std::vector<Module*>& loade
              "defaultmodargs",
              "instances",
              "connections",
-             "metadata"});
+             "metadata",
+             "linked_definitions"});
           Type* t = json2Type(c, jmod.at("type"));
           Params modparams;
           if (jmod.count("modparams")) {
@@ -311,66 +374,7 @@ bool load(Context* c, string filename, Module** top, std::vector<Module*>& loade
     for (auto &[m, jmod] : modqueue) {
       ASSERT(hasDef(jmod), "Missing Def " + m->getRefName());
       ModuleDef* mdef = m->newModuleDef();
-      if (jmod.count("instances")) {
-        for (auto jinstmap : jmod.at("instances").get<jsonmap>()) {
-          string instname = jinstmap.first;
-          json jinst = jinstmap.second;
-          checkJson(
-            jinst,
-            set<string>(),
-            {
-              "modref",
-              "genref",
-              "genargs",
-              "modargs",
-              "metadata",
-            });
-          // This function can throw an error
-          Instance* inst;
-          if (jinst.count("modref")) {
-            assert(jinst.count("genref") == 0);
-            assert(jinst.count("genargs") == 0);
-            Module* modRef = getModSymbol(c, jinst.at("modref").get<string>());
-            Values modargs;
-            if (jinst.count("modargs")) {
-              modargs = json2Values(c, jinst.at("modargs"), modRef);
-            }
-            inst = mdef->addInstance(instname, modRef, modargs);
-          }
-          else if (
-            jinst.count("genargs") &&
-            jinst.count("genref")) {  // This is a generator
-            auto gref = getRef(jinst.at("genref").get<string>());
-            Generator* genRef = getGenSymbol(c, gref[0], gref[1]);
-            Values genargs = json2Values(c, jinst.at("genargs"));
-            Values modargs;
-            if (jinst.count("modargs")) {
-              modargs = json2Values(c, jinst.at("modargs"));
-            }
-            inst = mdef->addInstance(instname, genRef, genargs, modargs);
-          }
-          else {
-            assert_throw(
-              0,
-              "Bad Instance. Need (modref || (genref && genargs)) " + instname);
-          }
-          if (jinst.count("metadata")) { inst->setMetaData(jinst["metadata"]); }
-        }  // End Instances
-      }
-
-      // Connections
-      if (jmod.count("connections")) {
-        for (auto jcon : jmod.at("connections").get<vector<jsonvector>>()) {
-          assert_throw(
-            jcon.size() == 2 || jcon.size() == 3,
-            "Connection invalid");
-          Wireable* a = mdef->sel(jcon[0].get<string>());
-          Wireable* b = mdef->sel(jcon[1].get<string>());
-          mdef->connect(a, b);
-          if (jcon.size() == 3) { mdef->getMetaData(a, b) = jcon[2]; }
-        }
-      }
-
+      makeDef(jmod, mdef, c);
       // Add Def back in
       m->setDef(mdef);
     }  // End Module loop

--- a/src/ir/fileReader.cpp
+++ b/src/ir/fileReader.cpp
@@ -207,7 +207,7 @@ bool load(Context* c, string filename, Module** top, std::vector<Module*>& loade
              "instances",
              "connections",
              "metadata",
-             "linked_definitions"});
+             "linked_modules"});
           Type* t = json2Type(c, jmod.at("type"));
           Params modparams;
           if (jmod.count("modparams")) {
@@ -373,8 +373,8 @@ bool load(Context* c, string filename, Module** top, std::vector<Module*>& loade
       }
       // Add Def back in
       m->setDef(mdef);
-      if (jmod.count("linked_definitions")) {
-        for (auto entry : jmod.at("linked_definitions").get<jsonmap>()) {
+      if (jmod.count("linked_modules")) {
+        for (auto entry : jmod.at("linked_modules").get<jsonmap>()) {
           Module* linked_module = getModSymbol(c, entry.second);
           // Requries that linked modules referenced come first in the json
           m->linkModule(entry.first, linked_module);

--- a/src/ir/module.cpp
+++ b/src/ir/module.cpp
@@ -115,17 +115,6 @@ void Module::setDef(ModuleDef* def, bool validate) {
   delete this->directedModule;
 }
 
-void Module::linkDefinition(std::string key, ModuleDef* def, bool validate) {
-  if (validate) {
-    if (def->validate()) {
-      cout << "Error Validating def" << endl;
-      this->getContext()->die();
-    }
-  }
-  // TODO: Should we raise en error if a key is used twice?
-  this->linkedDefinitions[key] = def;
-}
-
 string Module::toString() const {
   return "Module: " + this->getRefName() +
     (isGenerated() ? ::CoreIR::toString(genargs) : "") +

--- a/src/ir/module.cpp
+++ b/src/ir/module.cpp
@@ -115,6 +115,17 @@ void Module::setDef(ModuleDef* def, bool validate) {
   delete this->directedModule;
 }
 
+void Module::linkDefinition(std::string key, ModuleDef* def, bool validate) {
+  if (validate) {
+    if (def->validate()) {
+      cout << "Error Validating def" << endl;
+      this->getContext()->die();
+    }
+  }
+  // TODO: Should we raise en error if a key is used twice?
+  this->linkedDefinitions[key] = def;
+}
+
 string Module::toString() const {
   return "Module: " + this->getRefName() +
     (isGenerated() ? ::CoreIR::toString(genargs) : "") +

--- a/src/passes/analysis/coreir_json_lib.cpp
+++ b/src/passes/analysis/coreir_json_lib.cpp
@@ -216,6 +216,11 @@ string Module2Json(Module* m, bool onlyDecl=false) {
     }
     if (m->hasMetaData()) { j.add("metadata", toString(m->getMetaData())); }
   }
+  if (m->hasDefaultLinkedModule()) {
+    auto linked = m->getDefaultLinkedModule();
+    auto ref_name = quote(linked->getRefName());
+    j.add("default_linked_module", ref_name);
+  }
   const auto linked = m->getLinkedModules();
   if (linked.size() > 0) {
     Dict linked_json(taboffset + 2);

--- a/src/passes/analysis/coreir_json_lib.cpp
+++ b/src/passes/analysis/coreir_json_lib.cpp
@@ -223,7 +223,7 @@ string Module2Json(Module* m, bool onlyDecl=false) {
       auto ref_name = quote(entry.second->getRefName());
       linked_json.add(entry.first, ref_name);
     }
-    j.add("linked_definitions", linked_json.toMultiString());
+    j.add("linked_modules", linked_json.toMultiString());
   }
   return j.toMultiString();
 }

--- a/src/passes/analysis/coreir_json_lib.cpp
+++ b/src/passes/analysis/coreir_json_lib.cpp
@@ -216,6 +216,15 @@ string Module2Json(Module* m, bool onlyDecl=false) {
     }
     if (m->hasMetaData()) { j.add("metadata", toString(m->getMetaData())); }
   }
+  const auto linked = m->getLinkedModules();
+  if (linked.size() > 0) {
+    Dict linked_json(taboffset + 2);
+    for (const auto& entry : linked) {
+      auto ref_name = quote(entry.second->getRefName());
+      linked_json.add(entry.first, ref_name);
+    }
+    j.add("linked_definitions", linked_json.toMultiString());
+  }
   return j.toMultiString();
 }
 

--- a/src/passes/analysis/verilog.cpp
+++ b/src/passes/analysis/verilog.cpp
@@ -1613,8 +1613,6 @@ void Passes::Verilog::compileModule(Module* module) {
     }
     vAST::AssignInliner assign_inliner(wires);
     verilog_module = assign_inliner.visit(std::move(verilog_module));
-    std::cout << "Foo" << std::endl;
-    std::cout << verilog_module->toString() << std::endl;
     AlwaysStarMerger always_star_merger;
     verilog_module = always_star_merger.visit(std::move(verilog_module));
   }

--- a/tests/gtest/CMakeLists.txt
+++ b/tests/gtest/CMakeLists.txt
@@ -74,3 +74,7 @@ add_test(NAME test_unit COMMAND test_unit WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/
 add_executable(test_inline_instance test_inline_instance.cpp)
 target_link_libraries(test_inline_instance gtest_main coreir coreir-commonlib)
 add_test(NAME test_inline_instance COMMAND test_inline_instance WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests/gtest)
+
+add_executable(test_link_defs test_link_defs.cpp)
+target_link_libraries(test_link_defs gtest_main coreir coreir-commonlib)
+add_test(NAME test_link_defs COMMAND test_link_defs WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests/gtest)

--- a/tests/gtest/golds/link_def.v
+++ b/tests/gtest/golds/link_def.v
@@ -1,3 +1,4 @@
+// Module `STDCELLREG` defined externally
 module coreir_reg #(
     parameter width = 1,
     parameter clk_posedge = 1,
@@ -14,6 +15,22 @@ module coreir_reg #(
     outReg <= in;
   end
   assign out = outReg;
+endmodule
+
+module default_register (
+    input [15:0] I,
+    output [15:0] O,
+    input CLK
+);
+coreir_reg #(
+    .clk_posedge(1'b1),
+    .init(16'h0000),
+    .width(16)
+) my_reg (
+    .clk(CLK),
+    .in(I),
+    .out(O)
+);
 endmodule
 
 module my_register_synthesis (
@@ -50,6 +67,7 @@ coreir_reg #(
     .in(I),
     .out(O)
 );
+
 `endif
 endmodule
 

--- a/tests/gtest/golds/link_def.v
+++ b/tests/gtest/golds/link_def.v
@@ -1,0 +1,37 @@
+module coreir_reg #(
+    parameter width = 1,
+    parameter clk_posedge = 1,
+    parameter init = 1
+) (
+    input clk,
+    input [width-1:0] in,
+    output [width-1:0] out
+);
+  reg [width-1:0] outReg=init;
+  wire real_clk;
+  assign real_clk = clk_posedge ? clk : ~clk;
+  always @(posedge real_clk) begin
+    outReg <= in;
+  end
+  assign out = outReg;
+endmodule
+
+module my_register (
+    input [15:0] I,
+    output [15:0] O,
+    input CLK
+);
+`ifdef SYNTHESIS
+`else
+coreir_reg #(
+    .clk_posedge(1'b1),
+    .init(16'h0000),
+    .width(16)
+) my_reg (
+    .clk(CLK),
+    .in(I),
+    .out(O)
+);
+`endif
+endmodule
+

--- a/tests/gtest/golds/link_def.v
+++ b/tests/gtest/golds/link_def.v
@@ -16,12 +16,30 @@ module coreir_reg #(
   assign out = outReg;
 endmodule
 
+module my_register_synthesis (
+    input [15:0] I,
+    output [15:0] O,
+    input CLK
+);
+STDCELLREG stdcell_reg (
+    .I(I),
+    .O(O),
+    .CLK(CLK)
+);
+endmodule
+
 module my_register (
     input [15:0] I,
     output [15:0] O,
     input CLK
 );
 `ifdef SYNTHESIS
+STDCELLREG stdcell_reg (
+    .I(I),
+    .O(O),
+    .CLK(CLK)
+);
+
 `else
 coreir_reg #(
     .clk_posedge(1'b1),

--- a/tests/gtest/golds/link_def_default.v
+++ b/tests/gtest/golds/link_def_default.v
@@ -1,0 +1,26 @@
+// Module `STDCELLREG` defined externally
+module my_register_synthesis (
+    input [15:0] I,
+    output [15:0] O,
+    input CLK
+);
+STDCELLREG stdcell_reg (
+    .I(I),
+    .O(O),
+    .CLK(CLK)
+);
+endmodule
+
+module my_register (
+    input [15:0] I,
+    output [15:0] O,
+    input CLK
+);
+STDCELLREG stdcell_reg (
+    .I(I),
+    .O(O),
+    .CLK(CLK)
+);
+
+endmodule
+

--- a/tests/gtest/golds/link_def_no_default.v
+++ b/tests/gtest/golds/link_def_no_default.v
@@ -1,0 +1,75 @@
+// Module `STDCELLREG` defined externally
+module coreir_reg #(
+    parameter width = 1,
+    parameter clk_posedge = 1,
+    parameter init = 1
+) (
+    input clk,
+    input [width-1:0] in,
+    output [width-1:0] out
+);
+  reg [width-1:0] outReg=init;
+  wire real_clk;
+  assign real_clk = clk_posedge ? clk : ~clk;
+  always @(posedge real_clk) begin
+    outReg <= in;
+  end
+  assign out = outReg;
+endmodule
+
+module foo_register (
+    input [15:0] I,
+    output [15:0] O,
+    input CLK
+);
+coreir_reg #(
+    .clk_posedge(1'b1),
+    .init(16'h0000),
+    .width(16)
+) my_reg (
+    .clk(CLK),
+    .in(I),
+    .out(O)
+);
+endmodule
+
+module my_register_synthesis (
+    input [15:0] I,
+    output [15:0] O,
+    input CLK
+);
+STDCELLREG stdcell_reg (
+    .I(I),
+    .O(O),
+    .CLK(CLK)
+);
+endmodule
+
+module my_register (
+    input [15:0] I,
+    output [15:0] O,
+    input CLK
+);
+`ifdef SYNTHESIS
+STDCELLREG stdcell_reg (
+    .I(I),
+    .O(O),
+    .CLK(CLK)
+);
+
+`else
+`ifdef FOO
+coreir_reg #(
+    .clk_posedge(1'b1),
+    .init(16'h0000),
+    .width(16)
+) my_reg (
+    .clk(CLK),
+    .in(I),
+    .out(O)
+);
+
+`endif
+`endif
+endmodule
+

--- a/tests/gtest/srcs/link_def.json
+++ b/tests/gtest/srcs/link_def.json
@@ -1,0 +1,43 @@
+{"top":"global.my_register",
+"namespaces":{
+  "global":{
+    "modules":{
+      "my_register": {
+        "type":["Record",[
+          ["I",["Array",16,"BitIn"]],
+          ["O",["Array",16,"Bit"]],
+          ["CLK",["Named","coreir.clkIn"]]
+        ]],
+        "instances": {
+          "my_reg":{
+            "genref":"coreir.reg",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"clk_posedge":["Bool",true], "init":[["BitVector",16],"16'h0000"]}
+          }
+        },
+        "connections": [
+          ["self.I", "my_reg.in"],
+          ["self.O", "my_reg.out"],
+          ["self.CLK", "my_reg.clk"]
+        ],
+        "linked_definitions": {
+          "SYNTHESIS": {
+            "instances": {
+              "my_reg":{
+                "genref":"coreir.reg",
+                "genargs":{"width":["Int",16]},
+                "modargs":{"clk_posedge":["Bool",true], "init":[["BitVector",16],"16'h0000"]}
+              }
+            },
+            "connections": [
+              ["self.I", "my_reg.in"],
+              ["self.O", "my_reg.out"],
+              ["self.CLK", "my_reg.clk"]
+            ]
+          }
+        }
+      }
+    }
+  }
+}
+}

--- a/tests/gtest/srcs/link_def.json
+++ b/tests/gtest/srcs/link_def.json
@@ -35,9 +35,9 @@
               }
             },
             "connections": [
-              ["self.I", "my_reg.in"],
-              ["self.O", "my_reg.out"],
-              ["self.CLK", "my_reg.clk"]
+              ["self.I", "stdcell_reg.I"],
+              ["self.O", "stdcell_reg.O"],
+              ["self.CLK", "stdcell_reg.CLK"]
             ]
           }
         }

--- a/tests/gtest/srcs/link_def.json
+++ b/tests/gtest/srcs/link_def.json
@@ -2,6 +2,13 @@
 "namespaces":{
   "global":{
     "modules":{
+      "STDCELLREG": {
+        "type":["Record",[
+          ["I",["Array",16,"BitIn"]],
+          ["O",["Array",16,"Bit"]],
+          ["CLK",["Named","coreir.clkIn"]]
+        ]]
+      },
       "my_register": {
         "type":["Record",[
           ["I",["Array",16,"BitIn"]],
@@ -23,10 +30,8 @@
         "linked_definitions": {
           "SYNTHESIS": {
             "instances": {
-              "my_reg":{
-                "genref":"coreir.reg",
-                "genargs":{"width":["Int",16]},
-                "modargs":{"clk_posedge":["Bool",true], "init":[["BitVector",16],"16'h0000"]}
+              "stdcell_reg":{
+                "modref": "global.STDCELLREG"
               }
             },
             "connections": [

--- a/tests/gtest/srcs/link_def.json
+++ b/tests/gtest/srcs/link_def.json
@@ -44,7 +44,7 @@
           ["self.O", "my_reg.out"],
           ["self.CLK", "my_reg.clk"]
         ],
-        "linked_definitions": {
+        "linked_modules": {
           "SYNTHESIS": "global.my_register_synthesis"
         }
       }

--- a/tests/gtest/srcs/link_def.json
+++ b/tests/gtest/srcs/link_def.json
@@ -9,6 +9,23 @@
           ["CLK",["Named","coreir.clkIn"]]
         ]]
       },
+      "my_register_synthesis": {
+        "type":["Record",[
+          ["I",["Array",16,"BitIn"]],
+          ["O",["Array",16,"Bit"]],
+          ["CLK",["Named","coreir.clkIn"]]
+        ]],
+        "instances": {
+          "stdcell_reg":{
+            "modref": "global.STDCELLREG"
+          }
+        },
+        "connections": [
+          ["self.I", "stdcell_reg.I"],
+          ["self.O", "stdcell_reg.O"],
+          ["self.CLK", "stdcell_reg.CLK"]
+        ]
+      },
       "my_register": {
         "type":["Record",[
           ["I",["Array",16,"BitIn"]],
@@ -28,18 +45,7 @@
           ["self.CLK", "my_reg.clk"]
         ],
         "linked_definitions": {
-          "SYNTHESIS": {
-            "instances": {
-              "stdcell_reg":{
-                "modref": "global.STDCELLREG"
-              }
-            },
-            "connections": [
-              ["self.I", "stdcell_reg.I"],
-              ["self.O", "stdcell_reg.O"],
-              ["self.CLK", "stdcell_reg.CLK"]
-            ]
-          }
+          "SYNTHESIS": "global.my_register_synthesis"
         }
       }
     }

--- a/tests/gtest/srcs/link_def.json
+++ b/tests/gtest/srcs/link_def.json
@@ -26,7 +26,7 @@
           ["self.CLK", "stdcell_reg.CLK"]
         ]
       },
-      "my_register": {
+      "default_register": {
         "type":["Record",[
           ["I",["Array",16,"BitIn"]],
           ["O",["Array",16,"Bit"]],
@@ -43,7 +43,15 @@
           ["self.I", "my_reg.in"],
           ["self.O", "my_reg.out"],
           ["self.CLK", "my_reg.clk"]
-        ],
+        ]
+      },
+      "my_register": {
+        "type":["Record",[
+          ["I",["Array",16,"BitIn"]],
+          ["O",["Array",16,"Bit"]],
+          ["CLK",["Named","coreir.clkIn"]]
+        ]],
+        "default_linked_module": "global.default_register",
         "linked_modules": {
           "SYNTHESIS": "global.my_register_synthesis"
         }

--- a/tests/gtest/srcs/link_def_default.json
+++ b/tests/gtest/srcs/link_def_default.json
@@ -1,0 +1,42 @@
+{"top":"global.my_register",
+"namespaces":{
+  "global":{
+    "modules":{
+      "STDCELLREG": {
+        "type":["Record",[
+          ["I",["Array",16,"BitIn"]],
+          ["O",["Array",16,"Bit"]],
+          ["CLK",["Named","coreir.clkIn"]]
+        ]]
+      },
+      "my_register_synthesis": {
+        "type":["Record",[
+          ["I",["Array",16,"BitIn"]],
+          ["O",["Array",16,"Bit"]],
+          ["CLK",["Named","coreir.clkIn"]]
+        ]],
+        "instances": {
+          "stdcell_reg":{
+            "modref": "global.STDCELLREG"
+          }
+        },
+        "connections": [
+          ["self.I", "stdcell_reg.I"],
+          ["self.O", "stdcell_reg.O"],
+          ["self.CLK", "stdcell_reg.CLK"]
+        ]
+      },
+      "my_register": {
+        "type":["Record",[
+          ["I",["Array",16,"BitIn"]],
+          ["O",["Array",16,"Bit"]],
+          ["CLK",["Named","coreir.clkIn"]]
+        ]],
+        "linked_modules": {
+          "SYNTHESIS": "global.my_register_synthesis"
+        }
+      }
+    }
+  }
+}
+}

--- a/tests/gtest/srcs/link_def_no_default.json
+++ b/tests/gtest/srcs/link_def_no_default.json
@@ -1,0 +1,62 @@
+{"top":"global.my_register",
+"namespaces":{
+  "global":{
+    "modules":{
+      "STDCELLREG": {
+        "type":["Record",[
+          ["I",["Array",16,"BitIn"]],
+          ["O",["Array",16,"Bit"]],
+          ["CLK",["Named","coreir.clkIn"]]
+        ]]
+      },
+      "my_register_synthesis": {
+        "type":["Record",[
+          ["I",["Array",16,"BitIn"]],
+          ["O",["Array",16,"Bit"]],
+          ["CLK",["Named","coreir.clkIn"]]
+        ]],
+        "instances": {
+          "stdcell_reg":{
+            "modref": "global.STDCELLREG"
+          }
+        },
+        "connections": [
+          ["self.I", "stdcell_reg.I"],
+          ["self.O", "stdcell_reg.O"],
+          ["self.CLK", "stdcell_reg.CLK"]
+        ]
+      },
+      "foo_register": {
+        "type":["Record",[
+          ["I",["Array",16,"BitIn"]],
+          ["O",["Array",16,"Bit"]],
+          ["CLK",["Named","coreir.clkIn"]]
+        ]],
+        "instances": {
+          "my_reg":{
+            "genref":"coreir.reg",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"clk_posedge":["Bool",true], "init":[["BitVector",16],"16'h0000"]}
+          }
+        },
+        "connections": [
+          ["self.I", "my_reg.in"],
+          ["self.O", "my_reg.out"],
+          ["self.CLK", "my_reg.clk"]
+        ]
+      },
+      "my_register": {
+        "type":["Record",[
+          ["I",["Array",16,"BitIn"]],
+          ["O",["Array",16,"Bit"]],
+          ["CLK",["Named","coreir.clkIn"]]
+        ]],
+        "linked_modules": {
+          "FOO": "global.foo_register",
+          "SYNTHESIS": "global.my_register_synthesis"
+        }
+      }
+    }
+  }
+}
+}

--- a/tests/gtest/test_link_defs.cpp
+++ b/tests/gtest/test_link_defs.cpp
@@ -24,4 +24,36 @@ TEST(VerilogTests, TestLinkDefs) {
   assertPassEq(c, "verilog", "golds/link_def.v");
   deleteContext(c);
 }
+
+TEST(VerilogTests, TestLinkDefsDefault) {
+  Context* c = newContext();
+  CoreIRLoadVerilog_coreir(c);
+  Module* top;
+
+  if (!loadFromFile(c, "srcs/link_def_default.json", &top)) { c->die(); }
+  assert(top != nullptr);
+  c->setTop(top->getRefName());
+
+  const std::vector<std::string> passes = {
+    "verilog --inline"};
+  c->runPasses(passes, {});
+  assertPassEq(c, "verilog", "golds/link_def_default.v");
+  deleteContext(c);
+}
+
+TEST(VerilogTests, TestLinkDefsNoDefault) {
+  Context* c = newContext();
+  CoreIRLoadVerilog_coreir(c);
+  Module* top;
+
+  if (!loadFromFile(c, "srcs/link_def_no_default.json", &top)) { c->die(); }
+  assert(top != nullptr);
+  c->setTop(top->getRefName());
+
+  const std::vector<std::string> passes = {
+    "verilog --inline"};
+  c->runPasses(passes, {});
+  assertPassEq(c, "verilog", "golds/link_def_no_default.v");
+  deleteContext(c);
+}
 }

--- a/tests/gtest/test_link_defs.cpp
+++ b/tests/gtest/test_link_defs.cpp
@@ -9,7 +9,7 @@ using namespace CoreIR;
 
 namespace {
 
-TEST(VerilogTests, TestStringModule) {
+TEST(VerilogTests, TestLinkDefs) {
   Context* c = newContext();
   CoreIRLoadVerilog_coreir(c);
   Module* top;

--- a/tests/gtest/test_link_defs.cpp
+++ b/tests/gtest/test_link_defs.cpp
@@ -1,0 +1,27 @@
+#include "gtest/gtest.h"
+#include "assert_pass.h"
+#include "coreir.h"
+#include "coreir/definitions/coreVerilog.hpp"
+#include "coreir/definitions/corebitVerilog.hpp"
+#include "coreir/libs/commonlib.h"
+
+using namespace CoreIR;
+
+namespace {
+
+TEST(VerilogTests, TestStringModule) {
+  Context* c = newContext();
+  CoreIRLoadVerilog_coreir(c);
+  Module* top;
+
+  if (!loadFromFile(c, "srcs/link_def.json", &top)) { c->die(); }
+  assert(top != nullptr);
+  c->setTop(top->getRefName());
+
+  const std::vector<std::string> passes = {
+    "verilog --inline"};
+  c->runPasses(passes, {});
+  assertPassEq(c, "verilog", "golds/link_def.v");
+  deleteContext(c);
+}
+}


### PR DESCRIPTION
Adds capability to generate multiple variants of a definitions using `ifdef in verilog to select.

Adds a JSON field that is a map from key (ifdef variable) to module (containing alternate definition).
Adds IR API to represent map from key to module
Adds verilog code generation logic to generate code for alternate definitions (normally not in the instance graph) as well as inlining them into the call site (to avoid extra hierarchy).  Since verilogAST-cpp doesn't support cloning structural statements, for now we just store the module body as a string, but in the future we should add cloning logic so we can copy the AST.  Since this happens at the end of module code generation (all verilogAST passes have been run), I'm actually not sure if it matters so much that we just inline the string.